### PR TITLE
Make contributor guidance self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
-      # Slice-5 gates. Thresholds are backstops for a shared 2-vCPU runner (catch
+      # Benchmark gates. Thresholds are backstops for a shared 2-vCPU runner (catch
       # order-of-magnitude regressions like the Nagle 40ms/write stall); the published
       # numbers come from the ARM target run recorded in BENCHMARKS.md.
       - name: benchmark gates (density, reclaim, creep, turns/s, TTFT) + leakage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,22 +1,16 @@
 # Working in this repository
 
-* Neutral session and Brain↔Hand wire formats are owned here. `hands` and downstream products such
-  as Aex consume immutable Brain tags or revisions. Change schemas and generated views together;
-  never hand-edit generated contract files.
-* Brain owns the Brain-side Hand client and the public Hand composition ports. It must not depend on
-  a Hands implementation crate. `hands` depends on Brain and implements the protocol/ports; Aex or
-  another downstream server composition wires a selected adapter into Brain.
-* Design authority is `aex-research/docs/ARCHITECTURE-v1.md` plus its accepted
-  `brain-independent-product-design.md` amendment (private sibling repo). The invariants that
-  bind the brain: one durable DynamoDB write per decision (D9); the prefix is sealed for the
-  session's life (D11); absent ≠ zero on usage (D10); tool intents journal before dispatch and
-  results journal before `release`; a lost hand is `hand_lost`, interrupted, never replayed (I10);
-  the brain mints every presigned URL (I8); never attach an execution role to a hand MicroVM.
-* The brain is host-side Rust and builds/tests on any OS. `brain` is the substrate-generic core — NO
-  cloud SDK or Hands implementation may appear in its dependency tree. Cloud/storage behavior goes
-  behind public adapters; never let a local-mode convenience weaken a production invariant, and
-  never re-fuse the core to a cloud.
-* `tests/local_e2e.rs` drives the whole loop (HTTP + SSE + journal + real subprocess tools)
-  with a scripted provider and runs in CI. Hosted AWS composition and MicroVM gates live
-  downstream in Aex/Platform and Hands; do not pull those implementations back into Brain.
-* Fail fast; plain English in comments. Commit style: `area: imperative summary`.
+- Brain owns the neutral session API, Brain-to-Hand protocol, Brain-side Hand client, and public
+  Hand composition ports. Change schemas and generated views together; never hand-edit generated
+  contract files.
+- `hands` and downstream products consume immutable Brain tags or revisions. Brain must not depend
+  on a Hands implementation crate or product-specific runtime.
+- Journal every decision before its external effect. Seal the session prefix for its lifetime,
+  preserve absent usage counters as absent, record tool intents before dispatch, and record results
+  before releasing Hand state. A lost Hand interrupts work and is never replayed.
+- Keep the `brain` core independent of cloud SDKs. Put storage, custody, and runtime behaviour behind
+  public adapters, and do not weaken production invariants for local development.
+- `tests/local_e2e.rs` covers HTTP, SSE, journaling, and real subprocess tools with a scripted model
+  provider. Hosted infrastructure and MicroVM gates belong downstream.
+- Fail fast, keep comments self-contained, and use plain English.
+- Commit style: `area: imperative summary`.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,64 +1,45 @@
-# Benchmarks — the slice-5 record
+# Benchmarks
 
-The published numbers behind the platform. Method before numbers: every figure measures the
-PLATFORM, never a model — the provider is the scripted fake (instant), the hand is an
-in-process echo, the journal is in-memory, and the drive path is the real public HTTP API with
-SSE, because that is what production serves. Reproduce with `cargo run -p brain-bench
---release -- <arm>`; the same suite gates every push in CI (thresholds are loose backstops for
-the shared runner; this file is the record).
+Brain's benchmark suite measures the engine, not a model. It drives the public HTTP and SSE paths
+with an instant scripted provider, an in-process echo Hand, and an in-memory journal. Reference
+measurements below were recorded on 18 August 2026 using a release build on a c7g.xlarge
+(4-vCPU Graviton3, Ubuntu, glibc).
 
-**Environment:** c7g.xlarge (4 vCPU Graviton3, Ubuntu, glibc), release build — the production
-target family. Windows/macOS runs are smoke only (memory arms refuse without `smaps_rollup`).
+## Reference results
 
-## The brain
+| Measurement | Result |
+| --- | ---: |
+| First visible byte, one session | p50 1.4 ms · p99 2.2 ms |
+| Complete text turn, one session | p50 2.3 ms · p99 3.2 ms |
+| Admission to `turn.started` | p50 0.22 ms |
+| Throughput, 64 sessions | 2,002 turns/s · p99 58 ms |
+| Throughput, 256 sessions | 2,100 turns/s · p99 254 ms |
+| Tool loop, 64 sessions, 2 rounds × 4 calls | 429 turns/s · about 3,430 tool calls/s |
+| Resident session, excluding the in-process journal | 21–31 KiB private memory |
+| Memory returned after deleting all sessions | 82–86% in one cycle |
+| Steady-state change across delete cycles | −0.6 MiB per cycle over 6 cycles |
 
-| Number | Value |
-| --- | --- |
-| Platform-added TTFT (`POST /messages` → first `assistant.delta` at the client, K=1) | **p50 1.4 ms · p99 2.2 ms** |
-| Whole-turn overhead (pure text turn over HTTP+SSE, K=1) | p50 2.3 ms · p99 3.2 ms |
-| Admission (`POST` → `turn.started`, K=1) | p50 0.22 ms |
-| Unpaced throughput, K=64 sessions | **2,002 turns/s** · turn p99 58 ms |
-| Unpaced throughput, K=256 sessions | 2,100 turns/s · turn p99 254 ms |
-| Tool loop, K=64, 2 rounds × 4 parallel calls/turn | 429 turns/s (**≈3,430 tool calls/s**) |
-| Resident session (fold cached between turns; journal-neutral) | **21–31 KiB private** (≈5 KiB with `MALLOC_ARENA_MAX=1`) |
-| Memory returned on delete-all, single cycle | 82–86 % (glibc `malloc_trim`; the rest is arena fragmentation) |
-| Steady-state creep (create/turns/delete cycles, tail) | **−0.6 MiB/cycle over 6 cycles** — a plateau, not a leak |
+The first-byte and turn measurements include HTTP, SSE, request construction, journaling, and
+dispatch. The provider itself is instant. The resident-session figure is the private-memory delta
+between live actors and the post-discard state; production journals are off-process. An
+in-process journal at four 8-KiB turns uses roughly 450–470 KiB per session.
 
-Notes that keep these honest:
+The one-cycle reclaim percentage reflects allocator fragmentation. The stronger long-running
+invariant is that the post-delete floor stops rising; the measured floor plateaued. CI thresholds
+are deliberately loose regression guards for shared runners, not replacements for the reference
+record.
 
