### PR TITLE
release: bootstrap first Brain npm publication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,10 @@ jobs:
       - run: npm test
       - run: npm run package-smoke
       - name: Publish in dependency order
+        env:
+          # A token is required only to bootstrap a package before its OIDC trust relationship
+          # can exist. Provenance is still minted by this public GitHub Actions job.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
Allows the existing provenance-enabled GitHub Actions workflow to use the repository's masked npm release credential for the first package publication. Once packages exist, their OIDC trusted publisher can be configured without a long-lived bootstrap path.