### PR TITLE
Make session creation idempotent

### DIFF
--- a/crates/brain/src/api.rs
+++ b/crates/brain/src/api.rs
@@ -7,7 +7,7 @@
 //! The subscription starts BEFORE the replay read so nothing falls between them; duplicates
 //! are dropped by seq.
 //!
-//! Output admission persists a hash of Idempotency-Key for 24-hour replay. Raw keys never enter
+//! Create and output admission persist hashes of Idempotency-Key for replay. Raw keys never enter
 //! the journal.
 
 use crate::events::{event_seq, event_type};
@@ -158,7 +158,23 @@ async fn create_session(
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<session::Session>), Failure> {
     auth(&state, &headers)?;
-    let doc = state.brain.create_session(req).await.map_err(map_err)?;
+    let idempotency_key = headers
+        .get("idempotency-key")
+        .map(|value| {
+            value.to_str().map_err(|_| {
+                Failure(
+                    StatusCode::BAD_REQUEST,
+                    ApiErrorCode::InvalidRequest,
+                    "Idempotency-Key must be valid ASCII".into(),
+                )
+            })
+        })
+        .transpose()?;
+    let doc = state
+        .brain
+        .create_session(req, idempotency_key)
+        .await
+        .map_err(map_err)?;
     Ok((StatusCode::CREATED, Json(doc)))
 }
 

