### PR TITLE
fix: make message admission idempotent

### DIFF
--- a/crates/brain-standalone/src/sqlite.rs
+++ b/crates/brain-standalone/src/sqlite.rs
@@ -494,6 +494,8 @@ mod tests {
             turn: "trn_test".into(),
             content: vec![ContentBlock::text(text)],
             metadata: HashMap::new(),
+            idempotency_key_hash: None,
+            request_hash: None,
         }
     }
 

--- a/crates/brain/src/api.rs
+++ b/crates/brain/src/api.rs
@@ -7,8 +7,8 @@
 //! The subscription starts BEFORE the replay read so nothing falls between them; duplicates
 //! are dropped by seq.
 //!
-//! Create and output admission persist hashes of Idempotency-Key for replay. Raw keys never enter
-//! the journal.
+//! Create and message admission persist hashes of Idempotency-Key for replay. Raw keys never
+//! enter the journal.
 
 use crate::events::{event_seq, event_type};
 use crate::journal::Record;
@@ -346,9 +346,21 @@ async fn send_message(
     Json(req): Json<MessageRequest>,
 ) -> Result<(StatusCode, Json<MessageAccepted>), Failure> {
     auth(&state, &headers)?;
+    let idempotency_key = headers
+        .get("idempotency-key")
+        .map(|value| {
+            value.to_str().map_err(|_| {
+                Failure(
+                    StatusCode::BAD_REQUEST,
+                    api_code("invalid_request"),
+                    "Idempotency-Key must be valid ASCII".into(),
+                )
+            })
+        })
+        .transpose()?;
     let (turn_id, seq) = state
         .brain
-        .message_with_metadata(&id, req.content, req.metadata)
+        .message_with_metadata_idempotent(&id, req.content, req.metadata, idempotency_key)
         .await
         .map_err(map_err)?;
     Ok((

--- a/crates/brain/src/compact.rs
+++ b/crates/brain/src/compact.rs
@@ -141,6 +141,8 @@ mod tests {
                             turn: "t".into(),
                             content: m.content.clone(),
                             metadata: std::collections::HashMap::new(),
+                            idempotency_key_hash: None,
+                            request_hash: None,
                         });
                     } else {
                         for b in &m.content {

--- a/crates/brain/src/events.rs
+++ b/crates/brain/src/events.rs
@@ -389,6 +389,8 @@ mod tests {
             turn: "trn_aaaaaaaaaaaaaaaaaaaa".into(),
             content: vec![],
             metadata: std::collections::HashMap::new(),
+            idempotency_key_hash: None,
+            request_hash: None,
         };
         assert!(derive("ses_aaaaaaaaaaaaaaaaaaaa", 1, 0, &r, &hand_info()).is_none());
         let c = Record::Compacted {

--- a/crates/brain/src/journal.rs
+++ b/crates/brain/src/journal.rs
@@ -43,6 +43,13 @@ pub enum Record {
         /// input and must survive replay with the admitted message.
         #[serde(default, skip_serializing_if = "HashMap::is_empty")]
         metadata: HashMap<String, String>,
+        /// SHA-256 of the caller's Idempotency-Key. The raw key is never persisted.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        idempotency_key_hash: Option<String>,
+        /// SHA-256 of the canonical message content and metadata. Paired with the key hash so
+        /// replay can reject reuse of one key for a different request.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_hash: Option<String>,
     },
     TurnStarted {
         turn: String,
@@ -786,6 +793,8 @@ mod tests {
             turn: turn.into(),
             content: vec![ContentBlock::text(text)],
             metadata: HashMap::new(),
+            idempotency_key_hash: None,
+            request_hash: None,
         }
     }
     fn assistant(turn: &str, blocks: Vec<ContentBlock>) -> Record {
@@ -820,6 +829,27 @@ mod tests {
                 record,
             })
             .collect()
+    }
+
+    #[test]
+    fn pre_idempotency_user_records_remain_readable() {
+        let record: Record = serde_json::from_value(serde_json::json!({
+            "kind": "user_message",
+            "turn": "trn_old",
+            "content": [{"type": "text", "text": "hello"}],
+            "metadata": {}
+        }))
+        .unwrap();
+        let Record::UserMessage {
+            idempotency_key_hash,
+            request_hash,
+            ..
+        } = record
+        else {
+            panic!("expected user message");
+        };
+        assert!(idempotency_key_hash.is_none());
+        assert!(request_hash.is_none());
     }
 
     #[test]

--- a/crates/brain/src/session.rs
+++ b/crates/brain/src/session.rs
@@ -165,10 +165,24 @@ pub(crate) fn idempotent_session_id(key: &str) -> String {
     format!("ses_{}", &hash[..24])
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MessageIdentity {
+    key_hash: String,
+    request_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MessageReplay {
+    request_hash: String,
+    turn_id: String,
+    user_seq: u64,
+}
+
 enum Command {
     Message {
         content: Vec<ContentBlock>,
         metadata: HashMap<String, String>,
+        idempotency: Option<MessageIdentity>,
         reply: oneshot::Sender<Result<(String, u64)>>, // (turn_id, seq of the user message)
     },
     Cancel {
@@ -812,6 +826,17 @@ impl Brain {
         content: MessageRequestContent,
         metadata: HashMap<String, String>,
     ) -> Result<(String, u64)> {
+        self.message_with_metadata_idempotent(session_id, content, metadata, None)
+            .await
+    }
+
+    pub async fn message_with_metadata_idempotent(
+        self: &Arc<Self>,
+        session_id: &str,
+        content: MessageRequestContent,
+        metadata: HashMap<String, String>,
+        idempotency_key: Option<&str>,
+    ) -> Result<(String, u64)> {
         if metadata.len() > 32
             || metadata
                 .iter()
@@ -822,10 +847,30 @@ impl Brain {
                     .into(),
             ));
         }
+        if let Some(key) = idempotency_key
+            && (key.is_empty() || key.len() > 128)
+        {
+            return Err(BrainError::Invalid(
+                "Idempotency-Key must contain 1 to 128 bytes".into(),
+            ));
+        }
         let blocks = content_blocks(content)?;
+        let idempotency = idempotency_key
+            .map(|key| {
+                let canonical = serde_jcs::to_vec(&serde_json::json!({
+                    "content": &blocks,
+                    "metadata": &metadata,
+                }))?;
+                Ok::<_, BrainError>(MessageIdentity {
+                    key_hash: hash_create_key(key),
+                    request_hash: hex::encode(Sha256::digest(canonical)),
+                })
+            })
+            .transpose()?;
         self.deliver(session_id, |reply| Command::Message {
             content: blocks.clone(),
             metadata: metadata.clone(),
+            idempotency: idempotency.clone(),
             reply,
         })
         .await?
@@ -962,12 +1007,14 @@ fn bytes_check_path(path: &str) -> Result<()> {
 struct Resident {
     st: TurnState,
     key: ProviderKey,
+    message_replays: HashMap<String, MessageReplay>,
 }
 
 struct Running {
     handle: tokio::task::JoinHandle<(TurnState, RunningOutcome)>,
     cancel: CancellationToken,
     key: ProviderKey,
+    message_replays: HashMap<String, MessageReplay>,
 }
 
 enum RunningOutcome {
@@ -975,6 +1022,59 @@ enum RunningOutcome {
         turn_id: String,
         outcome: Result<crate::turn::TurnReport>,
     },
+}
+
+fn collect_message_replays(entries: &[Entry]) -> Result<HashMap<String, MessageReplay>> {
+    let mut replays = HashMap::new();
+    for entry in entries {
+        let Record::UserMessage {
+            turn,
+            idempotency_key_hash,
+            request_hash,
+            ..
+        } = &entry.record
+        else {
+            continue;
+        };
+        let (key_hash, request_hash) = match (idempotency_key_hash, request_hash) {
+            (None, None) => continue,
+            (Some(key_hash), Some(request_hash)) => (key_hash, request_hash),
+            _ => {
+                return Err(BrainError::Journal(
+                    "message idempotency record is incomplete".into(),
+                ));
+            }
+        };
+        let replay = MessageReplay {
+            request_hash: request_hash.clone(),
+            turn_id: turn.clone(),
+            user_seq: entry.seq,
+        };
+        if let Some(previous) = replays.insert(key_hash.clone(), replay.clone())
+            && previous != replay
+        {
+            return Err(BrainError::Journal(
+                "message idempotency key maps to conflicting journal records".into(),
+            ));
+        }
+    }
+    Ok(replays)
+}
+
+fn replay_message(
+    replays: &HashMap<String, MessageReplay>,
+    identity: Option<&MessageIdentity>,
+) -> Result<Option<(String, u64)>> {
+    let Some(identity) = identity else {
+        return Ok(None);
+    };
+    let Some(replay) = replays.get(&identity.key_hash) else {
+        return Ok(None);
+    };
+    if replay.request_hash != identity.request_hash {
+        return Err(BrainError::IdempotencyConflict);
+    }
+    Ok(Some((replay.turn_id.clone(), replay.user_seq)))
 }
 
 #[derive(Debug)]
@@ -1429,7 +1529,14 @@ async fn actor(
         tokio::select! {
             done = async { (&mut running.as_mut().expect("guarded").handle).await }, if running.is_some() => {
                 let task = running.take().expect("running");
-                resident = settle_running(&brain, &session_id, task.key, done).await;
+                resident = settle_running(
+                    &brain,
+                    &session_id,
+                    task.key,
+                    task.message_replays,
+                    done,
+                )
+                .await;
             }
             cmd = rx.recv() => {
                 let Some(cmd) = cmd else { break };
@@ -1444,21 +1551,59 @@ async fn actor(
                         };
                         let _ = reply.send(doc);
                     }
-                    Command::Message { content, metadata, reply } => {
-                        if running.is_some() {
-                            let _ = reply.send(Err(BrainError::TurnInFlight(session_id.clone())));
+                    Command::Message { content, metadata, idempotency, reply } => {
+                        if let Some(task) = &running {
+                            let response = match replay_message(
+                                &task.message_replays,
+                                idempotency.as_ref(),
+                            ) {
+                                Ok(Some(replay)) => Ok(replay),
+                                Ok(None) => Err(BrainError::TurnInFlight(session_id.clone())),
+                                Err(error) => Err(error),
+                            };
+                            let _ = reply.send(response);
                             continue;
                         }
                         let r = match ensure_resident(&brain, &session_id, &mut resident).await {
                             Ok(r) => r,
                             Err(e) => { let _ = reply.send(Err(e)); continue; }
                         };
+                        match replay_message(&r.message_replays, idempotency.as_ref()) {
+                            Ok(Some(replay)) => {
+                                let _ = reply.send(Ok(replay));
+                                continue;
+                            }
+                            Ok(None) => {}
+                            Err(error) => {
+                                let _ = reply.send(Err(error));
+                                continue;
+                            }
+                        }
                         let permit = match brain.turn_permits.clone().try_acquire_owned() {
                             Ok(p) => p,
                             Err(_) => { let _ = reply.send(Err(BrainError::Overloaded)); continue; }
                         };
-                        match admit(&brain, &session_id, r, content, metadata.clone()).await {
+                        match admit(
+                            &brain,
+                            &session_id,
+                            r,
+                            content,
+                            metadata.clone(),
+                            idempotency.clone(),
+                        )
+                        .await
+                        {
                             Ok((turn_id, seq, cancel)) => {
+                                if let Some(identity) = &idempotency {
+                                    r.message_replays.insert(
+                                        identity.key_hash.clone(),
+                                        MessageReplay {
+                                            request_hash: identity.request_hash.clone(),
+                                            turn_id: turn_id.clone(),
+                                            user_seq: seq,
+                                        },
+                                    );
+                                }
                                 let _ = reply.send(Ok((turn_id.clone(), seq)));
                                 // Park the resident state into the turn task; the key rides
                                 // the running tuple until the task returns the state.
@@ -1472,13 +1617,19 @@ async fn actor(
                                     }
                                 };
                                 let key = parked.key.clone();
+                                let message_replays = std::mem::take(&mut parked.message_replays);
                                 let handle = tokio::spawn(async move {
                                     let _permit = permit; // held for the whole turn (admission)
                                     let mut st = parked.st;
                                     let out = run.run(&mut st).await;
                                     (st, RunningOutcome::Turn { turn_id: turn_id.clone(), outcome: out })
                                 });
-                                running = Some(Running { handle, cancel, key });
+                                running = Some(Running {
+                                    handle,
+                                    cancel,
+                                    key,
+                                    message_replays,
+                                });
                             }
                             Err(e) => { let _ = reply.send(Err(e)); }
                         }
@@ -1500,8 +1651,16 @@ async fn actor(
                         if let Some(task) = running.take() {
                             task.cancel.cancel();
                             let key = task.key;
+                            let message_replays = task.message_replays;
                             let done = task.handle.await;
-                            resident = settle_running(&brain, &session_id, key, done).await;
+                            resident = settle_running(
+                                &brain,
+                                &session_id,
+                                key,
+                                message_replays,
+                                done,
+                            )
+                            .await;
                         }
                         match end_session(&brain, &session_id, &mut resident).await {
                             Ok(doc) => { let _ = reply.send(Ok(doc)); }
@@ -1591,11 +1750,16 @@ async fn settle_running(
     brain: &Arc<Brain>,
     session_id: &str,
     key: ProviderKey,
+    message_replays: HashMap<String, MessageReplay>,
     done: std::result::Result<(TurnState, RunningOutcome), tokio::task::JoinError>,
 ) -> Option<Resident> {
     match done {
         Ok((st, outcome)) => {
-            let mut resident = Resident { st, key };
+            let mut resident = Resident {
+                st,
+                key,
+                message_replays,
+            };
             match outcome {
                 RunningOutcome::Turn { turn_id, outcome } => {
                     finish_turn(brain, session_id, &turn_id, &mut resident.st, outcome).await;
@@ -1736,6 +1900,7 @@ async fn hydrate(brain: &Arc<Brain>, session_id: &str) -> Result<Resident> {
         entries = brain.journal.read_records(session_id, 0).await?;
     }
 
+    let message_replays = collect_message_replays(&entries)?;
     let fold = crate::journal::fold(&entries);
     let key = brain
         .custody
@@ -1761,6 +1926,7 @@ async fn hydrate(brain: &Arc<Brain>, session_id: &str) -> Result<Resident> {
             identities: Arc::new(std::sync::atomic::AtomicU64::new(identities)),
         },
         key,
+        message_replays,
     };
     if let Some(recovered) =
         recover_external_calls(brain, session_id, &mut resident, &entries).await?
@@ -1861,6 +2027,7 @@ async fn admit(
     r: &mut Resident,
     content: Vec<ContentBlock>,
     metadata: HashMap<String, String>,
+    idempotency: Option<MessageIdentity>,
 ) -> Result<(String, u64, CancellationToken)> {
     if r.st.head.state == "failed" {
         return Err(BrainError::SessionFailed(
@@ -1898,6 +2065,12 @@ async fn admit(
                 turn: turn_id.clone(),
                 content: content.clone(),
                 metadata,
+                idempotency_key_hash: idempotency
+                    .as_ref()
+                    .map(|identity| identity.key_hash.clone()),
+                request_hash: idempotency
+                    .as_ref()
+                    .map(|identity| identity.request_hash.clone()),
             },
         ),
         (
@@ -2640,6 +2813,8 @@ mod tests {
                     turn: "trn_test".into(),
                     content: vec![ContentBlock::text("answer")],
                     metadata: context,
+                    idempotency_key_hash: None,
+                    request_hash: None,
                 },
             },
             Entry {
@@ -2779,6 +2954,8 @@ mod tests {
                     turn: turn.clone(),
                     content: vec![ContentBlock::text("return a typed value")],
                     metadata: HashMap::from([("request_id".into(), "out_test".into())]),
+                    idempotency_key_hash: None,
+                    request_hash: None,
                 },
             ),
             (first_seq + 1, Record::TurnStarted { turn: turn.clone() }),

--- a/crates/brain/tests/message_idempotency.rs
+++ b/crates/brain/tests/message_idempotency.rs
@@ -1,0 +1,190 @@
+use brain::config::Dialect;
+use brain::journal::Journal;
+use brain::local::LocalFactory;
+use brain::provider::fake::{FakeProvider, Scripted};
+use brain::session::{Brain, BrainConfig};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "brain-message-idempotency-{}-{}",
+            std::process::id(),
+            brain::wall_ms()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+async fn events(http: &reqwest::Client, base: &str, token: &str, session_id: &str) -> Vec<Value> {
+    let text = http
+        .get(format!(
+            "{base}/v1/sessions/{session_id}/events?after=0&follow=false"
+        ))
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    text.lines()
+        .filter_map(|line| line.strip_prefix("data: "))
+        .filter_map(|data| serde_json::from_str(data).ok())
+        .collect()
+}
+
+#[tokio::test]
+async fn message_key_replays_while_active_after_completion_and_after_cold_hydration() {
+    let temp = TempDir::new();
+    let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+    fake.script([Scripted::Text("one durable response".into())]);
+    fake.tokens_per_second.store(5, Ordering::Relaxed);
+    let factory_fake = fake.clone();
+    let brain = Brain::with_parts(
+        BrainConfig {
+            idle_discard: Duration::from_millis(40),
+            ..BrainConfig::default()
+        },
+        Journal::new_memory("message-idempotency-test"),
+        Arc::new(brain::keys::PlainCustody),
+        Arc::new(LocalFactory::new(temp.0.clone())),
+        Some(Arc::new(move |_| {
+            factory_fake.clone() as Arc<dyn brain::provider::Provider>
+        })),
+    );
+
+    let token = "message-idempotency-token".to_string();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = brain::api::router(brain::api::AppState {
+        brain,
+        token: token.clone(),
+    });
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let http = reqwest::Client::new();
+    let created: Value = http
+        .post(format!("{base}/v1/sessions"))
+        .bearer_auth(&token)
+        .json(&json!({
+            "model": {"provider": "anthropic", "name": "scripted", "api_key": "sk-fake"},
+            "hand": {"enabled": false}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let session_id = created["id"].as_str().unwrap();
+    let body = json!({"content": "hello", "metadata": {"request": "one"}});
+
+    let first = http
+        .post(format!("{base}/v1/sessions/{session_id}/messages"))
+        .bearer_auth(&token)
+        .header("Idempotency-Key", "same-message-request")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), 202);
+    let first: Value = first.json().await.unwrap();
+
+    // Admission returns before the paced provider finishes, so this exercises replay while the
+    // resident state is parked in the running turn.
+    let active_replay = http
+        .post(format!("{base}/v1/sessions/{session_id}/messages"))
+        .bearer_auth(&token)
+        .header("Idempotency-Key", "same-message-request")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(active_replay.status(), 202);
+    let active_replay: Value = active_replay.json().await.unwrap();
+    assert_eq!(active_replay, first);
+
+    let conflict = http
+        .post(format!("{base}/v1/sessions/{session_id}/messages"))
+        .bearer_auth(&token)
+        .header("Idempotency-Key", "same-message-request")
+        .json(&json!({"content": "different", "metadata": {"request": "one"}}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(conflict.status(), 409);
+    let conflict: Value = conflict.json().await.unwrap();
+    assert_eq!(conflict["error"]["code"], "conflict");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if events(&http, &base, &token, session_id)
+            .await
+            .iter()
+            .any(|event| event["type"] == "turn.completed")
+        {
+            break;
+        }
+        assert!(Instant::now() < deadline, "turn did not complete");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let completed_replay: Value = http
+        .post(format!("{base}/v1/sessions/{session_id}/messages"))
+        .bearer_auth(&token)
+        .header("Idempotency-Key", "same-message-request")
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(completed_replay, first);
+
+    // Let the actor discard, then prove the persisted hashes rebuild the same acceptance.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let cold_replay: Value = http
+        .post(format!("{base}/v1/sessions/{session_id}/messages"))
+        .bearer_auth(&token)
+        .header("Idempotency-Key", "same-message-request")
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(cold_replay, first);
+
+    let replayed_events = events(&http, &base, &token, session_id).await;
+    assert_eq!(
+        replayed_events
+            .iter()
+            .filter(|event| event["type"] == "turn.started")
+            .count(),
+        1
+    );
+    assert_eq!(
+        replayed_events
+            .iter()
+            .filter(|event| event["type"] == "turn.completed")
+            .count(),
+        1
+    );
+    assert_eq!(fake.call_count.load(Ordering::Relaxed), 1);
+}

--- a/crates/brain/tests/task_e2e.rs
+++ b/crates/brain/tests/task_e2e.rs
@@ -820,6 +820,8 @@ async fn cold_hydrate_answers_an_interrupted_task_without_replaying_it() {
             turn: turn.clone(),
             content: vec![ContentBlock::text("crash-root")],
             metadata: std::collections::HashMap::new(),
+            idempotency_key_hash: None,
+            request_hash: None,
         },
     ));
     seq += 1;


### PR DESCRIPTION
## Summary
- honor Idempotency-Key on Brain message admission
- persist only key/request hashes on the user-message journal record
- replay the original acceptance while active, after completion, and after cold hydration
- reject reuse of a key with different content or metadata
- preserve backward compatibility with pre-idempotency journal records

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- 
pm test
- 
pm run package-smoke

The hosted release canary exposed this by observing two committed turns for one repeated SDK message key.