### PR TITLE
session: implement private typed output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 [[package]]
 name = "aex-contracts"
 version = "0.1.0"
-source = "git+https://github.com/aexhq/aex?tag=aex-contracts-v0.3.0#f3c80e5c4bb1a978e92552d08247dcf13d3d06c4"
+source = "git+https://github.com/aexhq/aex?tag=aex-contracts-v0.4.0#6e3d5c7f387374117ee0e1142a32f0efd96b7730"
 dependencies = [
  "chrono",
  "hex",
@@ -20,6 +20,20 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -776,6 +790,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,6 +829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brain"
 version = "0.1.0"
 dependencies = [
@@ -814,11 +849,13 @@ dependencies = [
  "globset",
  "hex",
  "html2text",
+ "jsonschema",
  "libc",
  "rand 0.9.5",
  "regex",
  "reqwest",
  "serde",
+ "serde_jcs",
  "serde_json",
  "sha2 0.10.9",
  "thiserror",
@@ -907,6 +944,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -1187,6 +1230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1252,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1225,6 +1288,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1317,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1341,9 +1425,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1395,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "hand-client"
 version = "0.1.0"
-source = "git+https://github.com/aexhq/hands?tag=hands-v0.1.3#ac7a433a016ac50b5ba64cbdc4b5d6e07ca4d6b5"
+source = "git+https://github.com/aexhq/hands?tag=hands-v0.1.4#350fd80baed907957e672930db6d83000d61d27f"
 dependencies = [
  "aex-contracts",
  "futures-util",
@@ -1409,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "hand-lambda"
 version = "0.1.0"
-source = "git+https://github.com/aexhq/hands?tag=hands-v0.1.3#ac7a433a016ac50b5ba64cbdc4b5d6e07ca4d6b5"
+source = "git+https://github.com/aexhq/hands?tag=hands-v0.1.4#350fd80baed907957e672930db6d83000d61d27f"
 dependencies = [
  "aex-contracts",
  "anyhow",
@@ -1448,6 +1534,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1856,6 +1947,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ec8a241beed129f06114aa68007e905ca350e7baeb6e17a7631bb7978d91b2"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91994f45017ed5e66aa8e59b8415f4cb033a6380d7200387b7cf117595fbdf85"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec7637f83e510868ae6ed625f7ebfbbde4554ee8ce49854caa5126a8b9b9ecb"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,6 +2089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2137,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2187,27 @@ version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2300,6 +2509,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.49.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6efa2154ea6f5ce0fdecdd2a8d18f2fa1a39a8fbba91564f555a592e4dce8278"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -2802,6 +3048,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3208,6 +3481,16 @@ checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 # Contracts and the hand, pinned by tag: the wire formats are owned by their repos.
-aex-contracts = { git = "https://github.com/aexhq/aex", tag = "aex-contracts-v0.3.0" }
+aex-contracts = { git = "https://github.com/aexhq/aex", tag = "aex-contracts-v0.4.0" }
 brain = { path = "crates/brain" }
 brain-aws = { path = "crates/brain-aws" }
-hand-client = { git = "https://github.com/aexhq/hands", tag = "hands-v0.1.3" }
-hand-lambda = { git = "https://github.com/aexhq/hands", tag = "hands-v0.1.3" }
+hand-client = { git = "https://github.com/aexhq/hands", tag = "hands-v0.1.4" }
+hand-lambda = { git = "https://github.com/aexhq/hands", tag = "hands-v0.1.4" }
 
 anyhow = "1"
 async-trait = "0.1"
@@ -32,12 +32,14 @@ futures-util = { version = "0.3", default-features = false, features = ["std"] }
 globset = "0.4"
 hex = "0.4"
 html2text = "0.17.1"
+jsonschema = { version = "0.49", default-features = false }
 libc = "0.2"
 rand = "0.9"
 regex = "1"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "stream", "json", "http2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_jcs = "0.2"
 sha2 = "0.10"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "io-util", "net", "signal"] }

--- a/crates/brain/Cargo.toml
+++ b/crates/brain/Cargo.toml
@@ -19,11 +19,13 @@ futures-util = { workspace = true }
 globset = { workspace = true }
 hex = { workspace = true }
 html2text = { workspace = true }
+jsonschema = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_jcs = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["process"] }

--- a/crates/brain/src/api.rs
+++ b/crates/brain/src/api.rs
@@ -7,7 +7,8 @@
 //! The subscription starts BEFORE the replay read so nothing falls between them; duplicates
 //! are dropped by seq.
 //!
-//! Idempotency-Key headers are accepted and ignored in M0.
+//! Output admission persists a hash of Idempotency-Key for 24-hour replay. Raw keys never enter
+//! the journal.
 
 use crate::events::{event_seq, event_type};
 use crate::journal::Record;
@@ -15,7 +16,8 @@ use crate::session::Brain;
 use crate::{BrainError, mint_id};
 use aex_contracts::session::{
     self, ApiError, ApiErrorCode, ApiErrorResponse, Artifact, ArtifactList, CreateSessionRequest,
-    FileList, FileListObject, MessageAccepted, MessageRequest, PersistRequest, SessionList,
+    FileList, FileListObject, MessageAccepted, MessageRequest, OutputAccepted, OutputRequest,
+    PersistRequest, SessionList,
 };
 use axum::body::{Body, Bytes, to_bytes};
 use axum::extract::{Path, Query, State};
@@ -43,6 +45,7 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/sessions", post(create_session).get(list_sessions))
         .route("/v1/sessions/{id}", get(get_session).delete(delete_session))
         .route("/v1/sessions/{id}/messages", post(send_message))
+        .route("/v1/sessions/{id}/output", post(request_output))
         .route("/v1/sessions/{id}/events", get(stream_events))
         .route("/v1/sessions/{id}/cancel", post(cancel_turn))
         .route("/v1/sessions/{id}/end", post(end_session))
@@ -108,12 +111,17 @@ fn map_err(e: BrainError) -> Failure {
         BrainError::FileNotFound(_) => (S::NOT_FOUND, C::NotFound),
         BrainError::FileTooLarge { .. } => (S::PAYLOAD_TOO_LARGE, C::InvalidRequest),
         BrainError::TurnInFlight(_) => (S::CONFLICT, C::SessionBusy),
+        BrainError::IdempotencyConflict => (S::CONFLICT, C::Conflict),
         BrainError::SessionDeleted(_) => (S::GONE, C::SessionDeleted),
         BrainError::SessionFailed(_) => (S::CONFLICT, C::SessionFailed),
         BrainError::Overloaded => (S::TOO_MANY_REQUESTS, C::RateLimited),
         BrainError::ProviderStatus { .. } | BrainError::Transport(_) | BrainError::Protocol(_) => {
             (S::BAD_GATEWAY, C::ProviderError)
         }
+        BrainError::OutputSchema(_) => (S::BAD_REQUEST, C::OutputSchemaError),
+        BrainError::OutputRefused(_) => (S::UNPROCESSABLE_ENTITY, C::OutputRefused),
+        BrainError::OutputValidation(_) => (S::UNPROCESSABLE_ENTITY, C::OutputValidationError),
+        BrainError::Cancelled => (S::CONFLICT, C::Cancelled),
         BrainError::HandUnavailable(_) | BrainError::Hand(_) => {
             (S::SERVICE_UNAVAILABLE, C::HandUnavailable)
         }
@@ -229,6 +237,59 @@ async fn send_message(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     ApiErrorCode::Internal,
                     "turn id".into(),
+                )
+            })?,
+        }),
+    ))
+}
+
+async fn request_output(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(req): Json<OutputRequest>,
+) -> Result<(StatusCode, Json<OutputAccepted>), Failure> {
+    auth(&state, &headers)?;
+    let idempotency_key = headers
+        .get("idempotency-key")
+        .map(|value| {
+            value.to_str().map_err(|_| {
+                Failure(
+                    StatusCode::BAD_REQUEST,
+                    ApiErrorCode::InvalidRequest,
+                    "Idempotency-Key must be valid ASCII".into(),
+                )
+            })
+        })
+        .transpose()?;
+    let admitted = state
+        .brain
+        .output(&id, req, idempotency_key)
+        .await
+        .map_err(map_err)?;
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(OutputAccepted {
+            output_id: admitted.output_id.parse().map_err(|_| {
+                Failure(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ApiErrorCode::Internal,
+                    "output id".into(),
+                )
+            })?,
+            schema_hash: admitted.schema_hash.parse().map_err(|_| {
+                Failure(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    ApiErrorCode::Internal,
+                    "schema hash".into(),
+                )
+            })?,
+            seq: NonZeroU64::new(admitted.seq.max(1)).expect("nonzero"),
+            session_id: id.parse().map_err(|_| {
+                Failure(
+                    StatusCode::BAD_REQUEST,
+                    ApiErrorCode::InvalidRequest,
+                    "session id".into(),
                 )
             })?,
         }),

--- a/crates/brain/src/events.rs
+++ b/crates/brain/src/events.rs
@@ -7,7 +7,8 @@
 
 use crate::journal::Record;
 use aex_contracts::session::{
-    self, ApiError, ApiErrorCode, Event, EventStream, ProviderUsage, Timestamp, ToolOutcome,
+    self, ApiError, ApiErrorCode, Event, EventStream, OutputContent, OutputContentType,
+    OutputValidationIssue, ProviderUsage, Timestamp, ToolOutcome,
 };
 use std::collections::HashMap;
 use std::num::NonZeroU64;
@@ -75,7 +76,7 @@ pub fn usage_of(u: &crate::message::Usage) -> ProviderUsage {
         output_tokens: u.output_tokens,
         cache_read_input_tokens: u.cache_read_input_tokens,
         cache_creation_input_tokens: u.cache_creation_input_tokens,
-        reasoning_tokens: None,
+        reasoning_tokens: u.reasoning_tokens,
     }
 }
 
@@ -100,6 +101,70 @@ pub fn derive(
             seq,
             session_id: sid,
             turn_id: turn_of(turn)?,
+        },
+        Record::OutputStarted {
+            output,
+            turn,
+            schema_hash,
+            source_seq,
+        } => Event::OutputStarted {
+            at,
+            output_id: output.parse().ok()?,
+            schema_hash: schema_hash.parse().ok()?,
+            seq,
+            session_id: sid,
+            source_seq: *source_seq,
+            turn_id: turn.as_deref().and_then(turn_of),
+        },
+        Record::OutputCompleted {
+            output,
+            turn,
+            schema_hash,
+            value,
+            usage,
+        } => Event::OutputCompleted {
+            at,
+            output: OutputContent {
+                schema_hash: schema_hash.parse().ok()?,
+                type_: OutputContentType::Output,
+                value: value.clone(),
+            },
+            output_id: output.parse().ok()?,
+            seq,
+            session_id: sid,
+            turn_id: turn.as_deref().and_then(turn_of),
+            usage: usage_option(usage),
+        },
+        Record::OutputFailed {
+            output,
+            turn,
+            schema_hash,
+            code,
+            message,
+            issues,
+            usage,
+        } => Event::OutputFailed {
+            at,
+            error: ApiError {
+                code: error_code(code),
+                message: message.clone(),
+                param: None,
+                request_id: None,
+            },
+            issues: issues
+                .iter()
+                .map(|issue| OutputValidationIssue {
+                    keyword: issue.keyword.clone(),
+                    message: issue.message.clone(),
+                    path: issue.path.clone(),
+                })
+                .collect(),
+            output_id: output.parse().ok()?,
+            schema_hash: schema_hash.parse().ok()?,
+            seq,
+            session_id: sid,
+            turn_id: turn.as_deref().and_then(turn_of),
+            usage: usage_option(usage),
         },
         Record::Assistant {
             turn,
@@ -260,12 +325,20 @@ pub fn error_code(s: &str) -> ApiErrorCode {
         "session_busy" => ApiErrorCode::SessionBusy,
         "session_deleted" => ApiErrorCode::SessionDeleted,
         "session_failed" => ApiErrorCode::SessionFailed,
+        "cancelled" => ApiErrorCode::Cancelled,
         "rate_limited" => ApiErrorCode::RateLimited,
         "provider_error" => ApiErrorCode::ProviderError,
+        "output_schema_error" => ApiErrorCode::OutputSchemaError,
+        "output_refused" => ApiErrorCode::OutputRefused,
+        "output_validation_error" => ApiErrorCode::OutputValidationError,
         "hand_unavailable" => ApiErrorCode::HandUnavailable,
         "too_large" => ApiErrorCode::TooLarge,
         _ => ApiErrorCode::Internal,
     }
+}
+
+fn usage_option(usage: &crate::message::Usage) -> Option<ProviderUsage> {
+    (*usage != crate::message::Usage::default()).then(|| usage_of(usage))
 }
 
 /// Live constructors for the two ephemeral event types.