-- **Resident** = the private-byte delta between "actors alive, folds cached" and "actors
-  idle-discarded, journal retained". The in-memory journal is excluded on purpose: production
-  journals live in DynamoDB, off-process. (Journal-inclusive: ~450–470 KiB/session at 4 turns
-  × 8 KiB text with the dev journal in-process.)
-- **Reclaim** is two numbers because one would lie. The single-cycle percentage is capped by
-  glibc arena fragmentation (`malloc_trim` cannot compact interior holes; `MALLOC_ARENA_MAX`
-  trades hot-path throughput for a lower floor — a deploy-time knob). The invariant a
-  long-lived brain needs is the second number: the post-delete floor stops rising. It does.
-- The TTFT gate caught a real bug while being built: Nagle + delayed ACK put a hard **46 ms
-  floor** under every turn on Linux (SSE frames are small writes). `TCP_NODELAY` on the serve
-  path took K=1 p50 from 46 ms to 5 ms; the CI gate exists so it cannot come back.
+## Reproduce
 
-## The hand (real Lambda MicroVM, measured in-region, eu-west-1)
+```sh
+cargo run -p brain-bench --release -- ci
+cargo run -p brain-bench --release -- --help
+```
 
-| Number | Value |
-| --- | --- |
-| Endpoint round trip (raw HTTP probe through the JWE proxy) | **p50 2.1 ms** · p99 3.4 ms |
-| Tool call round trip (bash `true`: start → poll complete over the ABI), image v2.0 | p50 50.0 ms · p95 60.1 ms |
-| Tool call round trip, image v3.0 (`TCP_NODELAY` on both WebSocket ends) | **p50 4.4 ms · p99 5.3 ms** — 11× |
-| IMDS from inside the guest | **no IAM role, no credentials** (role list 404, creds unreachable; identity doc exposes the region only) |
+Density and reclaim measurements require Linux `/proc/*/smaps_rollup`; other platforms run the
+portable latency and correctness arms only. The benchmark refuses to substitute RSS because it
+would double-count shared pages.
 
