### PR TITLE
security: update bundled Docker CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /src
 COPY . .
 RUN cargo build --locked --release -p brain-server --bin brain
 
-FROM docker:28.3.3-cli AS docker-cli
+FROM docker:29.7.0-cli AS docker-cli
 
 FROM debian:bookworm-slim
 RUN apt-get update \


### PR DESCRIPTION
Updates the standalone Brain image to the current pinned Docker CLI 29.7.0 so the copied client is built with a patched Go toolchain. The previous 28.3.3 binary was blocked by the container vulnerability gate (CVE-2025-68121). The image workflow will build, smoke test, and scan this revision.