@@ -310,6 +383,9 @@ pub fn output_event(
 pub fn event_seq(e: &Event) -> u64 {
     match e {
         Event::TurnStarted { seq, .. }
+        | Event::OutputStarted { seq, .. }
+        | Event::OutputCompleted { seq, .. }
+        | Event::OutputFailed { seq, .. }
         | Event::AssistantDelta { seq, .. }
         | Event::AssistantMessage { seq, .. }
         | Event::ToolCall { seq, .. }

--- a/crates/brain/src/journal.rs
+++ b/crates/brain/src/journal.rs
@@ -43,6 +43,14 @@ pub enum Record {
     TurnStarted {
         turn: String,
     },
+    /// Admission for one typed output request. The schema is intentionally absent; only its
+    /// hash and the captured journal boundary are durable.
+    OutputStarted {
+        output: String,
+        turn: Option<String>,
+        schema_hash: String,
+        source_seq: u64,
+    },
     /// A complete assistant message, full-fidelity blocks. Only complete messages are
     /// journaled -- a stream that dies mid-message journals nothing.
     Assistant {
@@ -93,6 +101,24 @@ pub enum Record {
         code: String,
         message: String,
     },
+    /// The validated assistant value. This is the only output-commit content folded back into
+    /// future model history.
+    OutputCompleted {
+        output: String,
+        turn: Option<String>,
+        schema_hash: String,
+        value: serde_json::Value,
+        usage: Usage,
+    },
+    OutputFailed {
+        output: String,
+        turn: Option<String>,
+        schema_hash: String,
+        code: String,
+        message: String,
+        issues: Vec<crate::output::ValidationIssue>,
+        usage: Usage,
+    },
     /// A session/hand state transition worth telling clients about (`session.updated`).
     State {
         state: String,
@@ -116,12 +142,15 @@ impl Record {
         match self {
             Record::UserMessage { .. } => "user_message",
             Record::TurnStarted { .. } => "turn_started",
+            Record::OutputStarted { .. } => "output_started",
             Record::Assistant { .. } => "assistant",
             Record::Usage { .. } => "usage",
             Record::ToolCall { .. } => "tool_call",
             Record::ToolResult { .. } => "tool_result",
             Record::TurnCompleted { .. } => "turn_completed",
             Record::TurnFailed { .. } => "turn_failed",
+            Record::OutputCompleted { .. } => "output_completed",
+            Record::OutputFailed { .. } => "output_failed",
             Record::State { .. } => "state",
             Record::HandLost { .. } => "hand_lost",
             Record::Compacted { .. } => "compacted",
@@ -214,6 +243,22 @@ impl Fold {
                     content: content.clone(),
                 });
             }
+            Record::OutputCompleted {
+                schema_hash, value, ..
+            } => {
+                self.flush_results();
+                let block = ContentBlock::Output {
+                    schema_hash: schema_hash.clone(),
+                    value: value.clone(),
+                };
+                if let Some(last) = self.history.last_mut()
+                    && last.role == Role::Assistant
+                {
+                    last.content.push(block);
+                } else {
+                    self.history.push(Message::assistant(vec![block]));
+                }
+            }
             Record::ToolResult {
                 call,
                 content,
@@ -238,6 +283,8 @@ impl Fold {
             | Record::ToolCall { .. }
             | Record::TurnCompleted { .. }
             | Record::TurnFailed { .. }
+            | Record::OutputStarted { .. }
+            | Record::OutputFailed { .. }
             | Record::State { .. }
             | Record::HandLost { .. } => {}
         }
@@ -310,6 +357,10 @@ pub struct HeadDoc {
     pub workspace_bytes: u64,
     #[serde(default)]
     pub artifacts: Vec<ArtifactDoc>,
+    /// Bounded, 24-hour output idempotency index. Keys and request payloads are hashed; the
+    /// schema itself is never retained here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_requests: Vec<OutputRequestDoc>,
 }
 
 impl HeadDoc {
@@ -412,6 +463,17 @@ pub struct ArtifactDoc {
     pub sha256: String,
     pub media_type: String,
     pub created_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OutputRequestDoc {
+    pub key_hash: String,
+    pub request_hash: String,
+    pub output_id: String,
+    pub schema_hash: String,
+    pub started_seq: u64,
+    pub admitted_ms: u64,
 }
 
 /// The claim a hydrating owner holds. Every commit is conditioned on it.
@@ -1019,6 +1081,7 @@ mod tests {
             hand_state: serde_json::Value::Null,
             workspace_bytes: 0,
             artifacts: vec![],
+            output_requests: vec![],
         };
         let s = serde_json::to_string(&doc).unwrap();
         let back: HeadDoc = serde_json::from_str(&s).unwrap();
@@ -1060,6 +1123,7 @@ mod tests {
             hand_state: serde_json::Value::Null,
             workspace_bytes: 0,
             artifacts: vec![],
+            output_requests: vec![],
         }
     }
 

--- a/crates/brain/src/lib.rs
+++ b/crates/brain/src/lib.rs
@@ -23,6 +23,7 @@ pub mod local;
 pub mod mcp;
 pub mod message;
 pub mod outbound;
+pub mod output;
 pub mod provider;
 pub mod reclaim;
 pub mod session;
@@ -48,6 +49,9 @@ pub enum BrainError {
 
     #[error("session {0} is already running a turn")]
     TurnInFlight(String),
+
+    #[error("Idempotency-Key was already used with a different request")]
+    IdempotencyConflict,
 
     #[error("session {0} is deleted")]
     SessionDeleted(String),
@@ -91,6 +95,15 @@ pub enum BrainError {
 
     #[error("provider error {status}: {body}")]
     ProviderStatus { status: u16, body: String },
+
+    #[error("output schema: {0}")]
+    OutputSchema(String),
+
+    #[error("model refused the requested output: {0}")]
+    OutputRefused(String),
+
+    #[error("model output did not satisfy the schema: {0}")]
+    OutputValidation(String),
 
     #[error("hand unavailable: {0}")]
     HandUnavailable(String),

--- a/crates/brain/src/message.rs
+++ b/crates/brain/src/message.rs
@@ -33,6 +33,12 @@ pub enum ContentBlock {
         /// this flag; the model then reads a failure as a success.
         is_error: bool,
     },
+    /// A validated typed response committed by `session.output()`. The schema itself is
+    /// deliberately absent; only its stable hash and the value enter durable history.
+    Output {
+        schema_hash: String,
+        value: serde_json::Value,
+    },
 }
 
 impl ContentBlock {
@@ -53,6 +59,9 @@ impl ContentBlock {
                 content,
                 ..
             } => tool_use_id.capacity() + content.capacity(),
+            ContentBlock::Output { schema_hash, value } => {
+                schema_hash.capacity() + json_bytes(value)
+            }
         }
     }
 }
@@ -121,6 +130,7 @@ pub enum StopReason {
     ToolUse,
     MaxTokens,
     StopSequence,
+    Refusal,
     /// The provider ended the stream without a terminal reason. Distinct from
     /// EndTurn on purpose: absent is never zero.
     #[default]
@@ -136,6 +146,7 @@ pub struct Usage {
     pub output_tokens: Option<u64>,
     pub cache_read_input_tokens: Option<u64>,
     pub cache_creation_input_tokens: Option<u64>,
+    pub reasoning_tokens: Option<u64>,
 }
 
 impl Usage {
@@ -155,5 +166,6 @@ impl Usage {
             &mut self.cache_creation_input_tokens,
             other.cache_creation_input_tokens,
         );
+        add(&mut self.reasoning_tokens, other.reasoning_tokens);
     }
 }

--- a/crates/brain/src/output.rs
+++ b/crates/brain/src/output.rs
@@ -1,0 +1,963 @@
+//! The private commit phase behind `session.output(schema)`.
+//!
+//! The ordinary agent never sees the schema. This module makes one constrained provider call
+//! after work has finished, validates the candidate locally, and permits one isolated repair.
+//! Neither control instruction, candidate failure, nor repair context is returned as model
+//! history; the caller journals only the final validated value.
+
+use crate::config::{Dialect, SealedPrefix, SessionConfig};
+use crate::message::{ContentBlock, Message, Role, StopReason, Usage};
+use crate::provider::{Accumulator, OutputControl, OutputMode, Provider};
+use crate::{BrainError, Result, Shared};
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+
+pub const MAX_SCHEMA_BYTES: usize = 64 * 1024;
+const MAX_CONTROL_CANDIDATE_CHARS: usize = 24 * 1024;
+const MAX_ISSUES: usize = 32;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationIssue {
+    pub path: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keyword: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct CommitSuccess {
+    pub value: Value,
+    pub usage: Usage,
+}
+
+#[derive(Debug)]
+pub struct CommitFailure {
+    pub error: BrainError,
+    pub issues: Vec<ValidationIssue>,
+    pub usage: Usage,
+}
+
+pub struct CommitContext {
+    pub provider: Arc<dyn Provider>,
+    pub prefix: Shared<SealedPrefix>,
+    pub session: SessionConfig,
+    pub history: Vec<Message>,
+    pub model_permits: Arc<Semaphore>,
+    pub cancel: CancellationToken,
+}
+
+#[derive(Debug)]
+struct Candidate {
+    raw: String,
+    value: Option<Value>,
+    parse_error: Option<String>,
+    usage: Usage,
+}
+
+/// SHA-256 over RFC 8785 canonical JSON, lower-case hexadecimal.
+pub fn jcs_sha256<T: Serialize + ?Sized>(value: &T) -> Result<String> {
+    let canonical = serde_jcs::to_vec(value)?;
+    Ok(hex::encode(Sha256::digest(canonical)))
+}
+
+/// Validate the caller's schema before admission, so a schema mistake never starts model work.
+pub fn validate_schema(schema: &Value, claimed_hash: &str) -> Result<()> {
+    let bytes = serde_json::to_vec(schema)?;
+    if bytes.len() > MAX_SCHEMA_BYTES {
+        return Err(BrainError::OutputSchema(format!(
+            "schema is {} bytes; maximum is {MAX_SCHEMA_BYTES}",
+            bytes.len()
+        )));
+    }
+    if schema.get("type").and_then(Value::as_str) != Some("object") {
+        return Err(BrainError::OutputSchema(
+            "the beta output schema must have an object root".into(),
+        ));
+    }
+    reject_remote_refs(schema)?;
+    jsonschema::meta::validate(schema)
+        .map_err(|error| BrainError::OutputSchema(error.to_string()))?;
+    jsonschema::draft202012::new(schema)
+        .map_err(|error| BrainError::OutputSchema(error.to_string()))?;
+    let actual = jcs_sha256(schema)?;
+    if actual != claimed_hash {
+        return Err(BrainError::OutputSchema(format!(
+            "schema_hash mismatch: expected {actual}"
+        )));
+    }
+    Ok(())
+}
+
+fn reject_remote_refs(value: &Value) -> Result<()> {
+    match value {
+        Value::Object(object) => {
+            for keyword in ["$ref", "$dynamicRef", "$recursiveRef"] {
+                if let Some(reference) = object.get(keyword).and_then(Value::as_str)
+                    && !reference.starts_with('#')
+                {
+                    return Err(BrainError::OutputSchema(format!(
+                        "remote {keyword} values are not supported"
+                    )));
+                }
+            }
+            for child in object.values() {
+                reject_remote_refs(child)?;
+            }
+        }
+        Value::Array(array) => {
+            for child in array {
+                reject_remote_refs(child)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Prefer provider-native constrained output, use one forced internal tool for schemas the
+/// provider cannot constrain, then make at most one isolated repair on invalid data.
+pub async fn commit(
+    mut ctx: CommitContext,
+    schema: Value,
+) -> std::result::Result<CommitSuccess, CommitFailure> {
+    let candidate_answer = take_candidate_answer(&mut ctx.history);
+    let instruction = base_instruction(&candidate_answer);
+    let mut usage = Usage::default();
+
+    let preferred_mode = preferred_output_mode(&schema, ctx.provider.dialect());
+    let (mode, first) = match invoke(&ctx, &schema, &instruction, preferred_mode).await {
+        Ok(candidate) => (preferred_mode, candidate),
+        Err(error)
+            if preferred_mode == OutputMode::Native && native_capability_rejected(&error) =>
+        {
+            match invoke(&ctx, &schema, &instruction, OutputMode::ForcedTool).await {
+                Ok(candidate) => (OutputMode::ForcedTool, candidate),
+                Err(error) => {
+                    return Err(CommitFailure {
+                        error,
+                        issues: Vec::new(),
+                        usage,
+                    });
+                }
+            }
+        }
+        Err(error) => {
+            return Err(CommitFailure {
+                error,
+                issues: Vec::new(),
+                usage,
+            });
+        }
+    };
+    usage.merge(&first.usage);
+
+    let first_issues = candidate_issues(&schema, &first);
+    if first_issues.is_empty() {
+        return Ok(CommitSuccess {
+            value: first.value.expect("no issues means parsed JSON"),
+            usage,
+        });
+    }
+
+    let repair_instruction = repair_instruction(&candidate_answer, &first.raw, &first_issues);
+    let repaired = match invoke(&ctx, &schema, &repair_instruction, mode).await {
+        Ok(candidate) => candidate,
+        Err(error) => {
+            return Err(CommitFailure {
+                error,
+                issues: first_issues,
+                usage,
+            });
+        }
+    };
+    usage.merge(&repaired.usage);
+    let repaired_issues = candidate_issues(&schema, &repaired);
+    if repaired_issues.is_empty() {
+        Ok(CommitSuccess {
+            value: repaired.value.expect("no issues means parsed JSON"),
+            usage,
+        })
+    } else {
+        Err(CommitFailure {
+            error: BrainError::OutputValidation(format!(
+                "{} validation issue(s) remained after one repair",
+                repaired_issues.len()
+            )),
+            issues: repaired_issues,
+            usage,
+        })
+    }
+}
+
+async fn invoke(
+    ctx: &CommitContext,
+    schema: &Value,
+    instruction: &str,
+    mode: OutputMode,
+) -> Result<Candidate> {
+    let control = OutputControl {
+        schema: provider_schema(schema, ctx.provider.dialect(), mode),
+        instruction: instruction.to_string(),
+    };
+    let request = ctx.provider.build_output_request(
+        &ctx.prefix,
+        &ctx.history,
+        &ctx.session.key,
+        &ctx.session.base_url,
+        &control,
+        mode,
+    )?;
+    let _permit = tokio::select! {
+        permit = ctx.model_permits.clone().acquire_owned() => {
+            permit.map_err(|_| BrainError::Overloaded)?
+        }
+        () = ctx.cancel.cancelled() => return Err(BrainError::Cancelled),
+    };
+    let mut stream = tokio::select! {
+        stream = ctx.provider.stream(request) => stream?,
+        () = ctx.cancel.cancelled() => return Err(BrainError::Cancelled),
+    };
+    let mut accumulator = Accumulator::default();
+    loop {
+        let event = tokio::select! {
+            event = stream.next() => event,
+            () = ctx.cancel.cancelled() => return Err(BrainError::Cancelled),
+        };
+        match event {
+            Some(Ok(event)) => accumulator.push(event),
+            Some(Err(error)) => return Err(error),
+            None => break,
+        }
+    }
+    if !accumulator.saw_terminal {
+        return Err(BrainError::Protocol(
+            "provider output stream ended without a terminal event".into(),
+        ));
+    }
+    let (message, stop, usage) = accumulator.finish()?;
+    if stop == StopReason::Refusal {
+        return Err(BrainError::OutputRefused(message_text(&message)));
+    }
+    candidate_from_message(message, usage, mode)
+}
+
+fn candidate_from_message(message: Message, usage: Usage, mode: OutputMode) -> Result<Candidate> {
+    match mode {
+        OutputMode::Native => {
+            if message.tool_uses().next().is_some() {
+                return Err(BrainError::Protocol(
+                    "native output response unexpectedly called a tool".into(),
+                ));
+            }
+            let raw = message_text(&message);
+            let parsed = serde_json::from_str(raw.trim());
+            let (value, parse_error) = match parsed {
+                Ok(value) => (Some(value), None),
+                Err(error) => (None, Some(format!("response was not valid JSON: {error}"))),
+            };
+            Ok(Candidate {
+                raw,
+                value,
+                parse_error,
+                usage,
+            })
+        }
+        OutputMode::ForcedTool => {
+            let mut calls = message.tool_uses();
+            let Some((_, name, input)) = calls.next() else {
+                let text = message_text(&message);
+                return Err(if text.is_empty() {
+                    BrainError::Protocol("forced output tool was not called".into())
+                } else {
+                    BrainError::OutputRefused(text)
+                });
+            };
+            if name != "aex_output" || calls.next().is_some() {
+                return Err(BrainError::Protocol(
+                    "forced output response must contain exactly one aex_output call".into(),
+                ));
+            }
+            Ok(Candidate {
+                raw: serde_json::to_string(input)?,
+                value: Some(input.clone()),
+                parse_error: None,
+                usage,
+            })
+        }
+    }
+}
+
+fn candidate_issues(schema: &Value, candidate: &Candidate) -> Vec<ValidationIssue> {
+    if let Some(message) = &candidate.parse_error {
+        return vec![ValidationIssue {
+            path: String::new(),
+            message: message.clone(),
+            keyword: None,
+        }];
+    }
+    validation_issues(
+        schema,
+        candidate
+            .value
+            .as_ref()
+            .expect("parsed candidate has a value"),
+    )
+}
+
+fn validation_issues(schema: &Value, value: &Value) -> Vec<ValidationIssue> {
+    let Ok(validator) = jsonschema::draft202012::new(schema) else {
+        return vec![ValidationIssue {
+            path: String::new(),
+            message: "schema could not be compiled".into(),
+            keyword: None,
+        }];
+    };
+    validator
+        .iter_errors(value)
+        .take(MAX_ISSUES)
+        .map(|error| ValidationIssue {
+            path: error.instance_path().to_string(),
+            message: error.to_string(),
+            keyword: Some(error.kind().keyword().to_string()),
+        })
+        .collect()
+}
+
+fn provider_schema(schema: &Value, dialect: Dialect, mode: OutputMode) -> Value {
+    let clean = clean_provider_schema(schema);
+    if dialect == Dialect::AnthropicMessages && mode == OutputMode::Native {
+        return anthropic_provider_schema(clean.clone()).unwrap_or(clean);
+    }
+    clean
+}
+
+fn clean_provider_schema(schema: &Value) -> Value {
+    fn clean(value: &mut Value) {
+        match value {
+            Value::Object(object) => {
+                object.remove("$schema");
+                object.remove("$id");
+                for child in object.values_mut() {
+                    clean(child);
+                }
+            }
+            Value::Array(array) => {
+                for child in array {
+                    clean(child);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut schema = schema.clone();
+    clean(&mut schema);
+    schema
+}
+
+fn preferred_output_mode(schema: &Value, dialect: Dialect) -> OutputMode {
+    let clean = clean_provider_schema(schema);
+    let native_compatible = match dialect {
+        Dialect::AnthropicMessages => {
+            objects_are_closed(&clean) && anthropic_provider_schema(clean).is_some()
+        }
+        Dialect::OpenAiChat => openai_native_compatible(&clean),
+    };
+    if native_compatible {
+        OutputMode::Native
+    } else {
+        OutputMode::ForcedTool
+    }
+}
+
+/// Strict structured-output dialects cannot represent an open-ended record. Falling back to a
+/// non-strict forced tool preserves the caller's schema instead of silently closing the object.
+fn objects_are_closed(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            if schema_includes_type(object, "object")
+                && object.get("additionalProperties") != Some(&Value::Bool(false))
+            {
+                return false;
+            }
+            object.values().all(objects_are_closed)
+        }
+        Value::Array(array) => array.iter().all(objects_are_closed),
+        _ => true,
+    }
+}
+
+fn openai_native_compatible(value: &Value) -> bool {
+    const UNSUPPORTED: [&str; 9] = [
+        "allOf",
+        "not",
+        "dependentRequired",
+        "dependentSchemas",
+        "if",
+        "then",
+        "else",
+        "oneOf",
+        "default",
+    ];
+
+    match value {
+        Value::Object(object) => {
+            if UNSUPPORTED
+                .iter()
+                .any(|keyword| object.contains_key(*keyword))
+            {
+                return false;
+            }
+            if schema_includes_type(object, "object") {
+                if object.get("additionalProperties") != Some(&Value::Bool(false)) {
+                    return false;
+                }
+                let properties = match object.get("properties") {
+                    Some(Value::Object(properties)) => properties,
+                    None => {
+                        return object.values().all(openai_native_compatible);
+                    }
+                    _ => return false,
+                };
+                let Some(required) = object.get("required").and_then(Value::as_array) else {
+                    return properties.is_empty() && object.values().all(openai_native_compatible);
+                };
+                if properties
+                    .keys()
+                    .any(|name| !required.iter().any(|item| item.as_str() == Some(name)))
+                {
+                    return false;
+                }
+            }
+            object.values().all(openai_native_compatible)
+        }
+        Value::Array(array) => array.iter().all(openai_native_compatible),
+        _ => true,
+    }
+}
+
+fn schema_includes_type(object: &Map<String, Value>, expected: &str) -> bool {
+    match object.get("type") {
+        Some(Value::String(actual)) => actual == expected,
+        Some(Value::Array(types)) => types.iter().any(|value| value.as_str() == Some(expected)),
+        _ => false,
+    }
+}
+
+/// Match Anthropic's documented SDK transformation: retain the grammar-safe structural subset,
+/// move unsupported constraints into descriptions, and keep local validation on the untouched
+/// caller schema. `None` means the schema node has no representation in the native subset.
+fn anthropic_provider_schema(value: Value) -> Option<Value> {
+    const STRING_FORMATS: [&str; 10] = [
+        "date-time",
+        "time",
+        "date",
+        "duration",
+        "email",
+        "hostname",
+        "uri",
+        "ipv4",
+        "ipv6",
+        "uuid",
+    ];
+
+    let Value::Object(mut source) = value else {
+        return None;
+    };
+    source.remove("$schema");
+    source.remove("$id");
+
+    let mut strict = Map::new();
+    if let Some(reference) = source.remove("$ref") {
+        strict.insert("$ref".into(), reference);
+        return Some(Value::Object(strict));
+    }
+    if let Some(Value::Object(definitions)) = source.remove("$defs") {
+        let transformed = definitions
+            .into_iter()
+            .map(|(name, schema)| Some((name, anthropic_provider_schema(schema)?)))
+            .collect::<Option<Map<_, _>>>()?;
+        strict.insert("$defs".into(), Value::Object(transformed));
+    }
+
+    let schema_type = source.remove("type");
+    let any_of = source.remove("anyOf");
+    let one_of = source.remove("oneOf");
+    let all_of = source.remove("allOf");
+    if let Some(Value::Array(variants)) = any_of.or(one_of) {
+        let transformed = variants
+            .into_iter()
+            .map(anthropic_provider_schema)
+            .collect::<Option<Vec<_>>>()?;
+        strict.insert("anyOf".into(), Value::Array(transformed));
+    } else if let Some(Value::Array(entries)) = all_of {
+        let transformed = entries
+            .into_iter()
+            .map(anthropic_provider_schema)
+            .collect::<Option<Vec<_>>>()?;
+        strict.insert("allOf".into(), Value::Array(transformed));
+    } else {
+        strict.insert("type".into(), schema_type.clone()?);
+    }
+
+    if let Some(description) = source.remove("description") {
+        strict.insert("description".into(), description);
+    }
+    if let Some(title) = source.remove("title") {
+        strict.insert("title".into(), title);
+    }
+
+    match schema_type.as_ref().and_then(Value::as_str) {
+        Some("object") => {
+            let properties = match source.remove("properties") {
+                Some(Value::Object(properties)) => properties,
+                None => Map::new(),
+                _ => return None,
+            };
+            let transformed = properties
+                .into_iter()
+                .map(|(name, schema)| Some((name, anthropic_provider_schema(schema)?)))
+                .collect::<Option<Map<_, _>>>()?;
+            strict.insert("properties".into(), Value::Object(transformed));
+            source.remove("additionalProperties");
+            strict.insert("additionalProperties".into(), Value::Bool(false));
+            if let Some(required) = source.remove("required") {
+                strict.insert("required".into(), required);
+            }
+        }
+        Some("string") => {
+            if let Some(format) = source.remove("format") {
+                if format
+                    .as_str()
+                    .is_some_and(|value| STRING_FORMATS.contains(&value))
+                {
+                    strict.insert("format".into(), format);
+                } else {
+                    source.insert("format".into(), format);
+                }
+            }
+        }
+        Some("array") => {
+            if let Some(items) = source.remove("items") {
+                strict.insert("items".into(), anthropic_provider_schema(items)?);
+            }
+            if let Some(min_items) = source.remove("minItems") {
+                if min_items.as_u64().is_some_and(|value| value <= 1) {
+                    strict.insert("minItems".into(), min_items);
+                } else {
+                    source.insert("minItems".into(), min_items);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    if !source.is_empty() {
+        let constraints = source
+            .iter()
+            .map(|(name, value)| {
+                format!(
+                    "{name}: {}",
+                    serde_json::to_string(value).unwrap_or_else(|_| "null".into())
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let suffix = format!("{{{constraints}}}");
+        let description = strict
+            .get("description")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map_or(suffix.clone(), |current| format!("{current}\n\n{suffix}"));
+        strict.insert("description".into(), Value::String(description));
+    }
+    Some(Value::Object(strict))
+}
+
+fn take_candidate_answer(history: &mut Vec<Message>) -> String {
+    let Some(last) = history.last() else {
+        return String::new();
+    };
+    if last.role != Role::Assistant {
+        return String::new();
+    }
+    let message = history.pop().expect("checked last");
+    truncate_chars(message_text(&message), MAX_CONTROL_CANDIDATE_CHARS)
+}
+
+fn message_text(message: &Message) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.clone()),
+            ContentBlock::Output { value, .. } => serde_json::to_string(value).ok(),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn base_instruction(candidate: &str) -> String {
+    let mut instruction = String::from(
+        "AEX private output commit. Return the answer in the required structured format. \
+         Preserve facts already established in the session. Do not perform new work and do not \
+         call any tool except the forced aex_output tool if it is the only tool offered.",
+    );
+    if !candidate.is_empty() {
+        instruction.push_str("\n\nCandidate answer from the completed work phase:\n");
+        instruction.push_str(candidate);
+    }
+    instruction
+}
+
+fn repair_instruction(candidate_answer: &str, invalid: &str, issues: &[ValidationIssue]) -> String {
+    let mut instruction = base_instruction(candidate_answer);
+    instruction.push_str(
+        "\n\nThe previous private output candidate failed validation. Correct only its shape or \
+         values needed to satisfy the required schema; do not add unsupported facts.\nCandidate:\n",
+    );
+    instruction.push_str(&truncate_chars(
+        invalid.to_string(),
+        MAX_CONTROL_CANDIDATE_CHARS,
+    ));
+    instruction.push_str("\nValidation issues:\n");
+    instruction.push_str(
+        &serde_json::to_string(issues)
+            .unwrap_or_else(|_| "[{\"message\":\"validation failed\"}]".into()),
+    );
+    instruction
+}
+
+fn truncate_chars(value: String, max: usize) -> String {
+    if value.chars().count() <= max {
+        return value;
+    }
+    value.chars().take(max).collect()
+}
+
+fn native_capability_rejected(error: &BrainError) -> bool {
+    matches!(
+        error,
+        BrainError::ProviderStatus {
+            status: 400 | 404 | 415 | 422,
+            ..
+        }
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AgentDef, Dialect, ProviderKey};
+    use crate::provider::fake::{FakeProvider, Scripted};
+    use crate::provider::{ModelRequest, ProviderEvent};
+    use futures_util::stream::BoxStream;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[derive(Debug)]
+    struct NativeRejectingProvider {
+        inner: Arc<FakeProvider>,
+        rejected: AtomicU64,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for NativeRejectingProvider {
+        fn dialect(&self) -> Dialect {
+            self.inner.dialect()
+        }
+
+        fn build_request(
+            &self,
+            prefix: &SealedPrefix,
+            history: &[Message],
+            key: &ProviderKey,
+            base_url: &str,
+        ) -> Result<ModelRequest> {
+            self.inner.build_request(prefix, history, key, base_url)
+        }
+
+        fn build_output_request(
+            &self,
+            prefix: &SealedPrefix,
+            history: &[Message],
+            key: &ProviderKey,
+            base_url: &str,
+            control: &OutputControl,
+            mode: OutputMode,
+        ) -> Result<ModelRequest> {
+            self.inner
+                .build_output_request(prefix, history, key, base_url, control, mode)
+        }
+
+        async fn stream(
+            &self,
+            request: ModelRequest,
+        ) -> Result<BoxStream<'static, Result<ProviderEvent>>> {
+            let body: Value = serde_json::from_slice(&request.body)?;
+            if body.get("output_config").is_some() {
+                self.rejected.fetch_add(1, Ordering::SeqCst);
+                return Err(BrainError::ProviderStatus {
+                    status: 400,
+                    body: "structured output is not supported".into(),
+                });
+            }
+            self.inner.stream(request).await
+        }
+    }
+
+    #[test]
+    fn schema_hash_is_canonical_and_verified() {
+        let a = json!({"type":"object","properties":{"b":{"type":"string"},"a":{"type":"number"}}});
+        let b = json!({"properties":{"a":{"type":"number"},"b":{"type":"string"}},"type":"object"});
+        let hash = jcs_sha256(&a).unwrap();
+        assert_eq!(hash, jcs_sha256(&b).unwrap());
+        validate_schema(&b, &hash).unwrap();
+    }
+
+    #[test]
+    fn schema_mismatch_and_remote_refs_fail_before_a_model_call() {
+        let schema =
+            json!({"type":"object","properties":{"x":{"$ref":"https://example.test/schema"}}});
+        let error = validate_schema(&schema, &"0".repeat(64)).unwrap_err();
+        assert!(matches!(error, BrainError::OutputSchema(_)));
+
+        let schema = json!({"type":"object","properties":{"x":{"$dynamicRef":"https://example.test/schema"}}});
+        let error = validate_schema(&schema, &"0".repeat(64)).unwrap_err();
+        assert!(matches!(error, BrainError::OutputSchema(_)));
+
+        let schema = json!({"type":"object"});
+        let error = validate_schema(&schema, &"0".repeat(64)).unwrap_err();
+        assert!(error.to_string().contains("schema_hash mismatch"));
+    }
+
+    #[test]
+    fn validation_reports_json_pointer_without_coercion() {
+        let schema = json!({
+            "type":"object",
+            "additionalProperties":false,
+            "required":["count"],
+            "properties":{"count":{"type":"number"}}
+        });
+        let issues = validation_issues(&schema, &json!({"count":"42"}));
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].path, "/count");
+        assert_eq!(issues[0].keyword.as_deref(), Some("type"));
+    }
+
+    #[test]
+    fn provider_modes_preserve_optional_fields_and_open_records() {
+        let optional = json!({
+            "type":"object",
+            "additionalProperties":false,
+            "required":["answer"],
+            "properties":{
+                "answer":{"type":"string"},
+                "note":{"type":"string"}
+            }
+        });
+        assert_eq!(
+            preferred_output_mode(&optional, Dialect::AnthropicMessages),
+            OutputMode::Native
+        );
+        assert_eq!(
+            preferred_output_mode(&optional, Dialect::OpenAiChat),
+            OutputMode::ForcedTool
+        );
+
+        let required = json!({
+            "type":"object",
+            "additionalProperties":false,
+            "required":["answer"],
+            "properties":{"answer":{"type":"string"}}
+        });
+        assert_eq!(
+            preferred_output_mode(&required, Dialect::OpenAiChat),
+            OutputMode::Native
+        );
+
+        let record = json!({
+            "type":"object",
+            "additionalProperties":false,
+            "required":["values"],
+            "properties":{
+                "values":{
+                    "type":"object",
+                    "additionalProperties":{"type":"number"}
+                }
+            }
+        });
+        assert_eq!(
+            preferred_output_mode(&record, Dialect::AnthropicMessages),
+            OutputMode::ForcedTool
+        );
+        assert_eq!(
+            preferred_output_mode(&record, Dialect::OpenAiChat),
+            OutputMode::ForcedTool
+        );
+    }
+
+    #[test]
+    fn anthropic_native_schema_describes_unsupported_constraints() {
+        let original = json!({
+            "$schema":"https://json-schema.org/draft/2020-12/schema",
+            "type":"object",
+            "additionalProperties":false,
+            "required":["score","tag","email"],
+            "properties":{
+                "score":{"type":"number","minimum":1,"maximum":5},
+                "tag":{"type":"string","minLength":3,"format":"custom-tag"},
+                "email":{"type":"string","format":"email"}
+            }
+        });
+        let transformed =
+            provider_schema(&original, Dialect::AnthropicMessages, OutputMode::Native);
+        assert!(transformed.get("$schema").is_none());
+        assert!(transformed["properties"]["score"].get("minimum").is_none());
+        assert!(
+            transformed["properties"]["score"]["description"]
+                .as_str()
+                .unwrap()
+                .contains("minimum: 1")
+        );
+        assert!(
+            transformed["properties"]["tag"]["description"]
+                .as_str()
+                .unwrap()
+                .contains("format: \"custom-tag\"")
+        );
+        assert_eq!(transformed["properties"]["email"]["format"], "email");
+
+        let issues = validation_issues(&original, &json!({"score":0,"tag":"x","email":"a@b.com"}));
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.keyword.as_deref() == Some("minimum"))
+        );
+        assert!(
+            issues
+                .iter()
+                .any(|issue| issue.keyword.as_deref() == Some("minLength"))
+        );
+    }
+
+    #[tokio::test]
+    async fn openai_optional_schema_starts_with_the_non_strict_forced_tool() {
+        let fake = Arc::new(FakeProvider::new(Dialect::OpenAiChat));
+        fake.script([Scripted::tool("aex_output", json!({"answer":"done"}))]);
+        let prefix = AgentDef::new("system", "fake", Dialect::OpenAiChat).seal();
+        let session = SessionConfig::new(
+            prefix.clone(),
+            ProviderKey::new("sk-fake"),
+            "https://example.test",
+        );
+        let result = commit(
+            CommitContext {
+                provider: fake.clone(),
+                prefix,
+                session,
+                history: vec![Message::user_text("Answer")],
+                model_permits: Arc::new(Semaphore::new(1)),
+                cancel: CancellationToken::new(),
+            },
+            json!({
+                "type":"object",
+                "additionalProperties":false,
+                "required":["answer"],
+                "properties":{
+                    "answer":{"type":"string"},
+                    "note":{"type":"string"}
+                }
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.value, json!({"answer":"done"}));
+        fake.assert_drained(1, "optional OpenAI output").unwrap();
+        assert_eq!(fake.arrivals.lock().unwrap()[0].tools_offered, 1);
+    }
+
+    #[tokio::test]
+    async fn native_capability_rejection_uses_one_forced_terminal_tool() {
+        let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+        fake.script([Scripted::tool("aex_output", json!({"ok":true}))]);
+        let provider = Arc::new(NativeRejectingProvider {
+            inner: fake.clone(),
+            rejected: AtomicU64::new(0),
+        });
+        let prefix = AgentDef::new("system", "fake", Dialect::AnthropicMessages).seal();
+        let session = SessionConfig::new(
+            prefix.clone(),
+            ProviderKey::new("sk-fake"),
+            "https://example.test",
+        );
+        let schema = json!({
+            "type":"object",
+            "additionalProperties":false,
+            "required":["ok"],
+            "properties":{"ok":{"type":"boolean"}}
+        });
+        let result = commit(
+            CommitContext {
+                provider: provider.clone(),
+                prefix,
+                session,
+                history: vec![
+                    Message::user_text("Do the work"),
+                    Message::assistant(vec![ContentBlock::text("done")]),
+                ],
+                model_permits: Arc::new(Semaphore::new(1)),
+                cancel: CancellationToken::new(),
+            },
+            schema,
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.value, json!({"ok":true}));
+        assert_eq!(provider.rejected.load(Ordering::SeqCst), 1);
+        fake.assert_drained(1, "forced output fallback").unwrap();
+        let arrivals = fake.arrivals.lock().unwrap();
+        assert_eq!(arrivals[0].tools_offered, 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_output_repairs_once_then_fails() {
+        let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+        fake.script([
+            Scripted::Text(r#"{"count":"one"}"#.into()),
+            Scripted::Text(r#"{"count":"still wrong"}"#.into()),
+        ]);
+        let prefix = AgentDef::new("system", "fake", Dialect::AnthropicMessages).seal();
+        let session = SessionConfig::new(
+            prefix.clone(),
+            ProviderKey::new("sk-fake"),
+            "https://example.test",
+        );
+        let failure = commit(
+            CommitContext {
+                provider: fake.clone(),
+                prefix,
+                session,
+                history: vec![Message::user_text("Count")],
+                model_permits: Arc::new(Semaphore::new(1)),
+                cancel: CancellationToken::new(),
+            },
+            json!({
+                "type":"object",
+                "additionalProperties":false,
+                "required":["count"],
+                "properties":{"count":{"type":"number"}}
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(failure.error, BrainError::OutputValidation(_)));
+        assert_eq!(failure.issues[0].path, "/count");
+        fake.assert_drained(2, "one repair only").unwrap();
+    }
+}

--- a/crates/brain/src/provider/anthropic.rs
+++ b/crates/brain/src/provider/anthropic.rs
@@ -1,7 +1,7 @@
 //! Anthropic Messages API adapter.
 
 use super::sse::SseDecoder;
-use super::{ModelRequest, Provider, ProviderEvent};
+use super::{ModelRequest, OutputControl, OutputMode, Provider, ProviderEvent};
 use crate::config::{Dialect, ProviderKey, SealedPrefix};
 use crate::message::{ContentBlock, Message, Role, StopReason, Usage};
 use crate::{BrainError, Result};
@@ -12,6 +12,20 @@ use serde_json::{Map, Value, json};
 pub struct Anthropic;
 
 impl Anthropic {
+    fn request(body: Value, key: &ProviderKey, base_url: &str) -> Result<ModelRequest> {
+        Ok(ModelRequest {
+            method: "POST",
+            url: format!("{}/v1/messages", base_url.trim_end_matches('/')),
+            headers: vec![
+                ("content-type".into(), "application/json".into()),
+                ("accept".into(), "text/event-stream".into()),
+                ("anthropic-version".into(), "2023-06-01".into()),
+                ("x-api-key".into(), key.expose().to_string()),
+            ],
+            body: serde_json::to_vec(&body)?,
+        })
+    }
+
     /// Render ONE provider-neutral message into the dialect's array elements.
     ///
     /// Split out of `body` so the pre-rendered transcript store
@@ -41,6 +55,10 @@ impl Anthropic {
                     "content":content,
                     // ALWAYS present. Never omitted on a failure.
                     "is_error":is_error
+                }),
+                ContentBlock::Output { value, .. } => json!({
+                    "type":"text",
+                    "text":serde_json::to_string(value)?
                 }),
             });
         }
@@ -105,18 +123,51 @@ impl Provider for Anthropic {
         key: &ProviderKey,
         base_url: &str,
     ) -> Result<ModelRequest> {
-        let body = serde_json::to_vec(&Self::body(prefix, history)?)?;
-        Ok(ModelRequest {
-            method: "POST",
-            url: format!("{}/v1/messages", base_url.trim_end_matches('/')),
-            headers: vec![
-                ("content-type".into(), "application/json".into()),
-                ("accept".into(), "text/event-stream".into()),
-                ("anthropic-version".into(), "2023-06-01".into()),
-                ("x-api-key".into(), key.expose().to_string()),
-            ],
-            body,
-        })
+        Self::request(Self::body(prefix, history)?, key, base_url)
+    }
+
+    fn build_output_request(
+        &self,
+        prefix: &SealedPrefix,
+        history: &[Message],
+        key: &ProviderKey,
+        base_url: &str,
+        control: &OutputControl,
+        mode: OutputMode,
+    ) -> Result<ModelRequest> {
+        let mut body = Self::body(prefix, history)?;
+        let object = body.as_object_mut().expect("anthropic body is an object");
+        object.remove("tools");
+        object.insert(
+            "system".into(),
+            json!(format!(
+                "{}\n\n{}",
+                prefix.system_prompt, control.instruction
+            )),
+        );
+        match mode {
+            OutputMode::Native => {
+                object.insert(
+                    "output_config".into(),
+                    json!({"format":{"type":"json_schema","schema":control.schema}}),
+                );
+            }
+            OutputMode::ForcedTool => {
+                object.insert(
+                    "tools".into(),
+                    json!([{
+                        "name":"aex_output",
+                        "description":"Commit the final structured output.",
+                        "input_schema":control.schema
+                    }]),
+                );
+                object.insert(
+                    "tool_choice".into(),
+                    json!({"type":"tool","name":"aex_output","disable_parallel_tool_use":true}),
+                );
+            }
+        }
+        Self::request(body, key, base_url)
     }
 
     async fn stream(&self, req: ModelRequest) -> Result<BoxStream<'static, Result<ProviderEvent>>> {
@@ -220,6 +271,7 @@ fn map_stop(s: Option<&str>) -> StopReason {
         Some("tool_use") => StopReason::ToolUse,
         Some("max_tokens") => StopReason::MaxTokens,
         Some("stop_sequence") => StopReason::StopSequence,
+        Some("refusal") => StopReason::Refusal,
         // A stop reason we do not recognise is Unknown, not EndTurn. Guessing
         // EndTurn would end a turn the provider did not end.
         _ => StopReason::Unknown,
@@ -237,6 +289,7 @@ fn usage_of(u: Option<&Value>) -> Usage {
         output_tokens: g("output_tokens"),
         cache_read_input_tokens: g("cache_read_input_tokens"),
         cache_creation_input_tokens: g("cache_creation_input_tokens"),
+        reasoning_tokens: None,
     }
 }
 
@@ -284,6 +337,61 @@ mod tests {
     }
 
     #[test]
+    fn output_request_is_private_and_disables_ordinary_tools() {
+        let p = prefix();
+        let control = OutputControl {
+            schema: json!({
+                "type":"object",
+                "properties":{"answer":{"type":"number"}},
+                "required":["answer"],
+                "additionalProperties":false
+            }),
+            instruction: "commit privately".into(),
+        };
+        let native: Value = serde_json::from_slice(
+            &Anthropic
+                .build_output_request(
+                    &p,
+                    &[Message::user_text("hi")],
+                    &ProviderKey::new("k"),
+                    "http://x",
+                    &control,
+                    OutputMode::Native,
+                )
+                .unwrap()
+                .body,
+        )
+        .unwrap();
+        assert!(native.get("tools").is_none());
+        assert_eq!(native["output_config"]["format"]["type"], "json_schema");
+        assert_eq!(native["output_config"]["format"]["schema"], control.schema);
+        assert!(
+            native["system"]
+                .as_str()
+                .unwrap()
+                .ends_with("commit privately")
+        );
+
+        let fallback: Value = serde_json::from_slice(
+            &Anthropic
+                .build_output_request(
+                    &p,
+                    &[Message::user_text("hi")],
+                    &ProviderKey::new("k"),
+                    "http://x",
+                    &control,
+                    OutputMode::ForcedTool,
+                )
+                .unwrap()
+                .body,
+        )
+        .unwrap();
+        assert_eq!(fallback["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(fallback["tools"][0]["name"], "aex_output");
+        assert_eq!(fallback["tool_choice"]["name"], "aex_output");
+    }
+
+    #[test]
     fn tool_result_always_carries_is_error() {
         let p = prefix();
         let h = vec![Message::tool_results(vec![ContentBlock::ToolResult {
@@ -325,8 +433,8 @@ mod tests {
     }
 
     #[test]
-    fn unknown_stop_reason_is_unknown_not_end_turn() {
-        assert_eq!(map_stop(Some("refusal")), StopReason::Unknown);
+    fn refusal_is_typed_and_an_absent_reason_stays_unknown() {
+        assert_eq!(map_stop(Some("refusal")), StopReason::Refusal);
         assert_eq!(map_stop(None), StopReason::Unknown);
     }
 }

--- a/crates/brain/src/provider/fake.rs
+++ b/crates/brain/src/provider/fake.rs
@@ -10,7 +10,7 @@
 //! successfully, so a density run silently becomes a measurement of how fast the
 //! runtime produces error turns. `assert_drained` is not optional.
 
-use super::{ModelRequest, Provider, ProviderEvent};
+use super::{ModelRequest, OutputControl, OutputMode, Provider, ProviderEvent};
 use crate::config::{Dialect, ProviderKey, SealedPrefix};
 use crate::message::{Message, StopReason, Usage};
 use crate::{BrainError, Result};
@@ -22,6 +22,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 #[derive(Debug, Clone)]
 pub enum Scripted {
     Text(String),
+    Refusal(String),
     /// N tool calls **in one assistant message** -- this sameness is what makes
     /// them parallel rather than N turns.
     ToolCalls(Vec<(String, String, serde_json::Value)>),
@@ -408,6 +409,23 @@ impl Provider for FakeProvider {
         }
     }
 
+    fn build_output_request(
+        &self,
+        prefix: &SealedPrefix,
+        history: &[Message],
+        key: &ProviderKey,
+        base_url: &str,
+        control: &OutputControl,
+        mode: OutputMode,
+    ) -> Result<ModelRequest> {
+        match self.dialect {
+            Dialect::AnthropicMessages => super::anthropic::Anthropic
+                .build_output_request(prefix, history, key, base_url, control, mode),
+            Dialect::OpenAiChat => super::openai::OpenAiChat
+                .build_output_request(prefix, history, key, base_url, control, mode),
+        }
+    }
+
     async fn stream(&self, req: ModelRequest) -> Result<BoxStream<'static, Result<ProviderEvent>>> {
         let call_no = self.call_count.fetch_add(1, Ordering::SeqCst);
 
@@ -518,7 +536,18 @@ impl FakeProvider {
                         stop_reason: StopReason::EndTurn,
                         usage: Usage { input_tokens: Some(0), output_tokens: Some(0),
                                        cache_read_input_tokens: None,
-                                       cache_creation_input_tokens: None },
+                                       cache_creation_input_tokens: None,
+                                       reasoning_tokens: None },
+                    });
+                }
+                Scripted::Refusal(text) => {
+                    yield Ok(ProviderEvent::RefusalDelta { index: 0, text });
+                    yield Ok(ProviderEvent::MessageDone {
+                        stop_reason: StopReason::Refusal,
+                        usage: Usage { input_tokens: Some(0), output_tokens: Some(0),
+                                       cache_read_input_tokens: None,
+                                       cache_creation_input_tokens: None,
+                                       reasoning_tokens: None },
                     });
                 }
                 Scripted::ToolCalls(calls) => {
@@ -534,7 +563,8 @@ impl FakeProvider {
                         stop_reason: StopReason::ToolUse,
                         usage: Usage { input_tokens: Some(0), output_tokens: Some(0),
                                        cache_read_input_tokens: None,
-                                       cache_creation_input_tokens: None },
+                                       cache_creation_input_tokens: None,
+                                       reasoning_tokens: None },
                     });
                 }
             }

--- a/crates/brain/src/provider/mod.rs
+++ b/crates/brain/src/provider/mod.rs
@@ -35,6 +35,22 @@ pub struct ModelRequest {
     pub body: Vec<u8>,
 }
 
+/// The output commit request is a private provider step. It sees the requested schema and a
+/// transient control instruction, but neither becomes session history or a normal tool.
+#[derive(Debug, Clone)]
+pub struct OutputControl {
+    pub schema: serde_json::Value,
+    pub instruction: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputMode {
+    /// Provider-native constrained structured output.
+    Native,
+    /// A single forced internal `aex_output` tool. Ordinary session tools stay disabled.
+    ForcedTool,
+}
+
 impl ModelRequest {
     pub fn body_len(&self) -> usize {
         self.body.len()
@@ -63,6 +79,12 @@ impl std::fmt::Debug for ModelRequest {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ProviderEvent {
     TextDelta {
+        index: usize,
+        text: String,
+    },
+    /// A provider-native refusal payload. It is text for diagnostics, but it must not be parsed
+    /// as a structured-output candidate even when the provider finishes with an ordinary stop.
+    RefusalDelta {
         index: usize,
         text: String,
     },
@@ -99,6 +121,16 @@ pub trait Provider: Send + Sync + std::fmt::Debug {
         base_url: &str,
     ) -> Result<ModelRequest>;
 
+    fn build_output_request(
+        &self,
+        prefix: &SealedPrefix,
+        history: &[Message],
+        key: &ProviderKey,
+        base_url: &str,
+        control: &OutputControl,
+        mode: OutputMode,
+    ) -> Result<ModelRequest>;
+
     async fn stream(&self, req: ModelRequest) -> Result<BoxStream<'static, Result<ProviderEvent>>>;
 }
 
@@ -115,6 +147,7 @@ pub struct Accumulator {
     pub stop_reason: StopReason,
     pub usage: Usage,
     pub saw_terminal: bool,
+    saw_refusal: bool,
 }
 
 #[derive(Debug)]
@@ -135,6 +168,13 @@ impl Accumulator {
     pub fn push(&mut self, ev: ProviderEvent) {
         match ev {
             ProviderEvent::TextDelta { index, text } => {
+                self.ensure(index, || PartialBlock::Text(String::new()));
+                if let Some(PartialBlock::Text(s)) = self.blocks.get_mut(index) {
+                    s.push_str(&text);
+                }
+            }
+            ProviderEvent::RefusalDelta { index, text } => {
+                self.saw_refusal = true;
                 self.ensure(index, || PartialBlock::Text(String::new()));
                 if let Some(PartialBlock::Text(s)) = self.blocks.get_mut(index) {
                     s.push_str(&text);
@@ -163,7 +203,11 @@ impl Accumulator {
             }
             ProviderEvent::BlockDone { .. } => {}
             ProviderEvent::MessageDone { stop_reason, usage } => {
-                self.stop_reason = stop_reason;
+                // OpenAI emits usage in a final choices=[] chunk. Its unknown stop reason must
+                // not overwrite the real finish reason from the preceding chunk.
+                if stop_reason != StopReason::Unknown || self.stop_reason == StopReason::Unknown {
+                    self.stop_reason = stop_reason;
+                }
                 self.usage.merge(&usage);
                 self.saw_terminal = true;
             }
@@ -202,7 +246,12 @@ impl Accumulator {
                 }
             }
         }
-        Ok((Message::assistant(content), self.stop_reason, self.usage))
+        let stop_reason = if self.saw_refusal {
+            StopReason::Refusal
+        } else {
+            self.stop_reason
+        };
+        Ok((Message::assistant(content), stop_reason, self.usage))
     }
 }
 
@@ -341,6 +390,7 @@ mod tests {
                 output_tokens: Some(2),
                 cache_read_input_tokens: None,
                 cache_creation_input_tokens: None,
+                reasoning_tokens: None,
             },
         });
         let (msg, stop, usage) = a.finish().unwrap();

--- a/crates/brain/src/provider/openai.rs
+++ b/crates/brain/src/provider/openai.rs
@@ -6,7 +6,7 @@
 //! separate measurements.
 
 use super::sse::SseDecoder;
-use super::{ModelRequest, Provider, ProviderEvent};
+use super::{ModelRequest, OutputControl, OutputMode, Provider, ProviderEvent};
 use crate::config::{Dialect, ProviderKey, SealedPrefix};
 use crate::message::{ContentBlock, Message, Role, StopReason, Usage};
 use crate::{BrainError, Result};
@@ -17,6 +17,19 @@ use serde_json::{Map, Value, json};
 pub struct OpenAiChat;
 
 impl OpenAiChat {
+    fn request(body: Value, key: &ProviderKey, base_url: &str) -> Result<ModelRequest> {
+        Ok(ModelRequest {
+            method: "POST",
+            url: format!("{}/v1/chat/completions", base_url.trim_end_matches('/')),
+            headers: vec![
+                ("content-type".into(), "application/json".into()),
+                ("accept".into(), "text/event-stream".into()),
+                ("authorization".into(), format!("Bearer {}", key.expose())),
+            ],
+            body: serde_json::to_vec(&body)?,
+        })
+    }
+
     /// Render ONE provider-neutral message into the dialect's array elements.
     ///
     /// Split out of `body` so that the pre-rendered transcript store
@@ -45,6 +58,9 @@ impl OpenAiChat {
                             return Err(BrainError::Protocol(
                                 "a tool_result block cannot appear in an assistant message".into(),
                             ));
+                        }
+                        ContentBlock::Output { value, .. } => {
+                            text.push_str(&serde_json::to_string(value)?);
                         }
                     }
                 }
@@ -94,6 +110,11 @@ impl OpenAiChat {
                         ContentBlock::ToolUse { .. } => {
                             return Err(BrainError::Protocol(
                                 "a tool_use block cannot appear in a user message".into(),
+                            ));
+                        }
+                        ContentBlock::Output { .. } => {
+                            return Err(BrainError::Protocol(
+                                "an output block cannot appear in a user message".into(),
                             ));
                         }
                     }
@@ -164,17 +185,69 @@ impl Provider for OpenAiChat {
         key: &ProviderKey,
         base_url: &str,
     ) -> Result<ModelRequest> {
-        let body = serde_json::to_vec(&Self::body(prefix, history)?)?;
-        Ok(ModelRequest {
-            method: "POST",
-            url: format!("{}/v1/chat/completions", base_url.trim_end_matches('/')),
-            headers: vec![
-                ("content-type".into(), "application/json".into()),
-                ("accept".into(), "text/event-stream".into()),
-                ("authorization".into(), format!("Bearer {}", key.expose())),
-            ],
-            body,
-        })
+        Self::request(Self::body(prefix, history)?, key, base_url)
+    }
+
+    fn build_output_request(
+        &self,
+        prefix: &SealedPrefix,
+        history: &[Message],
+        key: &ProviderKey,
+        base_url: &str,
+        control: &OutputControl,
+        mode: OutputMode,
+    ) -> Result<ModelRequest> {
+        let mut body = Self::body(prefix, history)?;
+        let object = body.as_object_mut().expect("openai body is an object");
+        object.remove("tools");
+        if let Some(system) = object
+            .get_mut("messages")
+            .and_then(Value::as_array_mut)
+            .and_then(|messages| messages.first_mut())
+            .and_then(Value::as_object_mut)
+        {
+            system.insert(
+                "content".into(),
+                json!(format!(
+                    "{}\n\n{}",
+                    prefix.system_prompt, control.instruction
+                )),
+            );
+        }
+        match mode {
+            OutputMode::Native => {
+                object.insert(
+                    "response_format".into(),
+                    json!({
+                        "type":"json_schema",
+                        "json_schema":{
+                            "name":"aex_output",
+                            "strict":true,
+                            "schema":control.schema
+                        }
+                    }),
+                );
+            }
+            OutputMode::ForcedTool => {
+                object.insert(
+                    "tools".into(),
+                    json!([{
+                        "type":"function",
+                        "function":{
+                            "name":"aex_output",
+                            "description":"Commit the final structured output.",
+                            "parameters":control.schema
+                        }
+                    }]),
+                );
+                object.insert(
+                    "tool_choice".into(),
+                    json!({"type":"function","function":{"name":"aex_output"}}),
+                );
+                object.insert("parallel_tool_calls".into(), json!(false));
+            }
+        }
+        Self::request(body, key, base_url)
     }
 
     async fn stream(&self, req: ModelRequest) -> Result<BoxStream<'static, Result<ProviderEvent>>> {
@@ -204,6 +277,14 @@ pub fn decode(_event: Option<&str>, data: &str) -> Result<Vec<ProviderEvent>> {
                 && !t.is_empty()
             {
                 out.push(ProviderEvent::TextDelta {
+                    index: 0,
+                    text: t.to_string(),
+                });
+            }
+            if let Some(t) = delta.get("refusal").and_then(|c| c.as_str())
+                && !t.is_empty()
+            {
+                out.push(ProviderEvent::RefusalDelta {
                     index: 0,
                     text: t.to_string(),
                 });
@@ -262,6 +343,7 @@ fn map_stop(s: Option<&str>) -> StopReason {
         Some("stop") => StopReason::EndTurn,
         Some("tool_calls") | Some("function_call") => StopReason::ToolUse,
         Some("length") => StopReason::MaxTokens,
+        Some("content_filter") => StopReason::Refusal,
         _ => StopReason::Unknown,
     }
 }
@@ -280,6 +362,10 @@ fn usage_of(u: Option<&Value>) -> Usage {
             .and_then(|d| d.get("cached_tokens"))
             .and_then(|v| v.as_u64()),
         cache_creation_input_tokens: None,
+        reasoning_tokens: u
+            .get("completion_tokens_details")
+            .and_then(|details| details.get("reasoning_tokens"))
+            .and_then(Value::as_u64),
     }
 }
 
@@ -307,6 +393,66 @@ mod tests {
                 route: ToolRoute::Hand,
             })
             .seal()
+    }
+
+    #[test]
+    fn output_request_is_private_and_disables_ordinary_tools() {
+        let p = prefix();
+        let control = OutputControl {
+            schema: json!({
+                "type":"object",
+                "properties":{"answer":{"type":"number"}},
+                "required":["answer"],
+                "additionalProperties":false
+            }),
+            instruction: "commit privately".into(),
+        };
+        let native: Value = serde_json::from_slice(
+            &OpenAiChat
+                .build_output_request(
+                    &p,
+                    &[Message::user_text("hi")],
+                    &ProviderKey::new("k"),
+                    "http://x",
+                    &control,
+                    OutputMode::Native,
+                )
+                .unwrap()
+                .body,
+        )
+        .unwrap();
+        assert!(native.get("tools").is_none());
+        assert_eq!(native["response_format"]["type"], "json_schema");
+        assert_eq!(native["response_format"]["json_schema"]["strict"], true);
+        assert_eq!(
+            native["response_format"]["json_schema"]["schema"],
+            control.schema
+        );
+        assert!(
+            native["messages"][0]["content"]
+                .as_str()
+                .unwrap()
+                .ends_with("commit privately")
+        );
+
+        let fallback: Value = serde_json::from_slice(
+            &OpenAiChat
+                .build_output_request(
+                    &p,
+                    &[Message::user_text("hi")],
+                    &ProviderKey::new("k"),
+                    "http://x",
+                    &control,
+                    OutputMode::ForcedTool,
+                )
+                .unwrap()
+                .body,
+        )
+        .unwrap();
+        assert_eq!(fallback["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(fallback["tools"][0]["function"]["name"], "aex_output");
+        assert!(fallback["tools"][0]["function"].get("strict").is_none());
+        assert_eq!(fallback["parallel_tool_calls"], false);
     }
 
     #[test]
@@ -383,6 +529,26 @@ mod tests {
             }
             other => panic!("expected MessageDone, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn structured_refusal_survives_an_ordinary_stop_and_usage_chunk() {
+        let raw = concat!(
+            "data: {\"choices\":[{\"delta\":{\"refusal\":\"I cannot help with that.\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":5}}\n\n"
+        );
+        let mut accumulator = Accumulator::new();
+        for event in decode_stream(raw.as_bytes()).unwrap() {
+            accumulator.push(event);
+        }
+        let (message, stop, usage) = accumulator.finish().unwrap();
+        assert_eq!(stop, StopReason::Refusal);
+        assert_eq!(usage.input_tokens, Some(9));
+        assert!(matches!(
+            &message.content[0],
+            ContentBlock::Text { text } if text == "I cannot help with that."
+        ));
     }
 
     #[test]

--- a/crates/brain/src/session.rs
+++ b/crates/brain/src/session.rs
@@ -15,10 +15,11 @@ use crate::adapter::{
     HandAdapter, HandFactory, HandSpec, SeedFile, WorkspaceFile, WorkspaceListing,
 };
 use crate::compact::DEFAULT_HISTORY_BUDGET_BYTES;
-use crate::config::{AgentDef, Dialect, GenOpts, ProviderKey, SessionConfig};
+use crate::config::{AgentDef, Dialect, GenOpts, ProviderKey, SealedPrefix, SessionConfig};
 use crate::events::EventHub;
 use crate::journal::{
-    ArtifactDoc, Entry, FailureDoc, Head, HeadDoc, Journal, Lease, PrefixDoc, Record,
+    ArtifactDoc, Entry, FailureDoc, Head, HeadDoc, Journal, Lease, OutputRequestDoc, PrefixDoc,
+    Record,
 };
 use crate::keys::{KeyCustody, blob_from_b64, blob_to_b64};
 use crate::local::LocalFactory;
@@ -28,7 +29,8 @@ use crate::tools::TodoState;
 use crate::turn::{TurnRun, TurnState};
 use crate::{BrainError, Result};
 use aex_contracts::session::{
-    self, CreateSessionRequest, MessageRequestContent, Provider as ApiProvider,
+    self, CreateSessionRequest, MessageRequestContent, OutputRequest, OutputRequestInput,
+    Provider as ApiProvider,
 };
 use base64::Engine;
 use std::collections::HashMap;
@@ -161,6 +163,14 @@ enum Command {
         content: Vec<ContentBlock>,
         reply: oneshot::Sender<Result<(String, u64)>>, // (turn_id, seq of the user message)
     },
+    Output {
+        schema: serde_json::Value,
+        schema_hash: String,
+        request_hash: String,
+        idempotency_key_hash: Option<String>,
+        input: Option<Vec<ContentBlock>>,
+        reply: oneshot::Sender<Result<OutputAdmission>>,
+    },
     Cancel {
         reply: oneshot::Sender<Result<HeadDoc>>,
     },
@@ -193,6 +203,13 @@ enum Command {
     Snapshot {
         reply: oneshot::Sender<HeadDoc>,
     },
+}
+
+#[derive(Debug, Clone)]
+pub struct OutputAdmission {
+    pub output_id: String,
+    pub schema_hash: String,
+    pub seq: u64,
 }
 
 impl Brain {
@@ -421,6 +438,7 @@ impl Brain {
             hand_state,
             workspace_bytes: 0,
             artifacts: Vec::new(),
+            output_requests: Vec::new(),
         };
         self.journal
             .create(
@@ -522,6 +540,36 @@ impl Brain {
         let blocks = content_blocks(content)?;
         self.deliver(session_id, |reply| Command::Message {
             content: blocks.clone(),
+            reply,
+        })
+        .await?
+    }
+
+    pub async fn output(
+        self: &Arc<Self>,
+        session_id: &str,
+        req: OutputRequest,
+        idempotency_key: Option<&str>,
+    ) -> Result<OutputAdmission> {
+        if let Some(key) = idempotency_key
+            && (key.is_empty() || key.len() > 128)
+        {
+            return Err(BrainError::Invalid(
+                "Idempotency-Key must contain 1 to 128 bytes".into(),
+            ));
+        }
+        let request_hash = crate::output::jcs_sha256(&req)?;
+        let schema_hash = req.schema_hash.to_string();
+        let schema = serde_json::Value::Object(req.schema.0);
+        crate::output::validate_schema(&schema, &schema_hash)?;
+        let input = req.input.map(output_content_blocks).transpose()?;
+        let idempotency_key_hash = idempotency_key.map(crate::output::jcs_sha256).transpose()?;
+        self.deliver(session_id, |reply| Command::Output {
+            schema: schema.clone(),
+            schema_hash: schema_hash.clone(),
+            request_hash: request_hash.clone(),
+            idempotency_key_hash: idempotency_key_hash.clone(),
+            input: input.clone(),
             reply,
         })
         .await?
@@ -660,12 +708,88 @@ struct Resident {
     key: ProviderKey,
 }
 
+struct Running {
+    handle: tokio::task::JoinHandle<(TurnState, RunningOutcome)>,
+    cancel: CancellationToken,
+    key: ProviderKey,
+}
+
+enum RunningOutcome {
+    Turn {
+        turn_id: String,
+        outcome: Result<crate::turn::TurnReport>,
+    },
+    Output {
+        output_id: String,
+        outcome: Result<OutputJobReport>,
+    },
+}
+
+#[derive(Debug)]
+struct OutputJobReport {
+    completed: bool,
+}
+
+struct OutputRuntime {
+    prefix: Arc<SealedPrefix>,
+    session: SessionConfig,
+    provider: Arc<dyn Provider>,
+}
+
+enum OutputAdmit {
+    Replay(OutputAdmission),
+    Started {
+        admission: OutputAdmission,
+        turn_id: Option<String>,
+        cancel: CancellationToken,
+    },
+}
+
 #[derive(Debug)]
 struct PendingTask {
     seq: u64,
     turn: String,
     agent: String,
     call: String,
+}
+
+#[derive(Debug)]
+struct PendingOutput {
+    seq: u64,
+    output: String,
+    turn: Option<String>,
+    schema_hash: String,
+}
+
+fn pending_outputs(entries: &[Entry]) -> Vec<PendingOutput> {
+    let mut pending = HashMap::<String, PendingOutput>::new();
+    for entry in entries {
+        match &entry.record {
+            Record::OutputStarted {
+                output,
+                turn,
+                schema_hash,
+                ..
+            } => {
+                pending.insert(
+                    output.clone(),
+                    PendingOutput {
+                        seq: entry.seq,
+                        output: output.clone(),
+                        turn: turn.clone(),
+                        schema_hash: schema_hash.clone(),
+                    },
+                );
+            }
+            Record::OutputCompleted { output, .. } | Record::OutputFailed { output, .. } => {
+                pending.remove(output);
+            }
+            _ => {}
+        }
+    }
+    let mut pending: Vec<_> = pending.into_values().collect();
+    pending.sort_by_key(|output| output.seq);
+    pending
 }
 
 /// Finds `task` intents with no result. Once a new owner can claim the
@@ -723,13 +847,7 @@ async fn actor(
     eager_hand: bool,
 ) {
     let mut resident: Option<Resident> = None;
-    #[allow(clippy::type_complexity)]
-    let mut running: Option<(
-        tokio::task::JoinHandle<(TurnState, Result<crate::turn::TurnReport>)>,
-        CancellationToken,
-        String,
-        ProviderKey,
-    )> = None;
+    let mut running: Option<Running> = None;
 
     if eager_hand {
         // Eager hand creation, D16: ready the substrate without any caller waiting.
@@ -765,21 +883,9 @@ async fn actor(
 
     loop {
         tokio::select! {
-            done = async { (&mut running.as_mut().expect("guarded").0).await }, if running.is_some() => {
-                let (_, _, turn_id, key) = running.take().expect("running");
-                match done {
-                    Ok((st, outcome)) => {
-                        let mut r = Resident { st, key };
-                        finish_turn(&brain, &session_id, &turn_id, &mut r.st, outcome).await;
-                        resident = Some(r);
-                    }
-                    Err(join_err) => {
-                        tracing::error!(session = %session_id, error = %join_err, "turn task panicked");
-                        // The fold moved into the task and is gone; discard and rehydrate on
-                        // the next message. The journal has everything up to the last commit.
-                        resident = None;
-                    }
-                }
+            done = async { (&mut running.as_mut().expect("guarded").handle).await }, if running.is_some() => {
+                let task = running.take().expect("running");
+                resident = settle_running(&brain, &session_id, task.key, done).await;
             }
             cmd = rx.recv() => {
                 let Some(cmd) = cmd else { break };
@@ -826,16 +932,134 @@ async fn actor(
                                     let _permit = permit; // held for the whole turn (admission)
                                     let mut st = parked.st;
                                     let out = run.run(&mut st).await;
-                                    (st, out)
+                                    (st, RunningOutcome::Turn { turn_id: turn_id.clone(), outcome: out })
                                 });
-                                running = Some((handle, cancel, turn_id, key));
+                                running = Some(Running { handle, cancel, key });
                             }
                             Err(e) => { let _ = reply.send(Err(e)); }
                         }
                     }
+                    Command::Output {
+                        schema,
+                        schema_hash,
+                        request_hash,
+                        idempotency_key_hash,
+                        input,
+                        reply,
+                    } => {
+                        if running.is_some() {
+                            let replay = match brain.journal.get_head(&session_id).await {
+                                Ok(head) => replay_output(
+                                    &head.doc,
+                                    idempotency_key_hash.as_deref(),
+                                    &request_hash,
+                                ),
+                                Err(error) => Err(error),
+                            };
+                            match replay {
+                                Ok(Some(admission)) => { let _ = reply.send(Ok(admission)); }
+                                Ok(None) => { let _ = reply.send(Err(BrainError::TurnInFlight(session_id.clone()))); }
+                                Err(error) => { let _ = reply.send(Err(error)); }
+                            }
+                            continue;
+                        }
+                        let resident_ref = match ensure_resident(&brain, &session_id, &mut resident).await {
+                            Ok(resident) => resident,
+                            Err(error) => { let _ = reply.send(Err(error)); continue; }
+                        };
+                        // Replays are reads of an already-admitted identity. They must not need
+                        // provider configuration or a fresh global turn permit.
+                        match replay_output(
+                            &resident_ref.st.head,
+                            idempotency_key_hash.as_deref(),
+                            &request_hash,
+                        ) {
+                            Ok(Some(admission)) => {
+                                let _ = reply.send(Ok(admission));
+                                continue;
+                            }
+                            Ok(None) => {}
+                            Err(error) => {
+                                let _ = reply.send(Err(error));
+                                continue;
+                            }
+                        }
+                        let runtime = match output_runtime(&brain, resident_ref) {
+                            Ok(runtime) => runtime,
+                            Err(error) => { let _ = reply.send(Err(error)); continue; }
+                        };
+                        let permit = match brain.turn_permits.clone().try_acquire_owned() {
+                            Ok(permit) => permit,
+                            Err(_) => { let _ = reply.send(Err(BrainError::Overloaded)); continue; }
+                        };
+                        let admitted = admit_output(
+                            &brain,
+                            &session_id,
+                            resident_ref,
+                            &schema_hash,
+                            &request_hash,
+                            idempotency_key_hash.as_deref(),
+                            input,
+                        ).await;
+                        let OutputAdmit::Started { admission, turn_id, cancel } = (match admitted {
+                            Ok(OutputAdmit::Replay(admission)) => {
+                                let _ = reply.send(Ok(admission));
+                                continue;
+                            }
+                            Ok(started) => started,
+                            Err(error) => { let _ = reply.send(Err(error)); continue; }
+                        }) else { unreachable!("replay handled above") };
+
+                        let _ = reply.send(Ok(admission.clone()));
+                        let parked = resident.take().expect("resident");
+                        let work_run = turn_id.as_ref().map(|turn_id| TurnRun {
+                            session_id: session_id.clone(),
+                            turn_id: turn_id.clone(),
+                            prefix: runtime.prefix.clone(),
+                            session: runtime.session.clone(),
+                            provider: runtime.provider.clone(),
+                            provider_name: parked.st.head.prefix.provider.clone(),
+                            journal: brain.journal.clone(),
+                            hub: brain.hub.clone(),
+                            cancel: cancel.clone(),
+                            model_permits: brain.model_permits.clone(),
+                            history_budget_bytes: brain.cfg.history_budget_bytes,
+                            web: brain.web.clone(),
+                        });
+                        let key = parked.key.clone();
+                        let output_id = admission.output_id.clone();
+                        let brain_for_job = brain.clone();
+                        let session_for_job = session_id.clone();
+                        let schema_hash_for_job = schema_hash.clone();
+                        let cancel_for_job = cancel.clone();
+                        let handle = tokio::spawn(async move {
+                            let _permit = permit;
+                            let mut state = parked.st;
+                            let outcome = run_output_job(
+                                &brain_for_job,
+                                &session_for_job,
+                                &output_id,
+                                &schema_hash_for_job,
+                                turn_id,
+                                schema,
+                                runtime,
+                                work_run,
+                                cancel_for_job,
+                                &mut state,
+                            ).await;
+                            (
+                                state,
+                                RunningOutcome::Output {
+                                    output_id,
+                                    outcome,
+                                },
+                            )
+                        });
+                        running = Some(Running { handle, cancel, key });
+                    }
                     Command::Cancel { reply } => {
-                        if let Some((_, cancel, _, _)) = &running {
-                            cancel.cancel();
+                        if let Some(task) = &running {
+                            task.cancel.cancel();
                         }
                         let doc = match &resident {
                             Some(r) => r.st.head.clone(),
@@ -847,13 +1071,11 @@ async fn actor(
                         let _ = reply.send(Ok(doc));
                     }
                     Command::End { reply } => {
-                        if let Some((handle, cancel, turn_id, key)) = running.take() {
-                            cancel.cancel();
-                            if let Ok((st, outcome)) = handle.await {
-                                let mut r = Resident { st, key };
-                                finish_turn(&brain, &session_id, &turn_id, &mut r.st, outcome).await;
-                                resident = Some(r);
-                            }
+                        if let Some(task) = running.take() {
+                            task.cancel.cancel();
+                            let key = task.key;
+                            let done = task.handle.await;
+                            resident = settle_running(&brain, &session_id, key, done).await;
                         }
                         match end_session(&brain, &session_id, &mut resident).await {
                             Ok(doc) => { let _ = reply.send(Ok(doc)); }
@@ -861,9 +1083,9 @@ async fn actor(
                         }
                     }
                     Command::Delete { reply } => {
-                        if let Some((handle, cancel, _, _)) = running.take() {
-                            cancel.cancel();
-                            let _ = handle.await;
+                        if let Some(task) = running.take() {
+                            task.cancel.cancel();
+                            let _ = task.handle.await;
                             resident = None;
                         }
                         let out = delete_session(&brain, &session_id, &mut resident).await;
@@ -937,6 +1159,67 @@ async fn actor(
         }
     }
     tracing::debug!(session = %session_id, "actor exited");
+}
+
+async fn settle_running(
+    brain: &Arc<Brain>,
+    session_id: &str,
+    key: ProviderKey,
+    done: std::result::Result<(TurnState, RunningOutcome), tokio::task::JoinError>,
+) -> Option<Resident> {
+    match done {
+        Ok((st, outcome)) => {
+            let mut resident = Resident { st, key };
+            match outcome {
+                RunningOutcome::Turn { turn_id, outcome } => {
+                    finish_turn(brain, session_id, &turn_id, &mut resident.st, outcome).await;
+                }
+                RunningOutcome::Output { output_id, outcome } => {
+                    match outcome {
+                        Ok(report) => tracing::info!(
+                            session = %session_id,
+                            output = %output_id,
+                            completed = report.completed,
+                            "output done"
+                        ),
+                        Err(error) => tracing::error!(
+                            session = %session_id,
+                            output = %output_id,
+                            error = %error,
+                            "output task could not commit its terminal event"
+                        ),
+                    }
+                    match resident.st.hand.checkpoint().await {
+                        Ok(()) => {
+                            if let Err(error) =
+                                commit(brain, session_id, &mut resident.st, vec![]).await
+                            {
+                                tracing::warn!(session = %session_id, error = %error, "output checkpoint commit failed");
+                            }
+                        }
+                        Err(error) => {
+                            tracing::warn!(session = %session_id, error = %error, "output checkpoint failed")
+                        }
+                    }
+                    resident.st.hand.idle();
+                }
+            }
+            Some(resident)
+        }
+        Err(join_error) => {
+            tracing::error!(session = %session_id, error = %join_error, "session task panicked");
+            // The fold moved into the task and is gone. Rehydrate immediately so an admitted
+            // output gets a durable interrupted terminal instead of leaving its Promise open
+            // until some unrelated future request happens to touch the session.
+            match hydrate(brain, session_id).await {
+                Ok(resident) => Some(resident),
+                Err(error) => {
+                    tracing::error!(session = %session_id, error = %error, "session rehydrate after panic failed");
+                    None
+                }
+            }
+        }
+    }
 }
 
 async fn ensure_resident<'a>(
@@ -1041,6 +1324,75 @@ async fn hydrate(brain: &Arc<Brain>, session_id: &str) -> Result<Resident> {
             last_seq: head.last_seq,
         };
         let high_water = next_seq - 1;
+        brain
+            .journal
+            .commit(session_id, &mut lease, &records, &head.doc, high_water)
+            .await?;
+        let now = crate::wall_ms();
+        for (seq, record) in &records {
+            if let Some(event) =
+                crate::events::derive(session_id, *seq, now, record, &head.doc.hand_info)
+            {
+                brain.hub.publish(session_id, event);
+            }
+        }
+        head.last_seq = lease.last_seq;
+        entries = brain.journal.read_records(session_id, 0).await?;
+    }
+
+    // An output commit is a model-side effect and must never be replayed after ownership was
+    // lost. Close any admitted request that lacks a terminal event as interrupted; an
+    // idempotent retry then replays this same failure instead of asking the model twice.
+    let interrupted_outputs = pending_outputs(&entries);
+    if !interrupted_outputs.is_empty() {
+        let mut next_seq = head.last_seq + 1;
+        let mut records = Vec::with_capacity(interrupted_outputs.len() * 2 + 1);
+        for output in &interrupted_outputs {
+            records.push((
+                next_seq,
+                Record::OutputFailed {
+                    output: output.output.clone(),
+                    turn: output.turn.clone(),
+                    schema_hash: output.schema_hash.clone(),
+                    code: "cancelled".into(),
+                    message:
+                        "output interrupted when its previous owner stopped; it was not replayed"
+                            .into(),
+                    issues: Vec::new(),
+                    usage: crate::message::Usage::default(),
+                },
+            ));
+            next_seq += 1;
+            if let Some(turn) = &output.turn
+                && head.doc.turn.as_deref() == Some(turn)
+            {
+                records.push((
+                    next_seq,
+                    Record::TurnFailed {
+                        turn: turn.clone(),
+                        code: "cancelled".into(),
+                        message: "turn interrupted with its output request; it was not replayed"
+                            .into(),
+                    },
+                ));
+                next_seq += 1;
+            }
+        }
+        head.doc.state = "idle".into();
+        let previous_turn = head.doc.turn.take();
+        records.push((
+            next_seq,
+            Record::State {
+                state: "idle".into(),
+                turn: previous_turn,
+            },
+        ));
+        head.doc.updated_ms = crate::wall_ms();
+        let high_water = next_seq;
+        let mut lease = Lease {
+            fence: head.fence,
+            last_seq: head.last_seq,
+        };
         brain
             .journal
             .commit(session_id, &mut lease, &records, &head.doc, high_water)
@@ -1219,6 +1571,437 @@ async fn admit(
     r.st.hand.on_message_admitted();
 
     Ok((turn_id, user_seq, CancellationToken::new()))
+}
+
+fn output_runtime(brain: &Arc<Brain>, resident: &Resident) -> Result<OutputRuntime> {
+    let (prefix, dialect) = build_prefix(&resident.st.head.prefix)?;
+    let base_url = resident.st.head.prefix.base_url.clone().unwrap_or_default();
+    let session = SessionConfig::new(prefix.clone(), resident.key.clone(), base_url);
+    Ok(OutputRuntime {
+        prefix,
+        session,
+        provider: (brain.provider_factory)(dialect),
+    })
+}
+
+fn replay_output(
+    doc: &HeadDoc,
+    idempotency_key_hash: Option<&str>,
+    request_hash: &str,
+) -> Result<Option<OutputAdmission>> {
+    let Some(key_hash) = idempotency_key_hash else {
+        return Ok(None);
+    };
+    let Some(previous) = doc
+        .output_requests
+        .iter()
+        .find(|request| request.key_hash == key_hash)
+    else {
+        return Ok(None);
+    };
+    if previous.request_hash != request_hash {
+        return Err(BrainError::IdempotencyConflict);
+    }
+    Ok(Some(OutputAdmission {
+        output_id: previous.output_id.clone(),
+        schema_hash: previous.schema_hash.clone(),
+        seq: previous.started_seq,
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn admit_output(
+    brain: &Arc<Brain>,
+    session_id: &str,
+    resident: &mut Resident,
+    schema_hash: &str,
+    request_hash: &str,
+    idempotency_key_hash: Option<&str>,
+    input: Option<Vec<ContentBlock>>,
+) -> Result<OutputAdmit> {
+    if let Some(admission) = replay_output(&resident.st.head, idempotency_key_hash, request_hash)? {
+        return Ok(OutputAdmit::Replay(admission));
+    }
+    if resident.st.head.state == "failed" {
+        return Err(BrainError::SessionFailed(
+            resident
+                .st
+                .head
+                .failure
+                .as_ref()
+                .map(|failure| failure.message.clone())
+                .unwrap_or_default(),
+        ));
+    }
+
+    let now = crate::wall_ms();
+    resident
+        .st
+        .head
+        .output_requests
+        .retain(|request| now.saturating_sub(request.admitted_ms) <= 24 * 60 * 60 * 1000);
+
+    if input.is_some() && resident.st.hand.must_release() {
+        let _ = resident.st.hand.release().await;
+        let seq = resident.st.take_seq();
+        let record = Record::State {
+            state: resident.st.head.state.clone(),
+            turn: None,
+        };
+        commit(brain, session_id, &mut resident.st, vec![(seq, record)]).await?;
+    }
+
+    let source_seq = resident.st.lease.last_seq;
+    let output_id = crate::mint_id("out", 24);
+    let turn_id = input.as_ref().map(|_| crate::mint_id("trn", 24));
+    let mut records = Vec::with_capacity(if input.is_some() { 3 } else { 1 });
+
+    if let (Some(content), Some(turn)) = (input.as_ref(), turn_id.as_ref()) {
+        records.push((
+            resident.st.take_seq(),
+            Record::UserMessage {
+                turn: turn.clone(),
+                content: content.clone(),
+            },
+        ));
+        records.push((
+            resident.st.take_seq(),
+            Record::TurnStarted { turn: turn.clone() },
+        ));
+        resident.st.head.turn = Some(turn.clone());
+        resident.st.head.turns += 1;
+        resident.st.head.last_message_ms = Some(now);
+    }
+    let started_seq = resident.st.take_seq();
+    records.push((
+        started_seq,
+        Record::OutputStarted {
+            output: output_id.clone(),
+            turn: turn_id.clone(),
+            schema_hash: schema_hash.to_string(),
+            source_seq,
+        },
+    ));
+    resident.st.head.state = "active".into();
+
+    if let Some(key_hash) = idempotency_key_hash {
+        if resident.st.head.output_requests.len() >= 256 {
+            resident.st.head.output_requests.remove(0);
+        }
+        resident.st.head.output_requests.push(OutputRequestDoc {
+            key_hash: key_hash.to_string(),
+            request_hash: request_hash.to_string(),
+            output_id: output_id.clone(),
+            schema_hash: schema_hash.to_string(),
+            started_seq,
+            admitted_ms: now,
+        });
+    }
+    commit(brain, session_id, &mut resident.st, records).await?;
+
+    if let Some(content) = input {
+        if let Some(last) = resident.st.history.last_mut()
+            && last.role == crate::message::Role::User
+            && !last.content.is_empty()
+            && last
+                .content
+                .iter()
+                .all(|block| matches!(block, ContentBlock::ToolResult { .. }))
+        {
+            last.content.extend(content);
+        } else {
+            resident.st.history.push(Message {
+                role: crate::message::Role::User,
+                content,
+            });
+        }
+        resident.st.hand.on_message_admitted();
+    }
+
+    Ok(OutputAdmit::Started {
+        admission: OutputAdmission {
+            output_id,
+            schema_hash: schema_hash.to_string(),
+            seq: started_seq,
+        },
+        turn_id,
+        cancel: CancellationToken::new(),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_output_job(
+    brain: &Arc<Brain>,
+    session_id: &str,
+    output_id: &str,
+    schema_hash: &str,
+    turn_id: Option<String>,
+    schema: serde_json::Value,
+    runtime: OutputRuntime,
+    work_run: Option<TurnRun>,
+    cancel: CancellationToken,
+    state: &mut TurnState,
+) -> Result<OutputJobReport> {
+    let work_report = if let Some(run) = work_run {
+        match run.run_work(state).await {
+            Ok(report) => Some(report),
+            Err(error) => {
+                return finish_output_failure(
+                    brain,
+                    session_id,
+                    state,
+                    output_id,
+                    schema_hash,
+                    turn_id,
+                    None,
+                    error,
+                    Vec::new(),
+                    crate::message::Usage::default(),
+                    true,
+                )
+                .await;
+            }
+        }
+    } else {
+        None
+    };
+
+    if work_report
+        .as_ref()
+        .is_some_and(|report| report.stop_reason == "refusal")
+    {
+        let message = last_assistant_text(&state.history)
+            .filter(|message| !message.is_empty())
+            .unwrap_or_else(|| "the provider refused the output request".into());
+        return finish_output_failure(
+            brain,
+            session_id,
+            state,
+            output_id,
+            schema_hash,
+            turn_id,
+            work_report,
+            BrainError::OutputRefused(message),
+            Vec::new(),
+            crate::message::Usage::default(),
+            false,
+        )
+        .await;
+    }
+
+    if work_report
+        .as_ref()
+        .is_some_and(|report| report.stop_reason == "cancelled")
+    {
+        return finish_output_failure(
+            brain,
+            session_id,
+            state,
+            output_id,
+            schema_hash,
+            turn_id,
+            work_report,
+            BrainError::Cancelled,
+            Vec::new(),
+            crate::message::Usage::default(),
+            false,
+        )
+        .await;
+    }
+
+    let context = crate::output::CommitContext {
+        provider: runtime.provider,
+        prefix: runtime.prefix,
+        session: runtime.session,
+        history: state.history.clone(),
+        model_permits: brain.model_permits.clone(),
+        cancel,
+    };
+    match crate::output::commit(context, schema).await {
+        Ok(success) => {
+            let output_seq = state.take_seq();
+            let mut records = vec![(
+                output_seq,
+                Record::OutputCompleted {
+                    output: output_id.to_string(),
+                    turn: turn_id.clone(),
+                    schema_hash: schema_hash.to_string(),
+                    value: success.value.clone(),
+                    usage: success.usage,
+                },
+            )];
+            append_turn_terminal(
+                state,
+                &mut records,
+                turn_id.as_deref(),
+                work_report.as_ref(),
+            );
+            state.head.state = "idle".into();
+            state.head.turn = None;
+            let state_seq = state.take_seq();
+            records.push((
+                state_seq,
+                Record::State {
+                    state: "idle".into(),
+                    turn: turn_id.clone(),
+                },
+            ));
+            commit(brain, session_id, state, records).await?;
+            append_output_history(state, schema_hash, success.value);
+            Ok(OutputJobReport { completed: true })
+        }
+        Err(failure) => {
+            finish_output_failure(
+                brain,
+                session_id,
+                state,
+                output_id,
+                schema_hash,
+                turn_id,
+                work_report,
+                failure.error,
+                failure.issues,
+                failure.usage,
+                false,
+            )
+            .await
+        }
+    }
+}
+
+fn append_turn_terminal(
+    state: &TurnState,
+    records: &mut Vec<(u64, Record)>,
+    turn_id: Option<&str>,
+    report: Option<&crate::turn::TurnReport>,
+) {
+    if let (Some(turn), Some(report)) = (turn_id, report) {
+        records.push((
+            state.take_seq(),
+            Record::TurnCompleted {
+                turn: turn.to_string(),
+                stop_reason: report.stop_reason.clone(),
+                rounds: report.rounds,
+                tool_calls: report.tool_calls,
+            },
+        ));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finish_output_failure(
+    brain: &Arc<Brain>,
+    session_id: &str,
+    state: &mut TurnState,
+    output_id: &str,
+    schema_hash: &str,
+    turn_id: Option<String>,
+    work_report: Option<crate::turn::TurnReport>,
+    error: BrainError,
+    issues: Vec<crate::output::ValidationIssue>,
+    usage: crate::message::Usage,
+    work_failed: bool,
+) -> Result<OutputJobReport> {
+    let message = error.to_string();
+    let code = output_error_code(&error).to_string();
+    let mut records = vec![(
+        state.take_seq(),
+        Record::OutputFailed {
+            output: output_id.to_string(),
+            turn: turn_id.clone(),
+            schema_hash: schema_hash.to_string(),
+            code,
+            message: message.clone(),
+            issues,
+            usage,
+        },
+    )];
+    if work_failed {
+        if let Some(turn) = turn_id.as_ref() {
+            records.push((
+                state.take_seq(),
+                Record::TurnFailed {
+                    turn: turn.clone(),
+                    code: turn_error_code(&error).into(),
+                    message,
+                },
+            ));
+        }
+    } else {
+        append_turn_terminal(
+            state,
+            &mut records,
+            turn_id.as_deref(),
+            work_report.as_ref(),
+        );
+    }
+    state.head.state = "idle".into();
+    state.head.turn = None;
+    records.push((
+        state.take_seq(),
+        Record::State {
+            state: "idle".into(),
+            turn: turn_id,
+        },
+    ));
+    commit(brain, session_id, state, records).await?;
+    Ok(OutputJobReport { completed: false })
+}
+
+fn output_error_code(error: &BrainError) -> &'static str {
+    match error {
+        BrainError::OutputSchema(_) => "output_schema_error",
+        BrainError::OutputRefused(_) => "output_refused",
+        BrainError::OutputValidation(_) => "output_validation_error",
+        BrainError::Cancelled => "cancelled",
+        BrainError::ProviderStatus { .. } | BrainError::Transport(_) | BrainError::Protocol(_) => {
+            "provider_error"
+        }
+        BrainError::HandUnavailable(_) | BrainError::Hand(_) => "hand_unavailable",
+        BrainError::Overloaded => "rate_limited",
+        BrainError::SessionDeleted(_) | BrainError::SessionFailed(_) => "session_failed",
+        _ => "internal",
+    }
+}
+
+fn turn_error_code(error: &BrainError) -> &'static str {
+    match error {
+        BrainError::ProviderStatus { .. } | BrainError::Transport(_) | BrainError::Protocol(_) => {
+            "provider_error"
+        }
+        BrainError::HandUnavailable(_) | BrainError::Hand(_) => "hand_unavailable",
+        BrainError::SessionFailed(_) => "session_failed",
+        BrainError::Cancelled => "cancelled",
+        _ => "internal",
+    }
+}
+
+fn append_output_history(state: &mut TurnState, schema_hash: &str, value: serde_json::Value) {
+    let block = ContentBlock::Output {
+        schema_hash: schema_hash.to_string(),
+        value,
+    };
+    if let Some(last) = state.history.last_mut()
+        && last.role == crate::message::Role::Assistant
+    {
+        last.content.push(block);
+    } else {
+        state.history.push(Message::assistant(vec![block]));
+    }
+}
+
+fn last_assistant_text(history: &[Message]) -> Option<String> {
+    let message = history.last()?;
+    (message.role == crate::message::Role::Assistant).then(|| {
+        message
+            .content
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<String>()
+    })
 }
 
 fn turn_run(
@@ -1705,6 +2488,35 @@ fn content_blocks(content: MessageRequestContent) -> Result<Vec<ContentBlock>> {
     }
 }
 
+fn output_content_blocks(content: OutputRequestInput) -> Result<Vec<ContentBlock>> {
+    match content {
+        OutputRequestInput::String(value) => {
+            let value = value.to_string();
+            if value.is_empty() {
+                return Err(BrainError::Invalid("input must not be empty".into()));
+            }
+            Ok(vec![ContentBlock::text(value)])
+        }
+        OutputRequestInput::Array(parts) => {
+            if parts.is_empty() {
+                return Err(BrainError::Invalid("input must not be empty".into()));
+            }
+            let mut blocks = Vec::with_capacity(parts.len());
+            for part in parts {
+                match part {
+                    session::ContentPart::Text { text } => blocks.push(ContentBlock::text(text)),
+                    session::ContentPart::WorkspaceFile { .. } => {
+                        return Err(BrainError::Invalid(
+                            "workspace_file content parts are not available yet (M1)".into(),
+                        ));
+                    }
+                }
+            }
+            Ok(blocks)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1799,5 +2611,38 @@ mod tests {
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].call, "op_pending");
         assert_eq!(task_identity_count(&entries), 2);
+    }
+
+    #[test]
+    fn pending_output_scan_never_replays_a_model_side_effect() {
+        let started = |seq: u64, output: &str| Entry {
+            seq,
+            ts_ms: 0,
+            record: Record::OutputStarted {
+                output: output.into(),
+                turn: None,
+                schema_hash: "0".repeat(64),
+                source_seq: seq.saturating_sub(1),
+            },
+        };
+        let entries = vec![
+            started(4, "out_interrupted"),
+            started(5, "out_done"),
+            Entry {
+                seq: 6,
+                ts_ms: 0,
+                record: Record::OutputCompleted {
+                    output: "out_done".into(),
+                    turn: None,
+                    schema_hash: "0".repeat(64),
+                    value: serde_json::json!({"ok":true}),
+                    usage: crate::message::Usage::default(),
+                },
+            },
+        ];
+        let pending = pending_outputs(&entries);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].output, "out_interrupted");
+        assert_eq!(pending[0].seq, 4);
     }
 }

--- a/crates/brain/src/turn.rs
+++ b/crates/brain/src/turn.rs
@@ -125,6 +125,15 @@ impl TurnRun {
     /// The whole turn. The admitted user message and `turn_started` are already committed by
     /// the actor; `st.history` already carries the user message.
     pub async fn run(&self, st: &mut TurnState) -> Result<TurnReport> {
+        let report = self.run_work(st).await?;
+        self.complete(st, &report.stop_reason, report.rounds, report.tool_calls)
+            .await
+    }
+
+    /// Execute through the final assistant answer without committing the turn terminal. The
+    /// output path uses this so output.completed/output.failed and turn completion can land in
+    /// one final decision; ordinary messages use [`Self::run`].
+    pub async fn run_work(&self, st: &mut TurnState) -> Result<TurnReport> {
         let mut rounds: u64 = 0;
         let mut tool_calls: u64 = 0;
         let max_rounds = self.prefix.limits.max_rounds as u64;
@@ -144,14 +153,22 @@ impl TurnRun {
             }
 
             if rounds >= max_rounds {
-                return self.complete(st, "max_rounds", rounds, tool_calls).await;
+                return Ok(TurnReport {
+                    stop_reason: "max_rounds".into(),
+                    rounds,
+                    tool_calls,
+                });
             }
 
             // One model round.
             let (mut message, stop) = match self.root_round(st).await {
                 Ok(v) => v,
                 Err(BrainError::Cancelled) => {
-                    return self.complete(st, "cancelled", rounds, tool_calls).await;
+                    return Ok(TurnReport {
+                        stop_reason: "cancelled".into(),
+                        rounds,
+                        tool_calls,
+                    });
                 }
                 Err(e) => return Err(e),
             };
@@ -189,7 +206,15 @@ impl TurnRun {
             st.history.push(message.clone());
 
             if calls.is_empty() {
-                return self.complete(st, "end_turn", rounds, tool_calls).await;
+                return Ok(TurnReport {
+                    stop_reason: if stop == StopReason::Refusal {
+                        "refusal".into()
+                    } else {
+                        "end_turn".into()
+                    },
+                    rounds,
+                    tool_calls,
+                });
             }
             tool_calls += calls.len() as u64;
 
@@ -235,7 +260,11 @@ impl TurnRun {
             st.history.push(Message::tool_results(blocks));
 
             if self.cancel.is_cancelled() {
-                return self.complete(st, "cancelled", rounds, tool_calls).await;
+                return Ok(TurnReport {
+                    stop_reason: "cancelled".into(),
+                    rounds,
+                    tool_calls,
+                });
             }
         }
     }

--- a/crates/brain/tests/output_e2e.rs
+++ b/crates/brain/tests/output_e2e.rs
@@ -1,0 +1,509 @@
+//! Typed output over the real HTTP/SSE/journal path with only the provider scripted.
+
+use brain::Result;
+use brain::config::{Dialect, ProviderKey, SealedPrefix};
+use brain::journal::{Journal, Record};
+use brain::local::LocalFactory;
+use brain::message::Message;
+use brain::provider::fake::{FakeProvider, Scripted};
+use brain::provider::{ModelRequest, OutputControl, OutputMode, Provider, ProviderEvent};
+use brain::session::{Brain, BrainConfig};
+use futures_util::stream::BoxStream;
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+struct TempDir(PathBuf);
+
+#[derive(Debug)]
+struct AuditProvider {
+    inner: Arc<FakeProvider>,
+    bodies: Mutex<Vec<Value>>,
+}
+
+#[async_trait::async_trait]
+impl Provider for AuditProvider {
+    fn dialect(&self) -> Dialect {
+        self.inner.dialect()
+    }
+
+    fn build_request(
+        &self,
+        prefix: &SealedPrefix,
+        history: &[Message],
+        key: &ProviderKey,
+        base_url: &str,
+    ) -> Result<ModelRequest> {
+        self.inner.build_request(prefix, history, key, base_url)
+    }
+
+    fn build_output_request(
+        &self,
+        prefix: &SealedPrefix,
+        history: &[Message],
+        key: &ProviderKey,
+        base_url: &str,
+        control: &OutputControl,
+        mode: OutputMode,
+    ) -> Result<ModelRequest> {
+        self.inner
+            .build_output_request(prefix, history, key, base_url, control, mode)
+    }
+
+    async fn stream(
+        &self,
+        request: ModelRequest,
+    ) -> Result<BoxStream<'static, Result<ProviderEvent>>> {
+        self.bodies
+            .lock()
+            .unwrap()
+            .push(serde_json::from_slice(&request.body)?);
+        self.inner.stream(request).await
+    }
+}
+
+impl TempDir {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "aex-output-e2e-{}-{}",
+            std::process::id(),
+            brain::mint_id("t", 8)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+async fn events(http: &reqwest::Client, base: &str, token: &str, session: &str) -> Vec<Value> {
+    let text = http
+        .get(format!(
+            "{base}/v1/sessions/{session}/events?after=0&follow=false"
+        ))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    text.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str(data).ok())
+        .collect()
+}
+
+async fn wait_terminal(
+    http: &reqwest::Client,
+    base: &str,
+    token: &str,
+    session: &str,
+    output: &str,
+) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let all = events(http, base, token, session).await;
+        if let Some(event) = all.into_iter().find(|event| {
+            event["output_id"] == output
+                && matches!(
+                    event["type"].as_str(),
+                    Some("output.completed" | "output.failed")
+                )
+        }) {
+            return event;
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for output");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn wait_turn_terminal(
+    http: &reqwest::Client,
+    base: &str,
+    token: &str,
+    session: &str,
+    turn: &str,
+) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let all = events(http, base, token, session).await;
+        if let Some(event) = all.into_iter().find(|event| {
+            event["turn_id"] == turn
+                && matches!(
+                    event["type"].as_str(),
+                    Some("turn.completed" | "turn.failed")
+                )
+        }) {
+            return event;
+        }
+        assert!(Instant::now() < deadline, "timed out waiting for turn");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn output_is_typed_private_repairable_and_idempotent() {
+    let temp = TempDir::new();
+    let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+    fake.script([
+        // Normal work phase.
+        Scripted::Text("The researched answer is forty-two.".into()),
+        // Private commit: wrong type, followed by the one bounded repair.
+        Scripted::Text(r#"{"answer":"42"}"#.into()),
+        Scripted::Text(r#"{"answer":42}"#.into()),
+        // The session remains usable after output commits.
+        Scripted::Text("Still here.".into()),
+    ]);
+    let audit = Arc::new(AuditProvider {
+        inner: fake.clone(),
+        bodies: Mutex::new(Vec::new()),
+    });
+    let factory_audit = audit.clone();
+    let journal = Journal::new_memory("brain-output-test");
+    let brain = Brain::with_parts(
+        BrainConfig {
+            idle_discard: Duration::from_secs(300),
+            ..BrainConfig::default()
+        },
+        journal.clone(),
+        Arc::new(brain::keys::PlainCustody),
+        Arc::new(LocalFactory::new(temp.0.clone())),
+        Some(Arc::new(move |_| {
+            factory_audit.clone() as Arc<dyn Provider>
+        })),
+    );
+
+    let token = "output-token";
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = brain::api::router(brain::api::AppState {
+        brain: brain.clone(),
+        token: token.into(),
+    });
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let http = reqwest::Client::new();
+
+    let created = http
+        .post(format!("{base}/v1/sessions"))
+        .bearer_auth(token)
+        .json(&json!({
+            "model": {"provider":"anthropic","name":"scripted","api_key":"sk-fake"},
+            "system_prompt": "Be exact."
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), 201);
+    let session = created.json::<Value>().await.unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let schema = json!({
+        "$schema":"https://json-schema.org/draft/2020-12/schema",
+        "type":"object",
+        "additionalProperties":false,
+        "required":["answer"],
+        "properties":{"answer":{"type":"number"}}
+    });
+    let schema_hash = brain::output::jcs_sha256(&schema).unwrap();
+    let request = json!({
+        "schema":schema,
+        "schema_hash":schema_hash,
+        "input":"Research the answer."
+    });
+
+    let accepted = http
+        .post(format!("{base}/v1/sessions/{session}/output"))
+        .bearer_auth(token)
+        .header("Idempotency-Key", "typed-answer-1")
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    let status = accepted.status();
+    let accepted = accepted.json::<Value>().await.unwrap();
+    assert_eq!(status, 202, "{accepted}");
+    let output_id = accepted["output_id"].as_str().unwrap();
+    assert_eq!(accepted["schema_hash"], schema_hash);
+
+    let terminal = wait_terminal(&http, &base, token, &session, output_id).await;
+    assert_eq!(terminal["type"], "output.completed");
+    assert_eq!(terminal["output"]["value"], json!({"answer":42}));
+    assert_eq!(terminal["usage"]["input_tokens"], 0);
+
+    let replay = http
+        .post(format!("{base}/v1/sessions/{session}/output"))
+        .bearer_auth(token)
+        .header("Idempotency-Key", "typed-answer-1")
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(replay.status(), 202);
+    assert_eq!(
+        replay.json::<Value>().await.unwrap()["output_id"],
+        output_id
+    );
+    assert_eq!(fake.call_count.load(std::sync::atomic::Ordering::SeqCst), 3);
+
+    let conflict = http
+        .post(format!("{base}/v1/sessions/{session}/output"))
+        .bearer_auth(token)
+        .header("Idempotency-Key", "typed-answer-1")
+        .json(&json!({
+            "schema": request["schema"],
+            "schema_hash": schema_hash,
+            "input":"A different request."
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(conflict.status(), 409);
+
+    {
+        let arrivals = fake.arrivals.lock().unwrap();
+        assert_eq!(arrivals.len(), 3);
+        assert!(arrivals[0].tools_offered > 0, "work keeps normal tools");
+        assert_eq!(arrivals[1].tools_offered, 0, "commit disables tools");
+        assert_eq!(arrivals[2].tools_offered, 0, "repair disables tools");
+    }
+
+    let records = journal.read_records(&session, 0).await.unwrap();
+    assert!(records.iter().any(|entry| matches!(
+        &entry.record,
+        Record::OutputStarted { schema_hash: hash, .. } if hash == &schema_hash
+    )));
+    assert!(records.iter().any(|entry| matches!(
+        &entry.record,
+        Record::OutputCompleted { value, .. } if value == &json!({"answer":42})
+    )));
+    // No durable record has a schema field. Repair candidates/issues do not survive success.
+    let durable = serde_json::to_string(
+        &records
+            .iter()
+            .map(|entry| &entry.record)
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    assert!(!durable.contains("$schema"));
+    assert!(!durable.contains(r#""required""#));
+
+    let continued = http
+        .post(format!("{base}/v1/sessions/{session}/messages"))
+        .bearer_auth(token)
+        .header("Idempotency-Key", "after-output-1")
+        .json(&json!({"content":"Are you still there?"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(continued.status(), 202);
+    let continued = continued.json::<Value>().await.unwrap();
+    let turn_id = continued["turn_id"].as_str().unwrap();
+    let terminal = wait_turn_terminal(&http, &base, token, &session, turn_id).await;
+    assert_eq!(terminal["type"], "turn.completed");
+
+    {
+        let bodies = audit.bodies.lock().unwrap();
+        assert_eq!(bodies.len(), 4);
+        assert!(bodies[1].get("output_config").is_some());
+        assert!(bodies[2].get("output_config").is_some());
+        assert!(bodies[3].get("output_config").is_none());
+        assert_eq!(bodies[3]["system"], "Be exact.");
+        let continuation = serde_json::to_string(&bodies[3]).unwrap();
+        assert!(!continuation.contains("$schema"));
+        assert!(!continuation.contains("Validation issues"));
+        assert!(!continuation.contains("AEX private output commit"));
+    }
+
+    fake.assert_drained(4, "typed output e2e and continuation")
+        .unwrap();
+}
+
+#[tokio::test]
+async fn cancelling_output_commits_one_cancelled_terminal_and_never_formats() {
+    let temp = TempDir::new();
+    let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+    fake.tokens_per_second.store(1, Ordering::SeqCst);
+    fake.script([Scripted::Text("slow work phase".into())]);
+    let factory_fake = fake.clone();
+    let journal = Journal::new_memory("brain-output-cancel-test");
+    let brain = Brain::with_parts(
+        BrainConfig::default(),
+        journal.clone(),
+        Arc::new(brain::keys::PlainCustody),
+        Arc::new(LocalFactory::new(temp.0.clone())),
+        Some(Arc::new(move |_| {
+            factory_fake.clone() as Arc<dyn brain::provider::Provider>
+        })),
+    );
+    let token = "output-cancel-token";
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = brain::api::router(brain::api::AppState {
+        brain,
+        token: token.into(),
+    });
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let http = reqwest::Client::new();
+
+    let session = http
+        .post(format!("{base}/v1/sessions"))
+        .bearer_auth(token)
+        .json(&json!({
+            "model": {"provider":"anthropic","name":"scripted","api_key":"sk-fake"}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let schema = json!({
+        "type":"object",
+        "additionalProperties":false,
+        "required":["answer"],
+        "properties":{"answer":{"type":"string"}}
+    });
+    let schema_hash = brain::output::jcs_sha256(&schema).unwrap();
+    let accepted = http
+        .post(format!("{base}/v1/sessions/{session}/output"))
+        .bearer_auth(token)
+        .header("Idempotency-Key", "cancel-output-1")
+        .json(&json!({
+            "schema":schema,
+            "schema_hash":schema_hash,
+            "input":"Start slow work."
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+    let output_id = accepted["output_id"].as_str().unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while fake.call_count.load(Ordering::SeqCst) == 0 {
+        assert!(
+            Instant::now() < deadline,
+            "work phase never reached provider"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let cancelled = http
+        .post(format!("{base}/v1/sessions/{session}/cancel"))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cancelled.status(), 200);
+
+    let terminal = wait_terminal(&http, &base, token, &session, output_id).await;
+    assert_eq!(terminal["type"], "output.failed");
+    assert_eq!(terminal["error"]["code"], "cancelled");
+    assert_eq!(fake.call_count.load(Ordering::SeqCst), 1);
+    let records = journal.read_records(&session, 0).await.unwrap();
+    assert!(
+        !records
+            .iter()
+            .any(|entry| matches!(entry.record, Record::OutputCompleted { .. }))
+    );
+}
+
+#[tokio::test]
+async fn work_phase_refusal_is_not_formatted_into_success() {
+    let temp = TempDir::new();
+    let fake = Arc::new(FakeProvider::new(Dialect::OpenAiChat));
+    fake.script([Scripted::Refusal("I cannot help with that.".into())]);
+    let factory_fake = fake.clone();
+    let journal = Journal::new_memory("brain-output-refusal-test");
+    let brain = Brain::with_parts(
+        BrainConfig::default(),
+        journal.clone(),
+        Arc::new(brain::keys::PlainCustody),
+        Arc::new(LocalFactory::new(temp.0.clone())),
+        Some(Arc::new(move |_| {
+            factory_fake.clone() as Arc<dyn brain::provider::Provider>
+        })),
+    );
+    let token = "output-refusal-token";
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = brain::api::router(brain::api::AppState {
+        brain,
+        token: token.into(),
+    });
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let http = reqwest::Client::new();
+    let session = http
+        .post(format!("{base}/v1/sessions"))
+        .bearer_auth(token)
+        .json(&json!({
+            "model": {"provider":"openai","name":"scripted","api_key":"sk-fake"}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let schema = json!({
+        "type":"object",
+        "additionalProperties":false,
+        "required":["answer"],
+        "properties":{"answer":{"type":"string"}}
+    });
+    let schema_hash = brain::output::jcs_sha256(&schema).unwrap();
+    let accepted = http
+        .post(format!("{base}/v1/sessions/{session}/output"))
+        .bearer_auth(token)
+        .header("Idempotency-Key", "refused-output-1")
+        .json(&json!({
+            "schema":schema,
+            "schema_hash":schema_hash,
+            "input":"Do the disallowed thing."
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<Value>()
+        .await
+        .unwrap();
+    let terminal = wait_terminal(
+        &http,
+        &base,
+        token,
+        &session,
+        accepted["output_id"].as_str().unwrap(),
+    )
+    .await;
+    assert_eq!(terminal["type"], "output.failed");
+    assert_eq!(terminal["error"]["code"], "output_refused");
+    assert!(
+        terminal["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("I cannot help")
+    );
+    assert_eq!(fake.call_count.load(Ordering::SeqCst), 1);
+    let records = journal.read_records(&session, 0).await.unwrap();
+    assert!(
+        !records
+            .iter()
+            .any(|entry| matches!(&entry.record, Record::OutputCompleted { .. }))
+    );
+}

--- a/crates/brain/tests/task_e2e.rs
+++ b/crates/brain/tests/task_e2e.rs
@@ -13,7 +13,7 @@ use brain::config::{Dialect, ProviderKey, SealedPrefix};
 use brain::journal::{Entry, Journal, Lease, Record};
 use brain::local::LocalFactory;
 use brain::message::{ContentBlock, Message, StopReason, Usage};
-use brain::provider::{ModelRequest, Provider, ProviderEvent};
+use brain::provider::{ModelRequest, OutputControl, OutputMode, Provider, ProviderEvent};
 use brain::session::{Brain, BrainConfig};
 use brain::{BrainError, Result};
 use futures_util::stream::BoxStream;
@@ -257,6 +257,7 @@ fn zero_usage() -> Usage {
         output_tokens: Some(0),
         cache_read_input_tokens: None,
         cache_creation_input_tokens: None,
+        reasoning_tokens: None,
     }
 }
 
@@ -274,6 +275,19 @@ impl Provider for TaskProvider {
         base_url: &str,
     ) -> Result<ModelRequest> {
         brain::provider::anthropic::Anthropic.build_request(prefix, history, key, base_url)
+    }
+
+    fn build_output_request(
+        &self,
+        prefix: &SealedPrefix,
+        history: &[Message],
+        key: &ProviderKey,
+        base_url: &str,
+        control: &OutputControl,
+        mode: OutputMode,
+    ) -> Result<ModelRequest> {
+        brain::provider::anthropic::Anthropic
+            .build_output_request(prefix, history, key, base_url, control, mode)
     }
 
     async fn stream(&self, req: ModelRequest) -> Result<BoxStream<'static, Result<ProviderEvent>>> {


### PR DESCRIPTION
Implements the complete typed-output execution path behind POST /v1/sessions/{id}/output: private schema validation/hash, work/commit phase split, one isolated repair, durable output events, 24-hour idempotency, refusal/cancellation semantics, provider-native structured output with safe forced-tool fallback, and context-leakage protection. Pins aex-contracts-v0.4.0 and hands-v0.1.4. Local release gates: fmt; workspace clippy; full workspace tests (122 substantive tests); performance/leakage CI command passed (density is Linux-only and runs in CI).