-The 50 ms tool-call floor against a 2 ms network baseline was the same Nagle signature the
-brain had, in the ABI WebSocket hops. Client-side nodelay alone changed nothing (the delayed
-leg was the guest's responses); with image v3.0 fixing both ends the platform adds ~2 ms over
-the raw endpoint round trip. Reproduce with
-`hand-lambda gate --image hands-dev-1gb --version <v>` — IMDS is a hard pass/fail, the
-latency row is the record. The security gate and this latency measurement run on demand (they
-launch a real MicroVM and need AWS credentials); the brain suite runs in CI on every push.
-
-## Cross-session leakage
-
-`crates/brain/tests/leakage.rs`, on every push: two tenants on one brain, real files on disk,
-interleaved turns, dialect-split scripted providers. Workspaces are disjoint on disk, a probe
-for the other tenant's file by path finds nothing, no foreign content or model identity in
-either journal, provider keys appear in NO journal (not even the session's own), every event
-names its own session, and every wire request carries exactly its own sealed system prompt.
+`crates/brain/tests/leakage.rs` independently checks cross-session isolation on every push: files,
+conversation content, model identity, provider keys, events, and journals must remain scoped to
+their owning session.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
 # Brain
 
-Brain is an independent, Apache-2.0 session engine. One long-lived server owns many durable model
-sessions: their immutable prefixes, provider rounds, tool-call journal, recovery, cancellation,
-and event streams. Aex is a downstream product built on Brain; Brain does not require an Aex
-account or control plane.
+Brain is an independent session engine for durable model conversations, tool execution, recovery,
+cancellation, and event streaming. It runs without an Aex account or control plane.
 
-Brain starts with zero model-visible tools. Applications explicitly select ordinary `Tool` values
-from `@aexhq/brain-tools`, a third-party package, or their own source. The exact order,
-definitions, executor bindings, and executable checksums are frozen for the session. Core dispatch
-routes from those sealed executor descriptors and never from a model-visible name.
+## TypeScript client
 
 ```ts
 import { Brain, defineTool } from "@aexhq/brain";
@@ -31,38 +26,33 @@ const brain = new Brain({ token: process.env.BRAIN_TOKEN! });
 const session = await brain.sessions.create({
   model: {
     provider: "openai",
-    name: "gpt-5",
+    name: process.env.MODEL_NAME!,
     apiKey: process.env.OPENAI_API_KEY!,
   },
   tools: [echo],
 });
 ```
 
-Deployable TypeScript tools run in the session's default Hand. The local builder creates a
-deterministic Node 22 ESM bundle without importing the customer's module; its first evaluation is
-inside the Hand, after Brain has durably recorded the call intent. `echo.local()` is the explicit
-alternative for a callback in an attached application process. Server capabilities and remote MCP
-tools use the same definition/executor model.
+Tools run in the session's Hand by default. Use `echo.local()` only when execution should happen in
+the attached application process. Sessions expose no model tools unless the application selects
+them.
 
-## Repository map
+## Components
 
-| Crate or package | Responsibility |
+| Component | Purpose |
 | --- | --- |
-| `brain-protocol` | Brain-owned session API and Brain↔Hand wire types |
-| `brain-hand-client` | Neutral client for the public Hand protocol |
-| `brain` | Multi-session engine, providers, tool router, API, recovery, and public adapter ports |
-| `brain-standalone` | SQLite journal, local encrypted custody/storage, and Docker Hand adapter |
-| `brain-aws` | Neutral DynamoDB and KMS adapters; no Hands implementation |
-| `brain-server` | Standalone server binary and explicit development composition |
-| `@aexhq/brain` | TypeScript client, Tool API, attached worker, schemas, and local builder |
-| `@aexhq/brain-tools` | Portable official Tool values, selected explicitly |
+| `brain-protocol` | Session API and Brain-to-Hand wire types |
+| `brain-hand-client` | Client for the public Hand protocol |
+| `brain` | Session engine, providers, tool router, recovery, and adapter ports |
+| `brain-standalone` | SQLite journal, encrypted local custody, files, and Docker Hands |
+| `brain-aws` | Neutral DynamoDB and KMS adapters |
+| `brain-server` | Standalone server binary and development composition |
+| `@aexhq/brain` | TypeScript client, Tool API, worker, schemas, and builder |
+| `@aexhq/brain-tools` | Portable Tool values selected explicitly by an application |
 
-Hands implement Brain's public ports. Brain never imports a crate from the Hands repository.
+Hands implement Brain's public ports. Brain never imports a Hands implementation.
 
 ## Run standalone
-
-The default server mode is durable single-node operation with SQLite, a local AES-256-GCM master
-key, local files, and one Docker Hand per active session:
 
 ```sh
 export BRAIN_HAND_IMAGE='ghcr.io/aexhq/hands@sha256:<digest>'
@@ -70,25 +60,15 @@ export BRAIN_DATA_DIR="$PWD/brain-data"
 cargo run --release -p brain-server --bin brain
 ```
 
-It binds `127.0.0.1:3210` by default. Set `BRAIN_API_TOKEN`, or read the generated mode-0600 token
-from `$BRAIN_DATA_DIR/operator.token`. Brain fails closed if Docker, the configured image, SQLite,
-the custody key, or durable Hand state cannot be opened. It never falls back to an in-memory mode.
+Brain binds `127.0.0.1:3210` by default. Set `BRAIN_API_TOKEN`, or read the generated mode-0600
+token from `$BRAIN_DATA_DIR/operator.token`. See [STANDALONE.md](STANDALONE.md) for Docker Compose,
+backup, networking, and trust boundaries.
 
-See [STANDALONE.md](STANDALONE.md) for Docker Compose, backup, network, and trust-boundary details.
-Containers share the host kernel and are not advertised as hostile multi-tenant isolation.
+To embed Brain, implement `brain::adapter::{HandFactory, HandAdapter}` and any required journal,
+key-custody, storage, or trusted-tool adapters, then compose them with `Brain::with_parts`.
+`crates/brain/tests/custom_adapter.rs` is a complete third-party adapter example.
 
-For tests only, `BRAIN_MODE=development` selects the in-memory journal and unsandboxed host
-subprocess adapter. Sessions in that mode do not survive a restart.
-
-## Embed Brain
-
-Implement `brain::adapter::{HandFactory, HandAdapter}` and, when needed,
-`journal::JournalStore`, `keys::KeyCustody`, or the trusted `ToolExecutor` seam. Compose those
-public ports with `Brain::with_parts`. The engine owns protocol and journal invariants; the Hand
-implementation owns its isolation and lifecycle. `crates/brain/tests/custom_adapter.rs` is an
-end-to-end third-party adapter example.
-
-## Build and test
+## Verify
 
 ```sh
 cargo fmt --all -- --check
@@ -100,8 +80,8 @@ npm test
 npm run package-smoke
 ```
 
-The benchmark and leakage methodology is in [BENCHMARKS.md](BENCHMARKS.md). The session schemas,
-OpenAPI document, Hand protocol, examples, generators, and conformance fixtures in this repository
-are the neutral source of truth.
+Schemas, OpenAPI, protocol semantics, examples, generators, and conformance fixtures in this
+repository are the source of truth. See [BENCHMARKS.md](BENCHMARKS.md) for methodology and reference
+measurements.
 
-License: Apache-2.0.
+Apache-2.0 licensed.

--- a/contracts/abi/v1/README.md
+++ b/contracts/abi/v1/README.md
@@ -97,8 +97,8 @@ the brain's adapter (`hand.lost` on the session API) — the hand never reports 
   lane forked from `parent`. An attached operation holds its lane until terminal (`lane_busy`
   otherwise); a detached one does not hold the lane.
 * `cwd` is a per-call parameter defaulting to `paths.workspace`. The ABI never mutates a lane's
-  cwd; a `cd` inside a shell command is consumed by that command (98.1% of real `cd`s are
-  `cd x && cmd`, PD-4).
+  cwd; a `cd` inside a shell command is consumed by that command. This matches observed usage,
+  where 98.1% of directory changes were part of a command such as `cd x && cmd`.
 * `wait_ms` (attached only): the hand waits up to this long for the operation to become terminal
   before answering, capped by `limits.max_poll_wait_ms`; `max_bytes` bounds the stdout/stderr
   slices included from offset 0. Most calls therefore complete in one round trip.
@@ -178,8 +178,8 @@ URL minted by the trusted side:
 `hand_status` is published on every idle↔busy transition, when a job ends, and every
 `heartbeat_ms`. `idle_for_ms` is 0 while anything is in `inflight` or `live_jobs`. The brain's
 adapter keeps the VM alive (keepalive) while jobs are live so AWS's 180 s idle suspend does not
-fire under a running job; when nothing is live it lets the suspend happen. `pressure` is advisory
-(guest OOM gives no warning, HD-10).
+fire under a running job; when nothing is live it lets the suspend happen. `pressure` is advisory;
+the guest may be terminated for out-of-memory without advance notice.
 
 ## 3. Errors
 
@@ -204,6 +204,6 @@ work. Codes: see `ErrorCode` in the schema.
 Dropped: `signal`, `lane_info`, `probe`, streaming `update`, `terminal` push, effect classes,
 credit-based backpressure, hard version match, reject-unknown-fields.
 Folded: `result` into `poll` (one status+output view for start/poll/cancel).
-Added: `sync` (the durability decision D7 needed a wire operation), `wait_ms` on `start`/`poll`
+Added: `sync` for durable workspace state, `wait_ms` on `start`/`poll`
 (one round trip for short calls, no push channel needed), presigned-URL transfers, the pack +
 manifest format, `session_token` in `hello`.

--- a/crates/brain-aws/Cargo.toml
+++ b/crates/brain-aws/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 description = "Neutral AWS persistence and key-custody adapters for Brain"
+publish = false
 
 [dependencies]
 brain = { workspace = true }

--- a/crates/brain-aws/src/dynamo.rs
+++ b/crates/brain-aws/src/dynamo.rs
@@ -7,7 +7,7 @@
 //!   idempotency barrier;
 //! - claim is one conditional `UpdateItem` with `ADD fence 1` (the only fence advance);
 //! - commit is one `TransactWriteItems`: every record put plus the fenced HEAD update --
-//!   one decision, one durable write (D9);
+//!   one decision, one durable write;
 //! - `BatchWriteItem` is never used (it cannot be conditioned).
 
 use aws_sdk_dynamodb::error::{ProvideErrorMetadata, SdkError};

--- a/crates/brain-bench/src/main.rs
+++ b/crates/brain-bench/src/main.rs
@@ -1,4 +1,4 @@
-//! Benchmark gates for the brain (slice 5). Every number measures the PLATFORM, never a model:
+//! Benchmark gates for Brain. Every number measures the engine, never a model:
 //! the provider is the scripted fake (instant unless paced), the hand is an in-process echo,
 //! the journal is in-memory — and the drive path is the real public HTTP API with SSE, because
 //! that is what production serves.
@@ -7,7 +7,7 @@
 //!   density  N resident sessions -> KiB per resident session (journal-neutral: the resident
 //!            sample minus the post-discard sample, because an idle session is nothing but its
 //!            journal and the production journal lives in DynamoDB, not this process), then
-//!            delete-all -> memory returned (PD-13 gate: >=97% with explicit malloc_trim).
+//!            delete-all -> memory returned with explicit allocator reclamation.
 //!            The server runs in its OWN process and is sampled via /proc/<pid>: client-side
 //!            buffers (reqwest pools, driver vecs) must not pollute the brain's numbers.
 //!            Linux-only by construction (smaps_rollup; run on the production target).
@@ -112,7 +112,7 @@ async fn serve(args: &Args, idle_discard: Duration) -> anyhow::Result<Bench> {
         text_bytes: args.text_bytes,
     });
     // Sampled inspection: full-parse instrumentation on every request would dominate an
-    // unpaced measurement (the PD-11 lesson, kept).
+    // unpaced measurement.
     fake.inspect_every
         .store(args.inspect_every.max(1), Ordering::Relaxed);
     fake.arrivals_cap.store(64, Ordering::Relaxed);

--- a/crates/brain-bench/src/mem.rs
+++ b/crates/brain-bench/src/mem.rs
@@ -10,8 +10,8 @@
 //! *private* answers "what does the Nth session add"; *Pss* answers "what does this process
 //! occupy in the fleet". Both are recorded, never one alone. If `/proc/self/smaps_rollup` is
 //! unreadable (macOS, Windows) this module REFUSES rather than falling back to RSS: a bare RSS
-//! sum double-counts every shared page and would not be comparable with the banked PD-11
-//! figures. Density and reclaim gates are Linux-only by construction; run them on the target.
+//! sum double-counts every shared page and would not be comparable with the reference figures.
+//! Density and reclaim gates are Linux-only by construction; run them on the target.
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
 pub struct Mem {

--- a/crates/brain-hand-client/src/lib.rs
+++ b/crates/brain-hand-client/src/lib.rs
@@ -77,9 +77,8 @@ impl HandClient {
                 .map_err(|e| ClientError::Transport(e.to_string()))?;
             request.headers_mut().insert(name, value);
         }
-        // disable_nagle: ABI frames are small; Nagle + delayed ACK adds ~40 ms to every
-        // request/response pair (the slice-5 latency gate measured a 50 ms tool-call floor
-        // against a 2 ms network baseline before this).
+        // disable_nagle: ABI frames are small; Nagle + delayed ACK added ~40 ms to every
+        // request/response pair in the end-to-end latency benchmark.
         let (ws, _) = tokio_tungstenite::connect_async_with_config(request, None, true)
             .await
             .map_err(|e| ClientError::Transport(e.to_string()))?;

--- a/crates/brain-protocol/Cargo.toml
+++ b/crates/brain-protocol/Cargo.toml
@@ -2,6 +2,7 @@
 name = "brain-protocol"
 version = "0.1.0"
 description = "Brain session API and Brain-to-Hand protocol types generated from Brain-owned JSON Schemas"
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/brain-server/Cargo.toml
+++ b/crates/brain-server/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 description = "The standalone Brain server"
+publish = false
 
 [dependencies]
 brain = { workspace = true }

--- a/crates/brain-server/src/bin/mcp.rs
+++ b/crates/brain-server/src/bin/mcp.rs
@@ -1,7 +1,6 @@
-//! The slice-7 real-wire MCP operator gate: the brain's own MCP client against the OFFICIAL
-//! reference server (`@modelcontextprotocol/server-everything`), with a REAL model choosing
-//! the calls. The in-test axum servers prove our reading of the spec; this proves interop
-//! with the implementation everyone else runs.
+//! Real-wire MCP interoperability check: Brain's MCP client talks to the official
+//! `@modelcontextprotocol/server-everything` reference server while a real model chooses calls.
+//! The in-test Axum servers cover protocol behaviour; this binary covers external interoperability.
 //!
 //! What a pass proves, over real HTTP end to end:
 //!   - `protocol: auto` negotiates with whatever revision the official server speaks today

--- a/crates/brain-standalone/Cargo.toml
+++ b/crates/brain-standalone/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 description = "Durable single-node adapters for the standalone Brain server"
+publish = false
 
 [dependencies]
 brain = { workspace = true }

--- a/crates/brain/Cargo.toml
+++ b/crates/brain/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 description = "Brain session engine: durable journals, sealed tool prefixes, provider dialects, the tool loop, and a substrate-neutral session API."
+publish = false
 
 [dependencies]
 brain-protocol = { workspace = true }

--- a/crates/brain/src/api.rs
+++ b/crates/brain/src/api.rs
@@ -188,8 +188,7 @@ pub async fn serve(state: AppState, addr: std::net::SocketAddr) -> anyhow::Resul
 }
 
 /// TCP_NODELAY on every accepted connection. Load-bearing for the event stream: SSE frames are
-/// small writes, and Nagle + delayed ACK turns each one into a ~40 ms stall on Linux — the
-/// slice-5 TTFT gate measured a hard 46 ms floor per turn before this (1 ms after).
+/// small writes, and Nagle plus delayed ACK added a measured ~40 ms stall per turn on Linux.
 pub fn nodelay(
     listener: tokio::net::TcpListener,
 ) -> impl axum::serve::Listener<Io = tokio::net::TcpStream, Addr = std::net::SocketAddr> {

--- a/crates/brain/src/compact.rs
+++ b/crates/brain/src/compact.rs
@@ -1,4 +1,4 @@
-//! Linear, prefix-stable compaction (D11).
+//! Linear, prefix-stable compaction.
 //!
 //! When the model-visible history outgrows its byte budget, everything but a trailing window
 //! is replaced by one summary message. Two properties are load-bearing:

--- a/crates/brain/src/config.rs
+++ b/crates/brain/src/config.rs
@@ -1,7 +1,7 @@
 //! The SDK / configuration surface, and the sealed prefix.
 //!
-//! Platform invariant (`design-decisions.md` §1.12): **the prefix is immutable
-//! for a session's life.** Tools, system prompt, MCP set and model cannot change
+//! Core invariant: **the prefix is immutable for a session's life.** Tools, system prompt, MCP set,
+//! and model cannot change
 //! mid-session; changing any of them forks a new session. One appended tool
 //! definition destroyed a 6,103-token cache entry, so this is enforced by
 //! construction rather than by convention: there is no `&mut` path to a
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 /// A BYOK provider credential. Per-session and frozen.
 ///
-/// We never hold provider keys as our own (`design-decisions.md` §3). The
-/// redacting `Debug` is not politeness: a key that reaches a log, a span
+/// Provider keys remain per-session customer credentials. The redacting `Debug` is not politeness:
+/// a key that reaches a log, a span
 /// attribute or a journal entry has leaked into storage we control, which is
 /// precisely the thing BYOK promises does not happen.
 #[derive(Clone, PartialEq, Eq)]
@@ -75,10 +75,8 @@ pub enum ToolRoute {
     Intrinsic(String),
     /// Forwarded over the Brain->Hand ABI using this exact execution seal.
     Hand(HandToolSeal),
-    /// A sealed remote MCP tool: the brain makes the outbound call itself
-    /// behind the one `Outbound` seam with its SSRF guard (ARCHITECTURE-v1
-    /// D14 -- which supersedes §1.11's connector tier; there is no separate
-    /// connector in MVP).
+    /// A sealed remote MCP tool. Brain makes the outbound call through the single
+    /// SSRF-guarded `Outbound` seam; there is no separate connector tier.
     Mcp { server: String, remote_name: String },
     /// A host-owned trusted executor registered under a stable capability.
     Server(ServerToolPolicy),
@@ -153,7 +151,7 @@ pub struct Limits {
     /// Maximum tool calls dispatched concurrently from one assistant message.
     /// p90 batch size is 4; this is not sized for 64.
     pub max_parallel_tools: usize,
-    /// Maximum `task` subagent identities minted over the session's LIFETIME (D11).
+    /// Maximum `task` subagent identities minted over the session's lifetime.
     /// Counted from journaled `task` tool calls, so the cap survives re-materialise.
     pub max_subagent_identities: u32,
 }
@@ -505,7 +503,7 @@ mod tests {
         assert_ne!(
             prefix_digest(&more),
             base,
-            "one appended tool definition must fork the prefix (design-decisions §1.12)"
+            "one appended tool definition must fork the prefix"
         );
     }
 

--- a/crates/brain/src/journal.rs
+++ b/crates/brain/src/journal.rs
@@ -1,4 +1,4 @@
-//! The session journal: every decision is durable in one backend transaction (D9).
+//! The session journal: every decision is durable in one backend transaction.
 //!
 //! One item collection per session. `HEAD` carries ownership (lease + fence), the sealed
 //! configuration and the mutable session facts; `E#<seq>` items carry the decision records.

--- a/crates/brain/src/keys.rs
+++ b/crates/brain/src/keys.rs
@@ -7,8 +7,8 @@
 //! not decrypt). `brain-aws` carries the KMS implementation; [`PlainCustody`] is the local /
 //! test one.
 //!
-//! Custody never pools per-tenant state (ARCHITECTURE-v1 §2.9: a shared token accountant is
-//! how P1 leaked accounting across tenants) -- there is nothing here but stateless calls.
+//! Custody never pools per-tenant state. Keeping these calls stateless prevents accounting or key
+//! material from crossing tenant boundaries.
 
 use crate::config::ProviderKey;
 use crate::{BrainError, Result};

--- a/crates/brain/src/lib.rs
+++ b/crates/brain/src/lib.rs
@@ -3,13 +3,12 @@
 //! The core loop is deliberately small: build a provider request from (sealed
 //! prefix, history), stream it, parse tool calls, dispatch them over the
 //! brain->hand ABI, append results, repeat. Every decision is made durable in
-//! one journal decision before it takes effect anywhere else (D9), and an idle
+//! one journal decision before it takes effect anywhere else, and an idle
 //! session is nothing but a cached fold of its journal (hydrate-act-commit-
 //! discard).
 //!
-//! Design authority: `aex-research/docs/ARCHITECTURE-v1.md` and its accepted independent-product
-//! amendment. This repository owns the session and Brain↔Hand wire formats exposed by
-//! `brain-protocol`; downstream Hands and products consume immutable Brain identities.
+//! This repository owns the session and Brain-to-Hand wire formats exposed by `brain-protocol`;
+//! downstream Hands and products consume immutable Brain identities.
 
 pub mod adapter;
 pub mod api;

--- a/crates/brain/src/mcp/client.rs
+++ b/crates/brain/src/mcp/client.rs
@@ -2,8 +2,8 @@
 //! adapter (`initialize` + `Mcp-Session-Id`, Streamable HTTP 2025-03-26..2025-11-25, no SSE
 //! resumability) behind the same call surface.
 //!
-//! Scope is deliberately narrow (ARCHITECTURE-v1 D11): `tools/list` and `tools/call`, plus
-//! the version negotiation needed to reach them. No subscriptions, no sampling/roots (we
+//! Scope is deliberately narrow: `tools/list` and `tools/call`, plus the version negotiation
+//! needed to reach them. No subscriptions, no sampling/roots (we
 //! declare zero client capabilities), no resumability. MRTR `input_required` results are
 //! surfaced as structured tool failures. The legacy adapter is the first thing to cut.
 //!

--- a/crates/brain/src/mcp/mod.rs
+++ b/crates/brain/src/mcp/mod.rs
@@ -1,11 +1,10 @@
-//! MCP for the brain (ARCHITECTURE-v1 D11/D14): remote MCP servers become ordinary sealed
-//! tools.
+//! MCP for Brain: remote MCP servers become ordinary sealed tools.
 //!
 //! Shape of the feature:
 //! - **Resolved once at create, sealed forever.** `tools/list` runs at session create; the
 //!   full tool schemas (namespaced `server__tool`) are persisted in the HEAD prefix doc, so
 //!   rehydration does zero network I/O and a server-side schema drift can never silently fork
-//!   the prefix digest. Changing the MCP set forks a new session (§1.12).
+//!   the prefix digest. Changing the MCP set requires a new session.
 //! - **Brain-side dispatch behind the `Outbound` SSRF guard.** MCP URLs are user-controlled;
 //!   every request goes through [`crate::outbound::Outbound`]. Per-server headers (the
 //!   credentials) live in key custody, never in the journal plaintext and never in the hand.

--- a/crates/brain/src/message.rs
+++ b/crates/brain/src/message.rs
@@ -40,8 +40,8 @@ impl ContentBlock {
         ContentBlock::Text { text: s.into() }
     }
     /// Approximate resident bytes of this block's owned heap data. Used only by
-    /// the memory harness, never for billing -- token accounting is passed
-    /// through from the provider (standing constraint, design-decisions.md §3).
+    /// the memory harness, never for billing; token accounting is passed through from the
+    /// provider.
     pub fn heap_bytes(&self) -> usize {
         match self {
             ContentBlock::Text { text } => text.capacity(),

--- a/crates/brain/src/outbound.rs
+++ b/crates/brain/src/outbound.rs
@@ -1,4 +1,4 @@
-//! The `Outbound` seam (D14): every brain-originated request to a USER-CONTROLLED URL goes
+//! The `Outbound` seam: every Brain-originated request to a user-controlled URL goes
 //! through here. MCP servers are the first tenant; `web_fetch` joins in M1.
 //!
 //! The threat is SSRF from the trusted tier: the brain sits next to its own metadata service,

--- a/crates/brain/src/provider/anthropic.rs
+++ b/crates/brain/src/provider/anthropic.rs
@@ -86,8 +86,7 @@ impl Anthropic {
         body.insert("max_tokens".into(), json!(prefix.sampling.max_tokens));
         body.insert("stream".into(), json!(true));
         // System prompt first, then tools, then messages: the render order the
-        // prompt cache keys on. Reordering these silently invalidates every
-        // cached prefix, which is the bug §1.12 exists to retire.
+        // prompt cache keys on. Reordering these silently invalidates every cached prefix.
         body.insert("system".into(), json!(prefix.system_prompt));
         if !tools.is_empty() {
             body.insert("tools".into(), json!(tools));

--- a/crates/brain/src/provider/fake.rs
+++ b/crates/brain/src/provider/fake.rs
@@ -87,16 +87,16 @@ pub struct FakeProvider {
     /// measurements of an empty loop.
     pub tokens_per_second: AtomicU64,
     /// Inspect (fully parse + canonically hash + record) 1 request in every N.
-    /// `1` inspects every request, which is PD-10's behaviour and the default.
+    /// `1` inspects every request and is the default.
     ///
-    /// PD-11 needs this because it drives an **unpaced** provider at the
+    /// Unpaced benchmarks need this because they drive the provider at the
     /// platform's real context size: a full `serde_json` parse of a ~500 KB body
     /// on every model call costs several milliseconds, which is more than the
     /// entire brain loop it is supposed to be measuring. An instrument that
     /// dominates its measurement is not an instrument.
     pub inspect_every: AtomicU64,
     /// Cap on retained arrivals. Unbounded retention is a leak inside the thing
-    /// being measured; at PD-11's throughput it is a large one.
+    /// being measured and becomes significant at benchmark throughput.
     pub arrivals_cap: AtomicU64,
     /// Requests whose cheap byte-scan round count disagreed with the full parse
     /// on an inspected request. **Must be zero**; the harness treats any
@@ -144,14 +144,14 @@ impl FakeProvider {
     /// without parsing them.
     ///
     /// The full-parse version of this (below) costs several milliseconds on a
-    /// 122 K-token request, which is more than the brain loop PD-11 is trying to
+    /// 122 K-token request, which is more than the Brain loop this benchmark is trying to
     /// measure. This byte scan is microseconds, and still derived purely from
     /// the request, so K concurrent sessions cannot interfere.
     ///
     /// A turn boundary is a REAL user message. On the Anthropic wire, tool
     /// results also ride in `role:"user"` messages (as `tool_result` blocks) —
     /// treating those as boundaries resets the round count every tool round and
-    /// the policy emits tool calls until the round cap (the slice-5 bench hit
+    /// the policy emits tool calls until the round cap (the benchmark once observed
     /// exactly that: 2,560 model calls where 60 were expected).
     ///
     /// It is a heuristic on bytes, so it is **cross-checked against the full
@@ -284,7 +284,7 @@ impl FakeProvider {
         // assistants_this_turn_parsed; the two drifted (the duplicate kept treating Anthropic
         // tool-result user messages as turn boundaries) and the sampled-inspection runs took
         // the buggy copy on exactly 1-in-N requests — an off-by-a-few in the round counts that
-        // looked entirely plausible. The slice-5 bench guards caught it; never duplicate this.
+        // looked entirely plausible. The benchmark guards caught it; never duplicate this.
         let assistant_so_far = Self::assistants_this_turn_parsed(body);
         Some(Self::scripted_for(
             assistant_so_far,
@@ -414,7 +414,7 @@ impl Provider for FakeProvider {
 
         // The fast path: decide the turn from raw bytes and record nothing.
         // Taken only when the caller has explicitly asked for sampling; the
-        // default (`inspect_every == 1`) is PD-10's every-request behaviour.
+        // default (`inspect_every == 1`) inspects every request.
         let every = self.inspect_every.load(Ordering::Relaxed).max(1);
         if every > 1 && !call_no.is_multiple_of(every) {
             let next =
@@ -463,7 +463,7 @@ impl Provider for FakeProvider {
         {
             let mut a = self.arrivals.lock().expect("arrivals");
             // Bounded: an unbounded arrival log is a leak inside the thing being
-            // measured, and at PD-11's throughput it is a large one. Dropping
+            // measured, and at benchmark throughput it is a large one. Dropping
             // the OLDEST keeps the most recent window, which is what a guard
             // reads. The count of calls is `call_count` and is never truncated,
             // so "how many arrived" stays exact even when "which ones" does not.
@@ -668,7 +668,7 @@ mod tests {
     fn anthropic_tool_result_user_messages_are_not_turn_boundaries() {
         // On the Anthropic wire a tool result is a user-role message carrying tool_result
         // blocks. The round counter must skip those, or the policy resets to round 0 after
-        // every tool round and emits tool calls until the round cap (the slice-5 bench caught
+        // every tool round and emits tool calls until the round cap (the benchmark caught
         // exactly this: 2,560 model calls where 60 were expected).
         let body = serde_json::json!({"messages": [
             {"role": "user", "content": [{"type": "text", "text": "go"}]},

--- a/crates/brain/src/provider/mod.rs
+++ b/crates/brain/src/provider/mod.rs
@@ -14,8 +14,6 @@
 pub mod anthropic;
 pub mod fake;
 pub mod openai;
-// `render` (render-once + byte-splice request assembly) stays in the prototype until the
-// slice-5 density work lands; the reference `build_request` path below is the certified one.
 pub mod sse;
 
 use crate::Result;

--- a/crates/brain/src/provider/openai.rs
+++ b/crates/brain/src/provider/openai.rs
@@ -577,8 +577,7 @@ mod tests {
 
     #[test]
     fn a_real_zero_cached_tokens_survives() {
-        // The exact bug LANDSCAPE §2 documents in five products: testing
-        // truthiness drops a genuine 0, which is the finding, not the absence.
+        // Truthiness checks drop a genuine zero, even though zero is data rather than absence.
         let raw = "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":9,\"prompt_tokens_details\":{\"cached_tokens\":0}}}\n\n";
         let evs = decode_stream(raw.as_bytes()).unwrap();
         match &evs[0] {

--- a/crates/brain/src/reclaim.rs
+++ b/crates/brain/src/reclaim.rs
@@ -2,10 +2,9 @@
 //!
 //! # Why this module exists
 //!
-//! PD-10 found that dropping 10,000 sessions returned **0.00%** of 13.9 GB to
-//! the OS, and that one `malloc_trim(0)` recovered 99.96%. PD-13 repeated that
-//! across three allocators at the target session shape and found something
-//! worse than "glibc is the odd one out":
+//! An early load test found that dropping 10,000 sessions returned **0.00%** of 13.9 GB to
+//! the OS, while one `malloc_trim(0)` recovered 99.96%. A follow-up at the target session shape
+//! compared three allocators and found that none returned the memory without an explicit call:
 //!
 //! | allocator | dropped 10,000 sessions, no explicit call | after an explicit call |
 //! | --- | ---: | ---: |
@@ -19,10 +18,8 @@
 //! rather than by a timer. A process that has just evicted its sessions and is
 //! now idle is precisely the process that never triggers it.
 //!
-//! So the return has to be asked for, and the question PD-10 left open --
-//! "`malloc_trim` is not the answer, only the proof ... there is no principled
-//! place to call it" -- is answerable once you know what the call costs. PD-13
-//! measured that too, at ~6 GB held:
+//! Returning memory therefore needs an explicit trigger. Measuring the call cost at roughly 6 GB
+//! held identifies the right trigger boundary:
 //!
 //! | mechanism | call duration |
 //! | --- | ---: |

--- a/crates/brain/src/session.rs
+++ b/crates/brain/src/session.rs
@@ -1,9 +1,9 @@
-//! Sessions as spawned tasks (D9): one actor per resident session, hydrate-act-commit-discard.
+//! Sessions as spawned tasks: one actor per resident session, hydrate-act-commit-discard.
 //!
 //! An idle session is nothing but its journal. The actor holds the cached fold (history,
 //! head, lease, hand adapter); after `idle_discard` without traffic it releases the lease,
-//! drops the adapter and exits -- the next message hydrates from the journal (PD-11 measured
-//! the rehydrate at constant ~4 ms). Everything the actor holds is rebuildable; everything
+//! drops the adapter and exits -- the next message hydrates from the journal (measured at roughly
+//! 4 ms). Everything the actor holds is rebuildable; everything
 //! durable went through `Journal::commit` first.
 //!
 //! The brain is COMPOSED, not configured into a cloud: [`Brain::with_parts`] takes a journal
@@ -51,7 +51,7 @@ pub struct BrainConfig {
     pub history_budget_bytes: usize,
     /// Whether brain-originated requests to user-controlled URLs (MCP) may reach loopback /
     /// private / link-local addresses. `false` is the production invariant (the SSRF guard,
-    /// D14); [`Brain::local`] defaults it to `true` so a developer's MCP server on
+    /// user-controlled egress); [`Brain::local`] defaults it to `true` so a developer's MCP server on
     /// `127.0.0.1` works zero-config, and `brain-aws` refuses to start with `true`.
     pub outbound_allow_private: bool,
     /// Per-server budget for the create-time MCP probe + `tools/list`.
@@ -123,8 +123,8 @@ fn env_bool(k: &str, default: bool) -> bool {
         .unwrap_or(default)
 }
 
-/// Process-wide reclaim policy (PD-13: >=97% of a dropped session's memory returns with an
-/// explicit `malloc_trim`; no allocator does it unprompted).
+/// Process-wide reclaim policy. Measurements showed that allocators retain dropped session memory
+/// unless reclamation is requested explicitly.
 fn reclaim_policy() -> &'static crate::reclaim::ReclaimPolicy {
     static POLICY: std::sync::OnceLock<crate::reclaim::ReclaimPolicy> = std::sync::OnceLock::new();
     POLICY
@@ -146,7 +146,7 @@ pub struct Brain {
     pub hand_factory: Arc<dyn HandFactory>,
     pub hub: Arc<EventHub>,
     pub model_permits: Arc<Semaphore>,
-    /// The D14 egress seam: every brain-originated request to a user-controlled URL (MCP)
+    /// The egress seam: every Brain-originated request to a user-controlled URL (MCP)
     /// goes through this client and its SSRF guard.
     pub outbound: crate::outbound::Outbound,
     pub external_executor: Arc<dyn ToolExecutor>,
@@ -415,7 +415,7 @@ impl Brain {
             }
         }
 
-        // Resolve the declared MCP servers NOW: the tool list is sealed at create (§1.12),
+        // Resolve the declared MCP servers now: the tool list is sealed at create,
         // so `tools/list` runs here, concurrently per server, and never again for this
         // session. Strict: an unreachable server fails the create.
         let mcp = if tools_cfg.mcp.is_empty() {
@@ -713,7 +713,7 @@ impl Brain {
             return Err(error);
         }
 
-        // Eager hand creation (D16): the actor starts now and readies the substrate without
+        // Eager Hand creation: the actor starts now and readies the substrate without
         // the caller waiting.
         self.spawn_actor(&session_id, true).await;
 
@@ -1494,7 +1494,7 @@ async fn actor(
     let mut running: Option<Running> = None;
 
     if eager_hand {
-        // Eager hand creation, D16: ready the substrate without any caller waiting.
+        // Eager Hand creation readies the substrate without any caller waiting.
         match hydrate(&brain, &session_id).await {
             Ok(mut r) => {
                 match r.st.hand.ensure_ready().await {
@@ -1734,7 +1734,7 @@ async fn actor(
                     let _ = brain.journal.release(&session_id, &r.st.lease).await;
                     let freed: usize = r.st.history.iter().map(|m| m.heap_bytes()).sum();
                     drop(r);
-                    // PD-13: no allocator returns memory on drop without an explicit trim.
+                    // No tested allocator returned memory on drop without an explicit trim.
                     // The policy batches trims so a burst of discards pays one stall.
                     if reclaim_policy().freed(freed as u64).is_some() {
                         tracing::debug!(freed, "malloc_trim after session drop");
@@ -1909,7 +1909,7 @@ async fn hydrate(brain: &Arc<Brain>, session_id: &str) -> Result<Resident> {
     let mcp = build_mcp_runtime(brain, session_id, &head.doc).await?;
     let hand = brain.open_adapter(session_id, &head.doc).await?;
     // Every journaled subagent intent minted one child identity, including an
-    // interrupted call. Rebuilding the count here makes the D11 lifetime cap
+    // interrupted call. Rebuilding the count here makes the lifetime cap
     // survive discard and process restart.
     let identities = task_identity_count(&entries, &head.doc.prefix);
     let mut resident = Resident {
@@ -2099,7 +2099,7 @@ async fn admit(
         });
     }
 
-    // e.g. the speculative resume (F-4): substrate traffic now, hidden behind the model round.
+    // e.g. speculative resume: substrate traffic now, hidden behind the model round.
     r.st.hand.on_message_admitted();
 
     Ok((turn_id, user_seq, CancellationToken::new()))
@@ -2135,7 +2135,7 @@ fn turn_run(
 }
 
 /// Applies the turn outcome that `TurnRun::run` could not commit itself (failures), then the
-/// turn-end checkpoint (the workspace durability point, D7).
+/// turn-end checkpoint, which is the workspace durability point.
 async fn finish_turn(
     brain: &Arc<Brain>,
     session_id: &str,

--- a/crates/brain/src/tools.rs
+++ b/crates/brain/src/tools.rs
@@ -222,7 +222,7 @@ pub fn manifest_digest(manifest: &ToolManifest) -> String {
 }
 
 // ---------------------------------------------------------------------------------------------
-// task -- brain-side: a self-similar child agent inside the parent's turn (slice-8 spec)
+// task -- a Brain-side child agent inside the parent's turn
 // ---------------------------------------------------------------------------------------------
 
 /// The model-supplied input of one `task` call.

--- a/crates/brain/src/turn.rs
+++ b/crates/brain/src/turn.rs
@@ -47,7 +47,7 @@ pub struct TurnState {
     /// events (deltas, tool output) consume seqs too; every commit persists the
     /// high-water mark.
     pub seq: Seq,
-    /// Session-lifetime count of minted `task` subagent identities (D11 cap), seeded
+    /// Session-lifetime count of minted `task` subagent identities, seeded
     /// from the journal at hydrate so it survives re-materialise.
     pub identities: Arc<AtomicU64>,
 }
@@ -80,7 +80,7 @@ pub struct TurnRun {
     pub journal: Journal,
     pub hub: Arc<EventHub>,
     pub cancel: CancellationToken,
-    /// Bounds concurrent model rounds across the whole brain (admission, D9/D11).
+    /// Bounds concurrent model rounds across the whole Brain.
     pub model_permits: Arc<Semaphore>,
     pub history_budget_bytes: usize,
     pub external_executor: Arc<dyn ToolExecutor>,

--- a/crates/brain/tests/discard_race.rs
+++ b/crates/brain/tests/discard_race.rs
@@ -1,5 +1,5 @@
 //! Regression: a message arriving exactly when the idle timer discards the session's actor
-//! must succeed, not 500. The slice-5 density bench hit this as "actor dropped the reply"
+//! must succeed, not 500. The density benchmark exposed this as "actor dropped the reply"
 //! (the idle branch could win a select round against an already-buffered command and exit
 //! without answering it). The fix is close-then-drain in the actor plus a one-shot send retry
 //! in the callers; this test forces the collision hundreds of times.

--- a/crates/brain/tests/leakage.rs
+++ b/crates/brain/tests/leakage.rs
@@ -1,7 +1,6 @@
-//! The cross-session leakage gate (slice 5, ARCHITECTURE-v1 §2.9): two tenants on one brain,
+//! Cross-session leakage gate: two tenants on one Brain,
 //! adversarially interleaved, and NOTHING crosses — not workspace files, not prompt or output
-//! content, not model identity, not provider keys. This is the CI form of the P1 incident
-//! class (leaked accounting across tenants) and it runs on every push.
+//! content, not model identity, and not provider keys. It runs on every push.
 //!
 //! Method: one Brain, the real local substrate (real files on disk), two sessions on DIFFERENT
 //! dialects so each gets its own scripted fake — provider traffic is attributable per session

--- a/crates/brain/tests/mcp_e2e.rs
+++ b/crates/brain/tests/mcp_e2e.rs
@@ -1,4 +1,4 @@
-//! The slice-7 MCP gate, CI-runnable: real MCP servers (2026-07-28 stateless and the legacy
+//! CI-runnable MCP coverage: real servers (2026-07-28 stateless and the legacy
 //! `initialize` + `Mcp-Session-Id` adapter) exercised over the real HTTP surface, with only
 //! the model scripted (the fake provider).
 //!
@@ -252,7 +252,7 @@ impl TempDir {
     fn new() -> Self {
         // Unique per harness: the tests in this binary run concurrently in ONE process, so a
         // pid-keyed dir is shared -- and the remove_dir_all here (and in Drop) would delete a
-        // sibling test's live session workspace mid-create (the slice-7 flake).
+        // sibling test's live session workspace mid-create.
         static NEXT: AtomicU64 = AtomicU64::new(0);
         let p = std::env::temp_dir().join(format!(
             "brain-mcp-e2e-{}-{}",

--- a/crates/brain/tests/task_e2e.rs
+++ b/crates/brain/tests/task_e2e.rs
@@ -1,4 +1,4 @@
-//! Slice-8 gate: in-process `task` subagents over the real session HTTP API.
+//! In-process `task` subagents over the real session HTTP API.
 //!
 //! Only the model is scripted. Journal, SSE, local hand calls, MCP calls,
 //! cancellation, discard, and rehydrate all use their production seams.

--- a/packages/brain/README.md
+++ b/packages/brain/README.md
@@ -22,7 +22,11 @@ export default echo;
 
 const brain = new Brain({ token: process.env.BRAIN_TOKEN! });
 const session = await brain.sessions.create({
-  model: { provider: "openai", name: "gpt-5", apiKey: process.env.OPENAI_API_KEY! },
+  model: {
+    provider: "openai",
+    name: process.env.MODEL_NAME!,
+    apiKey: process.env.OPENAI_API_KEY!,
+  },
   tools: [echo],
 });
 ```

--- a/tools/mcp.sh
+++ b/tools/mcp.sh
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
-# Runs the slice-7 real-wire MCP operator gate: starts the OFFICIAL reference MCP server
+# Runs the real-wire MCP interoperability check: starts the official reference MCP server
 # (@modelcontextprotocol/server-everything, Streamable HTTP) via npx, then runs `bin/mcp`
-# against it with a real model. Provider keys are read from the private env file by NAME only
-# and never printed. Local mode -- no AWS.
+# against it with a real model. Provider credentials come from the environment and are never
+# printed. Local mode -- no AWS.
 set -euo pipefail
-ENVFILE="${BRAIN_KEYS_FILE:-$PWD/.env.dev}"
-pick() { grep "^$1=" "$ENVFILE" | head -1 | cut -d= -f2- | tr -d '\r\n'; }
 # The optional Vercel AI Gateway serves the Anthropic Messages dialect. Set
 # ANTHROPIC_API_KEY to use a direct key.
 if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-  export ANTHROPIC_API_KEY="$(pick VERCEL_AI_GATEWAY_API_KEY)"
+  : "${VERCEL_AI_GATEWAY_API_KEY:?set ANTHROPIC_API_KEY or VERCEL_AI_GATEWAY_API_KEY}"
+  export ANTHROPIC_API_KEY="$VERCEL_AI_GATEWAY_API_KEY"
   export BRAIN_MCP_BASE_URL="https://ai-gateway.vercel.sh"
   export BRAIN_MCP_MODEL="anthropic/claude-haiku-4.5"
 fi


### PR DESCRIPTION
Summary:
- simplify the README and benchmark record
- replace private research identifiers with the rationale contributors need
- keep real-model interoperability credentials environment-only
- mark Rust workspace crates as non-publishable

Verification:
- cargo fmt, clippy, and workspace tests
- npm workspace tests and clean-consumer package smoke
- npm dry-run package inspection and Markdown link scan