--- a/crates/brain/src/journal.rs
+++ b/crates/brain/src/journal.rs
@@ -330,6 +330,11 @@ pub struct HeadDoc {
     pub turns: u64,
     pub created_ms: u64,
     pub updated_ms: u64,
+    /// Hashes for replaying a create request without retaining the raw idempotency key or body.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub create_key_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub create_request_hash: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_message_ms: Option<u64>,
     /// True once `end` ran: compute released for good, the workspace is kept.
@@ -1055,6 +1060,8 @@ mod tests {
             turns: 0,
             created_ms: 1,
             updated_ms: 2,
+            create_key_hash: None,
+            create_request_hash: None,
             last_message_ms: None,
             ended: false,
             prefix: PrefixDoc {
@@ -1097,6 +1104,8 @@ mod tests {
             turns: 0,
             created_ms: 1,
             updated_ms: 1,
+            create_key_hash: None,
+            create_request_hash: None,
             last_message_ms: None,
             ended: false,
             prefix: PrefixDoc {

--- a/crates/brain/src/session.rs
+++ b/crates/brain/src/session.rs
@@ -33,6 +33,7 @@ use aex_contracts::session::{
     Provider as ApiProvider,
 };
 use base64::Engine;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -156,6 +157,15 @@ pub struct Brain {
     provider_factory: ProviderFactory,
     turn_permits: Arc<Semaphore>,
     sessions: Mutex<HashMap<String, mpsc::Sender<Command>>>,
+}
+
+fn hash_create_key(key: &str) -> String {
+    hex::encode(Sha256::digest(key.as_bytes()))
+}
+
+pub(crate) fn idempotent_session_id(key: &str) -> String {
+    let hash = hash_create_key(key);
+    format!("ses_{}", &hash[..24])
 }
 
 enum Command {
@@ -298,8 +308,31 @@ impl Brain {
     pub async fn create_session(
         self: &Arc<Self>,
         req: CreateSessionRequest,
+        idempotency_key: Option<&str>,
     ) -> Result<session::Session> {
-        let session_id = crate::mint_id("ses", 24);
+        if let Some(key) = idempotency_key
+            && (key.is_empty() || key.len() > 128)
+        {
+            return Err(BrainError::Invalid(
+                "Idempotency-Key must contain 1 to 128 bytes".into(),
+            ));
+        }
+        let create_key_hash = idempotency_key.map(hash_create_key);
+        let create_request_hash = create_key_hash
+            .as_ref()
+            .map(|_| crate::output::jcs_sha256(&req))
+            .transpose()?;
+        let session_id = idempotency_key
+            .map(idempotent_session_id)
+            .unwrap_or_else(|| crate::mint_id("ses", 24));
+
+        if create_key_hash.is_some()
+            && let Some(doc) = self
+                .replay_create(&session_id, &create_key_hash, &create_request_hash)
+                .await?
+        {
+            return Ok(doc);
+        }
 
         // Validate and resolve the sealed configuration.
         let provider = provider_name(&req.model.provider);
@@ -428,6 +461,8 @@ impl Brain {
             turns: 0,
             created_ms: now,
             updated_ms: now,
+            create_key_hash: create_key_hash.clone(),
+            create_request_hash: create_request_hash.clone(),
             last_message_ms: None,
             ended: false,
             prefix,
@@ -440,7 +475,8 @@ impl Brain {
             artifacts: Vec::new(),
             output_requests: Vec::new(),
         };
-        self.journal
+        if let Err(error) = self
+            .journal
             .create(
                 &session_id,
                 &doc,
@@ -449,13 +485,40 @@ impl Brain {
                     turn: None,
                 },
             )
-            .await?;
+            .await
+        {
+            if create_key_hash.is_some()
+                && let Some(doc) = self
+                    .replay_create(&session_id, &create_key_hash, &create_request_hash)
+                    .await?
+            {
+                return Ok(doc);
+            }
+            return Err(error);
+        }
 
         // Eager hand creation (D16): the actor starts now and readies the substrate without
         // the caller waiting.
         self.spawn_actor(&session_id, true).await;
 
         Ok(session_doc(&session_id, &doc))
+    }
+
+    async fn replay_create(
+        &self,
+        session_id: &str,
+        key_hash: &Option<String>,
+        request_hash: &Option<String>,
+    ) -> Result<Option<session::Session>> {
+        let head = match self.journal.get_head(session_id).await {
+            Ok(head) => head,
+            Err(BrainError::NoSuchSession(_)) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        if &head.doc.create_key_hash != key_hash || &head.doc.create_request_hash != request_hash {
+            return Err(BrainError::IdempotencyConflict);
+        }
+        Ok(Some(session_doc(session_id, &head.doc)))
     }
 
     // -- routing to actors -------------------------------------------------------------------

--- a/crates/brain/tests/create_idempotency.rs
+++ b/crates/brain/tests/create_idempotency.rs
@@ -1,0 +1,109 @@
+use brain::session::{Brain, BrainConfig};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "aex-create-idempotency-{}-{}",
+            std::process::id(),
+            brain::wall_ms()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+#[tokio::test]
+async fn create_replays_one_session_and_rejects_key_reuse_with_another_body() {
+    let temp = TempDir::new();
+    let brain = Brain::local(temp.0.clone(), BrainConfig::default()).unwrap();
+    let token = "create-idempotency-token".to_string();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = brain::api::router(brain::api::AppState {
+        brain,
+        token: token.clone(),
+    });
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let http = reqwest::Client::new();
+    let body = json!({
+        "model": {"provider": "anthropic", "name": "scripted", "api_key": "sk-fake"},
+        "metadata": {"test": "create-idempotency"}
+    });
+
+    let create = || {
+        http.post(format!("{base}/v1/sessions"))
+            .bearer_auth(&token)
+            .header("Idempotency-Key", "same-create-request")
+            .json(&body)
+            .send()
+    };
+    let (first, concurrent) = tokio::join!(create(), create());
+    let first = first.unwrap();
+    let concurrent = concurrent.unwrap();
+    assert_eq!(first.status(), 201);
+    assert_eq!(concurrent.status(), 201);
+    let first: Value = first.json().await.unwrap();
+    let concurrent: Value = concurrent.json().await.unwrap();
+    assert_eq!(first["id"], concurrent["id"]);
+
+    let replay: Value = create().await.unwrap().json().await.unwrap();
+    assert_eq!(first["id"], replay["id"]);
+
+    let conflict = http
+        .post(format!("{base}/v1/sessions"))
+        .bearer_auth(&token)
+        .header("Idempotency-Key", "same-create-request")
+        .json(&json!({
+            "model": {"provider": "anthropic", "name": "different", "api_key": "sk-fake"}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(conflict.status(), 409);
+    let conflict: Value = conflict.json().await.unwrap();
+    assert_eq!(conflict["error"]["code"], "conflict");
+
+    let unkeyed_one: Value = http
+        .post(format!("{base}/v1/sessions"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let unkeyed_two: Value = http
+        .post(format!("{base}/v1/sessions"))
+        .bearer_auth(&token)
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_ne!(unkeyed_one["id"], unkeyed_two["id"]);
+
+    let list: Value = http
+        .get(format!("{base}/v1/sessions"))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(list["data"].as_array().unwrap().len(), 3);
+}


### PR DESCRIPTION
Adds request-scoped idempotency for session creation. The brain derives a deterministic session ID from a hashed key, stores a canonical request hash, replays identical creates, rejects changed payloads, and covers concurrent retries with an HTTP integration test.\n\nValidation: cargo fmt --all -- --check; cargo clippy -p brain --all-targets -- -D warnings; create-idempotency and journal tests pass.