### PR TITLE
api: accept session tool bundle bodies

### DIFF
--- a/crates/brain/src/api.rs
+++ b/crates/brain/src/api.rs
@@ -16,7 +16,7 @@ use crate::session::Brain;
 use crate::{BrainError, mint_id};
 use axum::body::{Body, Bytes, to_bytes};
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
-use axum::extract::{Path, Query, State};
+use axum::extract::{DefaultBodyLimit, Path, Query, State};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::sse::{Event as SseFrame, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
@@ -41,6 +41,11 @@ pub struct AppState {
     pub token: String,
 }
 
+// A valid create request may carry 16 MiB of raw tool bundles. Base64 expands that beyond
+// Axum's 2 MiB default; 32 MiB leaves room for the tool definitions and other JSON fields while
+// remaining below Aex control's 64 MiB proxy limit.
+const SESSION_API_BODY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
+
 pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/healthz", get(|| async { "ok" }))
@@ -59,6 +64,7 @@ pub fn router(state: AppState) -> Router {
         .route("/v1/sessions/{id}/persist", post(persist_artifact))
         .route("/v1/sessions/{id}/artifacts", get(list_artifacts))
         .route("/v1/sessions/{id}/artifacts/{name}", get(get_artifact))
+        .layer(DefaultBodyLimit::max(SESSION_API_BODY_LIMIT_BYTES))
         .with_state(state)
 }
 

--- a/crates/brain/tests/create_idempotency.rs
+++ b/crates/brain/tests/create_idempotency.rs
@@ -107,3 +107,32 @@ async fn create_replays_one_session_and_rejects_key_reuse_with_another_body() {
         .unwrap();
     assert_eq!(list["data"].as_array().unwrap().len(), 3);
 }
+
+#[tokio::test]
+async fn create_session_accepts_tool_bundle_sized_http_bodies() {
+    let temp = TempDir::new();
+    let brain = Brain::local(temp.0.clone(), BrainConfig::default()).unwrap();
+    let token = "create-body-limit-token".to_string();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let app = brain::api::router(brain::api::AppState {
+        brain,
+        token: token.clone(),
+    });
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    // Eight official portable tools currently serialize to just under 3 MiB. This intentionally
+    // invalid body proves it reaches JSON validation instead of Axum's former 2 MiB rejection.
+    let body = format!(r#"{{"oversized":"{}"}}"#, "x".repeat(3 * 1024 * 1024));
+    let response = reqwest::Client::new()
+        .post(format!("{base}/v1/sessions"))
+        .bearer_auth(token)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_ne!(response.status(), reqwest::StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(response.status().is_client_error());
+}


### PR DESCRIPTION
## Summary
- raise the Brain session API body limit above Axum's 2 MiB default
- accommodate the protocol's valid 16 MiB raw tool-bundle allowance after base64 expansion
- add an HTTP regression proving a 3 MiB create request reaches JSON validation instead of returning 413

## Verification
- `cargo test -p brain --test create_idempotency`
- `cargo test -p brain`
- `cargo clippy -p brain --all-targets -- -D warnings`

## Release evidence
The first full customer canary exposed this through an eight-tool public SDK session: seven independent cases passed and only session creation with the complete portable tool set returned HTTP 413.