### PR TITLE
ci: require trusted npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,21 +17,18 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '22.23.2'
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
       - name: Use an npm version with trusted publishing support
         run: npm install --global npm@11.19.0
       - run: npm ci
       - run: npm test
       - run: npm run package-smoke
-      - name: Publish in dependency order
-        env:
-          # A token is required only to bootstrap a package before its OIDC trust relationship
-          # can exist. Provenance is still minted by this public GitHub Actions job.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish with trusted publishing in dependency order
         shell: bash
         run: |
           set -euo pipefail
@@ -39,20 +36,20 @@ jobs:
           publish_workspace() {
             local workspace="$1"
             local package_json="packages/$workspace/package.json"
-            local name version spec visible
+            local name version spec version_url
             name=$(node -p "require('./$package_json').name")
             version=$(node -p "require('./$package_json').version")
             spec="$name@$version"
+            version_url=$(node -e 'const [name, version] = process.argv.slice(1); process.stdout.write(`https://registry.npmjs.org/${encodeURIComponent(name)}/${encodeURIComponent(version)}`)' "$name" "$version")
 
-            if npm view "$spec" version --json >/dev/null 2>&1; then
+            if curl --fail --silent "$version_url" >/dev/null 2>&1; then
               echo "$spec is already published"
             else
               npm publish --workspace "$name" --access public
             fi
 
             for attempt in $(seq 1 12); do
-              visible=$(npm view "$spec" version --json 2>/dev/null | tr -d '"' || true)
-              if [[ "$visible" == "$version" ]]; then
+              if curl --fail --silent "$version_url" >/dev/null 2>&1; then
                 echo "$spec is visible on the public registry"
                 return 0
               fi


### PR DESCRIPTION
Removes the bootstrap token path now that both public packages have GitHub OIDC publishers. Also updates the Actions runtimes and checks registry visibility through the exact-version endpoint to avoid cached first-package 404s.

Validated with YAML parsing and git diff checks.