### PR TITLE
Use the Aex display name in output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # brain
 
-The **brain**: the aex LLM harness. One long-lived process owns every session's decisions —
+The **brain**: the Aex LLM harness. One long-lived process owns every session's decisions —
 the sealed prefix, the provider round, the tool loop, the journal (one durable write per
 decision), the SSE event stream, admission and cancellation.
 

--- a/crates/brain/src/output.rs
+++ b/crates/brain/src/output.rs
@@ -76,7 +76,7 @@ pub fn validate_schema(schema: &Value, claimed_hash: &str) -> Result<()> {
     }
     if schema.get("type").and_then(Value::as_str) != Some("object") {
         return Err(BrainError::OutputSchema(
-            "the beta output schema must have an object root".into(),
+            "the output schema must have an object root".into(),
         ));
     }
     reject_remote_refs(schema)?;
@@ -604,7 +604,7 @@ fn message_text(message: &Message) -> String {
 
 fn base_instruction(candidate: &str) -> String {
     let mut instruction = String::from(
-        "AEX private output commit. Return the answer in the required structured format. \
+        "Aex private output commit. Return the answer in the required structured format. \
          Preserve facts already established in the session. Do not perform new work and do not \
          call any tool except the forced aex_output tool if it is the only tool offered.",
     );

--- a/crates/brain/tests/output_e2e.rs
+++ b/crates/brain/tests/output_e2e.rs
@@ -320,7 +320,7 @@ async fn output_is_typed_private_repairable_and_idempotent() {
         let continuation = serde_json::to_string(&bodies[3]).unwrap();
         assert!(!continuation.contains("$schema"));
         assert!(!continuation.contains("Validation issues"));
-        assert!(!continuation.contains("AEX private output commit"));
+        assert!(!continuation.contains("Aex private output commit"));
     }
 
     fake.assert_drained(4, "typed output e2e and continuation")


### PR DESCRIPTION
Use Aex in public and private output copy and remove the obsolete beta label from schema validation.

Verified with the output unit suite and the full typed-output integration suite. The two unrelated local bash tests remain Windows-specific failures; Linux CI is the authoritative full gate.