### PR TITLE
brain: corruption is loud — the strict read-path pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,13 @@ jobs:
           node-version: "22.23.2"
           cache: npm
       - run: npm ci
+      # Generated contract artifacts must match their source schemas — a contract change
+      # without a regen ships stale published types (found by the 2026-08-22 audit).
+      - name: generated artifacts are fresh
+        if: runner.os == 'Linux'
+        run: |
+          npm run gen -w packages/brain
+          git diff --exit-code packages/brain
       - run: npm test
       - run: npm run package-smoke
 

--- a/crates/brain-aws/src/dynamo.rs
+++ b/crates/brain-aws/src/dynamo.rs
@@ -2041,7 +2041,12 @@ impl JournalStore for DynamoJournal {
                     .ok_or_else(|| BrainError::Journal(format!("recovery row missing {name}")))
             };
             let pk = string("pk")?;
-            let session_id = pk.strip_prefix("S#").unwrap_or(&pk).to_owned();
+            let session_id = pk
+                .strip_prefix("S#")
+                .ok_or_else(|| {
+                    BrainError::Journal(format!("recovery row pk {pk:?} is not a session key"))
+                })?
+                .to_owned();
             let due_key = string("recovery_due_key")?;
             let due_ms = due_key
                 .split_once('#')

--- a/crates/brain-aws/src/lib.rs
+++ b/crates/brain-aws/src/lib.rs
@@ -43,7 +43,9 @@ impl AwsPersistenceConfig {
                 .map_err(|_| brain::BrainError::Invalid(format!("{name} is not set")))
         };
         Ok(Self {
-            region: std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".into()),
+            // No fallback region: a hosted composition booted without AWS_REGION would
+            // otherwise silently pin itself to one region — a deploy mistake must fail boot.
+            region: get("AWS_REGION")?,
             journal_table: get("BRAIN_JOURNAL_TABLE")?,
             kms_key_id: get("BRAIN_KMS_KEY_ID")?,
             session_storage_bucket: get("BRAIN_SESSION_STORAGE_BUCKET")?,

--- a/crates/brain-aws/src/s3.rs
+++ b/crates/brain-aws/src/s3.rs
@@ -108,17 +108,31 @@ impl S3SessionStorage {
             .await
             .map_err(|error| s3_error("head session object", error))?;
         let metadata = output.metadata();
+        // Session objects are written exclusively by this composition with length and sha256
+        // metadata; a HEAD without them is an unexpected object, not a 0-byte/empty-digest one.
         let updated_at_ms = output
             .last_modified()
             .and_then(|time| time.to_millis().ok())
-            .unwrap_or(0) as u64;
+            .ok_or_else(|| {
+                BrainError::Journal(format!("session object {object_key} has no last-modified"))
+            })? as u64;
+        let bytes = output
+            .content_length()
+            .filter(|length| *length >= 0)
+            .ok_or_else(|| {
+                BrainError::Journal(format!("session object {object_key} has no content length"))
+            })? as u64;
         Ok(StorageObject {
             key: key.into(),
-            bytes: output.content_length().unwrap_or(0).max(0) as u64,
+            bytes,
             sha256: metadata
                 .and_then(|values| values.get("sha256"))
                 .cloned()
-                .unwrap_or_default(),
+                .ok_or_else(|| {
+                    BrainError::Journal(format!(
+                        "session object {object_key} has no sha256 metadata"
+                    ))
+                })?,
             content_type: output.content_type().map(str::to_owned),
             publication_id: metadata
                 .and_then(|values| values.get("publication-id"))

--- a/crates/brain-bench/src/main.rs
+++ b/crates/brain-bench/src/main.rs
@@ -153,6 +153,7 @@ async fn serve(args: &Args, idle_discard: Duration) -> anyhow::Result<Bench> {
     let app = brain::api::router(brain::api::AppState {
         brain,
         token: TOKEN.into(),
+        require_tenant: false,
     })
     .merge(bench_routes(fake.clone(), executor.clone()));
     tokio::spawn(async move {

--- a/crates/brain-loophost/guest/componentize-one.mjs
+++ b/crates/brain-loophost/guest/componentize-one.mjs
@@ -1,12 +1,31 @@
 // Componentize one admitted loop source bundle with the pinned toolchain. Invoked by the
-// loop-host registry at custom-loop admission: argv = source path, wit path, output path.
+// loop-host registry at custom-loop admission: argv = source path, wit path, output path,
+// expected toolchain string.
 import { componentize } from "@bytecodealliance/componentize-js";
 import { readFile, writeFile } from "node:fs/promises";
 
-const [, , sourcePath, witPath, outPath] = process.argv;
-if (!sourcePath || !witPath || !outPath) {
-  console.error("usage: componentize-one.mjs <source> <wit> <out>");
+const [, , sourcePath, witPath, outPath, expectedToolchain] = process.argv;
+if (!sourcePath || !witPath || !outPath || !expectedToolchain) {
+  console.error("usage: componentize-one.mjs <source> <wit> <out> <toolchain>");
   process.exit(2);
+}
+
+// The sealed toolchain string must name the componentizer actually installed here: a
+// dependency bump without renaming the constant would otherwise seal identities as a lie.
+// (The package's exports map hides its package.json, so read the manifest off disk.)
+const installed = JSON.parse(
+  await readFile(
+    new URL("./node_modules/@bytecodealliance/componentize-js/package.json", import.meta.url),
+    "utf8",
+  ),
+).version;
+const actualToolchain = `starlingmonkey-componentize-js-${installed}`;
+if (actualToolchain !== expectedToolchain) {
+  console.error(
+    `toolchain mismatch: this install componentizes as ${actualToolchain}, ` +
+      `but the composition seals ${expectedToolchain}`,
+  );
+  process.exit(3);
 }
 const source = await readFile(sourcePath, "utf8");
 const wit = await readFile(witPath, "utf8");

--- a/crates/brain-loophost/src/lib.rs
+++ b/crates/brain-loophost/src/lib.rs
@@ -48,8 +48,8 @@ const EPOCH_TICK: Duration = Duration::from_millis(10);
 const EPOCH_DEADLINE_TICKS: u64 = 3_000;
 /// One loop instance may grow to 256 MiB of linear memory before allocation fails.
 const MEMORY_LIMIT_BYTES: usize = 256 << 20;
-/// Bounded ctx-op payloads in both directions, mirroring `brain_protocol::MAX_CTX_OP_BYTES`.
-const MAX_OP_BYTES: usize = 768 * 1024;
+/// Bounded ctx-op payloads in both directions — the protocol constant, one authority.
+const MAX_OP_BYTES: usize = brain_protocol::MAX_CTX_OP_BYTES;
 
 /// One guest ctx op awaiting service: the op JSON and the channel its response goes back on.
 pub type CtxRequest = (String, oneshot::Sender<String>);
@@ -336,7 +336,18 @@ pub(crate) async fn service_ctx_op(
         Ok(value) => value,
         Err(_) => return error_json("invalid_request", "ctx op payload is not JSON"),
     };
-    let op = request["op"].as_str().unwrap_or_default();
+    let Some(op) = request["op"].as_str() else {
+        // An `op_id` marks a contract-envelope attempt that failed typed parsing above; give
+        // the author that diagnosis instead of a misleading "unknown ctx op".
+        return error_json(
+            "invalid_request",
+            if request.get("op_id").is_some() {
+                "the payload does not parse as a contracts/agentloop/v1 ctx op envelope"
+            } else {
+                "ctx op payload has no string \"op\""
+            },
+        );
+    };
     if engine_ops == EngineOps::ContractOnly
         && op.starts_with("engine.")
         && op != "engine.session_start"

--- a/crates/brain-loophost/src/registry.rs
+++ b/crates/brain-loophost/src/registry.rs
@@ -177,6 +177,7 @@ impl LoophostRegistry {
             .arg(&source)
             .arg(&wit)
             .arg(&staged)
+            .arg(LOOP_TOOLCHAIN)
             .current_dir(&self.toolchain_dir);
         let output = match tokio::time::timeout(COMPONENTIZE_TIMEOUT, command.output()).await {
             Err(_elapsed) => {

--- a/crates/brain-loophost/src/remote.rs
+++ b/crates/brain-loophost/src/remote.rs
@@ -8,6 +8,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use brain::BrainError;
@@ -37,9 +38,14 @@ pub struct WireClient {
 
 impl WireClient {
     /// Connect and authenticate. Fails fast on a wrong token (the daemon answers `hello_ack`
-    /// only after accepting the token; a refusal closes the connection).
+    /// only after accepting the token; a refusal closes the connection). Both the TCP connect
+    /// and the handshake carry deadlines: a wedged or unreachable daemon fails the
+    /// composition's startup loudly instead of hanging it.
     pub async fn connect(addr: SocketAddr, token: &str) -> anyhow::Result<Arc<Self>> {
-        let stream = TcpStream::connect(addr).await?;
+        const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+        let stream = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(addr))
+            .await
+            .map_err(|_| anyhow::anyhow!("loop host did not accept the connection within 10s"))??;
         let (mut reader, mut writer) = stream.into_split();
         wire::write_frame(
             &mut writer,
@@ -48,7 +54,10 @@ impl WireClient {
             },
         )
         .await?;
-        match wire::read_frame(&mut reader).await {
+        match tokio::time::timeout(CONNECT_TIMEOUT, wire::read_frame(&mut reader))
+            .await
+            .map_err(|_| anyhow::anyhow!("loop host did not answer hello within 10s"))?
+        {
             Ok(Frame::HelloAck) => {}
             Ok(other) => anyhow::bail!(
                 "loop host answered hello with a {} frame",
@@ -214,8 +223,15 @@ impl Agentloop for RemoteAgentloop {
             return Err(BrainError::Agentloop(CONNECTION_LOST.into()));
         }
 
+        // Guest-side silence is bounded: contiguous guest compute is capped by the daemon's
+        // CPU slice (30s), so an activation that produces no frame for far longer than that
+        // means a wedged daemon or a half-open connection — fail the turn honestly instead of
+        // pinning it until the session wall. The clock only runs while the guest owes us a
+        // frame; time spent servicing a ctx op (provider calls included) resets it.
+        const ACTIVATION_IDLE_LIMIT: Duration = Duration::from_secs(120);
         let mut first_error: Option<BrainError> = None;
         let outcome = loop {
+            let idle = tokio::time::sleep(ACTIVATION_IDLE_LIMIT);
             tokio::select! {
                 biased;
                 Some((id, payload)) = ctx_rx.recv() => {
@@ -236,6 +252,12 @@ impl Agentloop for RemoteAgentloop {
                 }
                 done = &mut done_rx => {
                     break done.unwrap_or_else(|_| Err(CONNECTION_LOST.to_string()));
+                }
+                _ = idle => {
+                    break Err(format!(
+                        "loop host produced no frame for {}s; treating the activation as lost",
+                        ACTIVATION_IDLE_LIMIT.as_secs()
+                    ));
                 }
             }
         };

--- a/crates/brain-loophost/tests/loop_e2e.rs
+++ b/crates/brain-loophost/tests/loop_e2e.rs
@@ -189,6 +189,7 @@ async fn serve_brain_with(
     let app = brain::api::router(brain::api::AppState {
         brain,
         token: token.clone(),
+        require_tenant: false,
     });
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     TestBrain {

--- a/crates/brain-protocol/src/contract.rs
+++ b/crates/brain-protocol/src/contract.rs
@@ -229,6 +229,37 @@ pub fn external_tool_response_wire_fits(response: &ExternalToolCallResponse) -> 
 mod tests {
     use super::*;
 
+    #[test]
+    fn the_bundle_byte_bound_matches_the_frozen_contract() {
+        let schema: Value = serde_json::from_str(AGENTLOOP_CONTRACT_SCHEMA_JSON).unwrap();
+        let maximum = schema["definitions"]["custom_selector"]["properties"]["source_bundle_bytes"]
+            ["maximum"]
+            .as_u64()
+            .or_else(|| {
+                // The schema layout is not load-bearing here: find the one
+                // source_bundle_bytes.maximum wherever it lives.
+                fn find(value: &Value) -> Option<u64> {
+                    match value {
+                        Value::Object(map) => {
+                            if let Some(bound) = map
+                                .get("source_bundle_bytes")
+                                .and_then(|v| v.get("maximum"))
+                                .and_then(Value::as_u64)
+                            {
+                                return Some(bound);
+                            }
+                            map.values().find_map(find)
+                        }
+                        Value::Array(items) => items.iter().find_map(find),
+                        _ => None,
+                    }
+                }
+                find(&schema)
+            })
+            .expect("the agentloop contract bounds source_bundle_bytes");
+        assert_eq!(crate::MAX_LOOP_BUNDLE_BYTES as u64, maximum);
+    }
+
     fn external_response(content: String, result: Value) -> ExternalToolCallResponse {
         serde_json::from_value(serde_json::json!({
             "outcome": "completed",

--- a/crates/brain-protocol/src/lib.rs
+++ b/crates/brain-protocol/src/lib.rs
@@ -114,3 +114,6 @@ pub const MAX_LOOP_KV_VALUE_BYTES: usize = 8 * 1024;
 pub const MAX_ACTIVATION_REQUEST_BYTES: usize = 4 * 1024 * 1024;
 /// Maximum encoded bytes in one ctx operation request or response.
 pub const MAX_CTX_OP_BYTES: usize = 768 * 1024;
+/// Upload bound for a custom loop source bundle. The frozen agentloop contract's
+/// `source_bundle_bytes.maximum` is the authority; a unit test pins this constant to it.
+pub const MAX_LOOP_BUNDLE_BYTES: usize = 8 * 1024 * 1024;

--- a/crates/brain-server/src/bin/brain.rs
+++ b/crates/brain-server/src/bin/brain.rs
@@ -73,7 +73,15 @@ async fn run() -> anyhow::Result<()> {
         }
         other => anyhow::bail!("unsupported BRAIN_MODE={other}; use production or local"),
     };
-    serve(AppState { brain, token }, address).await
+    serve(
+        AppState {
+            brain,
+            token,
+            require_tenant: false,
+        },
+        address,
+    )
+    .await
 }
 
 async fn audit_local(journal: &Journal, custody: &Arc<dyn KeyCustody>) -> anyhow::Result<()> {

--- a/crates/brain-standalone/tests/standalone_e2e.rs
+++ b/crates/brain-standalone/tests/standalone_e2e.rs
@@ -362,6 +362,7 @@ async fn http_sse_journal_storage_and_node_tools_are_durable_and_isolated() {
     let app = brain::api::router(brain::api::AppState {
         brain: brain.clone(),
         token: OPERATOR_TOKEN.into(),
+        require_tenant: false,
     });
     let server = tokio::spawn(async move { axum::serve(listener, app).await });
     let http = Client::new();

--- a/crates/brain/src/api.rs
+++ b/crates/brain/src/api.rs
@@ -40,6 +40,9 @@ pub struct AppState {
     pub brain: Arc<Brain>,
     /// The dev-plane bearer token. Identity proper is slice 4.
     pub token: String,
+    /// Hosted compositions set this: every request must carry `x-brain-tenant-id`, and a
+    /// missing header is a request error — never a silent booking to tenant "local".
+    pub require_tenant: bool,
 }
 
 /// Ordinary control requests contain only bounded identifiers, paths, cursors and page options.
@@ -984,10 +987,21 @@ fn map_err(e: BrainError) -> Failure {
 
 fn auth(state: &AppState, headers: &HeaderMap) -> Result<TrustedPrincipal, Failure> {
     if bearer_token(headers) == Some(state.token.as_str()) {
-        let tenant_id = headers
+        let tenant_id = match headers
             .get("x-brain-tenant-id")
             .and_then(|value| value.to_str().ok())
-            .unwrap_or("local");
+        {
+            Some(tenant) => tenant,
+            None if state.require_tenant => {
+                return Err(Failure(
+                    StatusCode::BAD_REQUEST,
+                    api_code("invalid_request"),
+                    "x-brain-tenant-id header is required by this composition".into(),
+                ));
+            }
+            // Single-tenant local/dev composition: the one implicit tenant.
+            None => "local",
+        };
         TrustedPrincipal::new(tenant_id).map_err(map_err)
     } else {
         Err(Failure(
@@ -1631,7 +1645,7 @@ async fn send_message(
     Ok((
         StatusCode::ACCEPTED,
         Json(MessageAccepted {
-            seq: NonZeroU64::new(seq.max(1)).expect("nonzero"),
+            seq: NonZeroU64::new(seq).expect("journal seqs start at 1; zero is corrupt"),
             session_id: id.parse().map_err(|_| {
                 Failure(
                     StatusCode::BAD_REQUEST,
@@ -2164,7 +2178,7 @@ async fn admit_child_message(
         .await
         .map_err(map_err)?;
     Ok(MessageAccepted {
-        seq: NonZeroU64::new(seq.max(1)).expect("nonzero"),
+        seq: NonZeroU64::new(seq).expect("journal seqs start at 1; zero is corrupt"),
         session_id: child_id.parse().map_err(|_| {
             Failure(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -2233,6 +2247,20 @@ struct WaitChildRequest {
     timeout_ms: Option<u64>,
 }
 
+/// The wait ceiling is 5 minutes; asking for more is rejected, never silently clamped.
+fn wait_child_timeout_ms(requested: Option<u64>) -> Result<u64, Failure> {
+    const WAIT_CHILD_MAX_MS: u64 = 300_000;
+    match requested {
+        None => Ok(30_000),
+        Some(ms) if ms <= WAIT_CHILD_MAX_MS => Ok(ms),
+        Some(ms) => Err(Failure(
+            StatusCode::BAD_REQUEST,
+            api_code("invalid_request"),
+            format!("timeout_ms {ms} exceeds the {WAIT_CHILD_MAX_MS}ms wait ceiling"),
+        )),
+    }
+}
+
 async fn wait_child(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -2246,7 +2274,7 @@ async fn wait_child(
             .wait_child(
                 &id,
                 &child_id,
-                std::time::Duration::from_millis(request.timeout_ms.unwrap_or(30_000).min(300_000)),
+                std::time::Duration::from_millis(wait_child_timeout_ms(request.timeout_ms)?),
             )
             .await
             .map_err(map_err)?,
@@ -2643,12 +2671,22 @@ async fn stream_events(
     Query(q): Query<EventsQuery>,
 ) -> Result<Sse<impl Stream<Item = Result<SseFrame, Infallible>>>, Failure> {
     authorize_session(&state, &headers, &id).await?;
-    // Last-Event-ID (reconnect) wins over ?after.
-    let after = headers
-        .get("last-event-id")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(q.after);
+    // Last-Event-ID (reconnect) wins over ?after. A present-but-malformed resume cursor is a
+    // request error: silently replaying from ?after would hand the client the wrong window.
+    let after = match headers.get("last-event-id") {
+        None => q.after,
+        Some(value) => value
+            .to_str()
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .ok_or_else(|| {
+                Failure(
+                    StatusCode::BAD_REQUEST,
+                    api_code("invalid_request"),
+                    "Last-Event-ID must be a decimal event seq".into(),
+                )
+            })?,
+    };
 
     // Existence check first: a stream for a missing session must 404, not hang.
     let head = state.brain.head(&id).await.map_err(map_err)?;

--- a/crates/brain/src/compact.rs
+++ b/crates/brain/src/compact.rs
@@ -442,7 +442,9 @@ pub fn plan(
                     _ => None,
                 })
             })
-            .unwrap_or_default()
+            // An installed summary IS the first message's text block; feeding the compactor
+            // an empty previous summary would silently degrade every later compaction.
+            .expect("an installed summary must be the first history message's text block")
     });
     let tail = history[cut..].to_vec();
     Some(CompactionPlan {

--- a/crates/brain/src/events.rs
+++ b/crates/brain/src/events.rs
@@ -25,11 +25,19 @@ pub const EVENT_HUB_RING_EVENTS: usize = 8;
 pub const DEFAULT_MAX_EVENT_FOLLOWERS: usize = 64;
 
 pub fn ts(ms: u64) -> Timestamp {
-    Timestamp(chrono::DateTime::from_timestamp_millis(ms as i64).unwrap_or_else(chrono::Utc::now))
+    // Timestamps are kernel-written wall-clock ms; a value chrono cannot represent is journal
+    // corruption and must be loud — substituting a plausible time would mask it.
+    Timestamp(
+        chrono::DateTime::from_timestamp_millis(ms as i64).unwrap_or_else(|| {
+            panic!("journal timestamp {ms}ms is outside the representable range")
+        }),
+    )
 }
 
 fn seq_nz(seq: u64) -> NonZeroU64 {
-    NonZeroU64::new(seq.max(1)).expect("nonzero")
+    // Journal seqs start at 1; a zero here is corruption, and clamping it to 1 would collide
+    // with a real record's seq instead of failing.
+    NonZeroU64::new(seq).unwrap_or_else(|| panic!("journal seq 0 is corrupt"))
 }
 
 fn preview(content: &str) -> (String, bool) {
@@ -87,6 +95,11 @@ pub fn usage_of(u: &crate::message::Usage) -> ProviderUsage {
 }
 
 /// Derives the SSE event for one durable record, or None for internal-only records.
+///
+/// This is a derived, non-authoritative projection: every `.ok()?` below is a deliberate
+/// projection drop — a journal-written id that no longer parses as its contract type
+/// suppresses that event from the stream while the journal keeps the truth (REST reads of
+/// the same state error loudly instead; see `session_doc`).
 pub fn derive(session_id: &str, seq: u64, ts_ms: u64, record: &Record) -> Option<Event> {
     let sid: session::SessionId = session_id.parse().ok()?;
     let at = ts(ts_ms);
@@ -308,7 +321,7 @@ pub fn derive(session_id: &str, seq: u64, ts_ms: u64, record: &Record) -> Option
         },
         Record::LoopEvent { turn, name, data } => Event::LoopEvent {
             at,
-            data: data.as_object().cloned().unwrap_or_default(),
+            data: data.clone(),
             name: name.parse().ok()?,
             seq,
             session_id: sid,

--- a/crates/brain/src/journal.rs
+++ b/crates/brain/src/journal.rs
@@ -460,22 +460,24 @@ pub enum Record {
     },
     /// A loop-authored opaque entry (`contracts/agentloop/v1` `journal_append` kind `custom`).
     /// Never model input, never an SSE event; readable back through `journal_read`.
+    /// `data` is typed as an object because the contract only admits objects — a journal row
+    /// that fails this shape fails deserialization loudly instead of projecting a fabrication.
     LoopCustom {
         turn: String,
-        data: serde_json::Value,
+        data: serde_json::Map<String, serde_json::Value>,
     },
     /// A loop-authored application-visible entry; surfaces on SSE as `loop.event`.
     LoopEvent {
         turn: String,
         name: String,
-        data: serde_json::Value,
+        data: serde_json::Map<String, serde_json::Value>,
     },
     /// The loop's hydration floor: `data` carries its compacted working context and the next
     /// `session_start` tail begins after `covers_through_seq`.
     LoopMark {
         turn: String,
         covers_through_seq: u64,
-        data: serde_json::Value,
+        data: serde_json::Map<String, serde_json::Value>,
     },
     /// One durable `kv_set` batch: key to value, `null` deletes. The session's kv map is the
     /// fold of these records; caps are enforced at the op boundary before the record exists.

--- a/crates/brain/src/loopctx.rs
+++ b/crates/brain/src/loopctx.rs
@@ -305,12 +305,12 @@ pub(crate) fn project_entry(
         },
         Record::LoopCustom { data, .. } => al::JournalEntryView::LoopCustom {
             at,
-            data: al::JsonObject(object_of(data)?),
+            data: al::JsonObject(data.clone()),
             seq: seq(seq_value)?,
         },
         Record::LoopEvent { name, data, .. } => al::JournalEntryView::LoopEvent {
             at,
-            data: al::JsonObject(object_of(data)?),
+            data: al::JsonObject(data.clone()),
             name: identifier(name)?,
             seq: seq(seq_value)?,
         },
@@ -321,7 +321,7 @@ pub(crate) fn project_entry(
         } => al::JournalEntryView::LoopMark {
             at,
             covers_through_seq: seq(*covers_through_seq)?,
-            data: al::JsonObject(object_of(data)?),
+            data: al::JsonObject(data.clone()),
             seq: seq(seq_value)?,
         },
         _ => return Ok(None),
@@ -421,7 +421,7 @@ mod tests {
             &crate::journal::Record::LoopEvent {
                 turn: "trn".into(),
                 name: "todo.updated".into(),
-                data: json!({"open": 3}),
+                data: json!({"open": 3}).as_object().cloned().expect("object"),
             },
         )
         .expect("projects")

--- a/crates/brain/src/session.rs
+++ b/crates/brain/src/session.rs
@@ -993,8 +993,15 @@ fn managed_bundle_descriptors(
 fn bundle_object_matches_descriptor(
     object: &brain_protocol::hand::ObjectReference,
     descriptor: &brain_protocol::hand::BundleDescriptor,
-) -> bool {
-    serde_jcs::to_vec(object).ok() == serde_jcs::to_vec(&descriptor.object).ok()
+) -> Result<bool> {
+    // An uncomputable comparison is an error, never a match: `.ok() == .ok()` would report
+    // two canonicalization failures as equality.
+    let object = serde_jcs::to_vec(object)
+        .map_err(|error| BrainError::Journal(format!("bundle object canonicalization: {error}")))?;
+    let descriptor = serde_jcs::to_vec(&descriptor.object).map_err(|error| {
+        BrainError::Journal(format!("bundle descriptor canonicalization: {error}"))
+    })?;
+    Ok(object == descriptor)
 }
 
 pub(crate) fn managed_hand_resources() -> Result<brain_protocol::hand::ResourceCeiling> {
@@ -1972,7 +1979,7 @@ impl Brain {
                     .map_err(|_| {
                         BrainError::Invalid("agentloop.bundle_base64 is not valid base64".into())
                     })?;
-                if bundle.is_empty() || bundle.len() > 8 * 1024 * 1024 {
+                if bundle.is_empty() || bundle.len() > brain_protocol::MAX_LOOP_BUNDLE_BYTES {
                     return Err(BrainError::Invalid(
                         "agentloop bundle must be between 1 byte and 8 MiB".into(),
                     ));
@@ -2100,7 +2107,7 @@ impl Brain {
                     .ok_or_else(|| {
                         BrainError::Journal("stored Tool bundle has no immutable descriptor".into())
                     })?;
-                if !bundle_object_matches_descriptor(&object, descriptor) {
+                if !bundle_object_matches_descriptor(&object, descriptor)? {
                     return Err(BrainError::Journal(
                         "Tool-bundle storage returned an object outside the immutable descriptor"
                             .into(),
@@ -2199,7 +2206,7 @@ impl Brain {
             return Err(error);
         }
 
-        Ok(session_doc(&session_id, &doc))
+        session_doc(&session_id, &doc)
     }
 
     async fn replay_create(
@@ -2216,7 +2223,7 @@ impl Brain {
         if &head.doc.create_key_hash != key_hash || &head.doc.create_request_hash != request_hash {
             return Err(BrainError::IdempotencyConflict);
         }
-        Ok(Some(session_doc(session_id, &head.doc)))
+        Ok(Some(session_doc(session_id, &head.doc)?))
     }
 
     // -- routing to actors -------------------------------------------------------------------
@@ -2527,14 +2534,14 @@ impl Brain {
         let doc = self
             .deliver(session_id, |reply| Command::Cancel { reply })
             .await??;
-        Ok(session_doc(session_id, &doc))
+        session_doc(session_id, &doc)
     }
 
     pub async fn end(self: &Arc<Self>, session_id: &str) -> Result<session::Session> {
         let doc = self
             .deliver(session_id, |reply| Command::End { reply })
             .await??;
-        Ok(session_doc(session_id, &doc))
+        session_doc(session_id, &doc)
     }
 
     /// Current logical status of the root tree's shared default sandbox. Reading status never
@@ -3258,7 +3265,7 @@ impl Brain {
         if head.doc.parent_id.as_deref() != Some(parent_id) {
             return Err(BrainError::NoSuchSession(child_id.to_owned()));
         }
-        Ok(session_doc(child_id, &head.doc))
+        session_doc(child_id, &head.doc)
     }
 
     pub async fn wait_child(
@@ -4776,7 +4783,7 @@ impl Brain {
         if head.doc.state == "deleted" {
             return Err(BrainError::NoSuchSession(session_id.into()));
         }
-        Ok(session_doc(session_id, &head.doc))
+        session_doc(session_id, &head.doc)
     }
 
     pub async fn get_for(
@@ -4799,11 +4806,11 @@ impl Brain {
 
     pub async fn list(self: &Arc<Self>, limit: usize) -> Result<Vec<session::Session>> {
         let heads = self.journal.list_sessions(limit).await?;
-        Ok(heads
+        heads
             .iter()
             .filter(|h| h.doc.state != "deleted")
             .map(|h| session_doc(&h.session_id, &h.doc))
-            .collect())
+            .collect()
     }
 
     pub async fn list_for(
@@ -8707,7 +8714,7 @@ async fn create_child_session(
             if existing.doc.turn.is_some() {
                 let _ = brain.spawn_actor(&child_id, ActorStartup::Recovery).await;
             }
-            return Ok(session_doc(&child_id, &existing.doc));
+            return session_doc(&child_id, &existing.doc);
         }
         Err(BrainError::NoSuchSession(_)) => {}
         Err(error) => return Err(error),
@@ -8785,7 +8792,7 @@ async fn create_child_session(
     // customer traffic.
     let _ = brain.spawn_actor(&child_id, ActorStartup::Recovery).await;
     let created = brain.journal.get_head(&child_id).await?;
-    Ok(session_doc(&child_id, &created.doc))
+    session_doc(&child_id, &created.doc)
 }
 
 fn fork_turn_opener(message: &Message) -> bool {
@@ -10572,38 +10579,51 @@ fn default_system_prompt() -> String {
         .to_string()
 }
 
-/// Builds the contract Session document from the head.
-pub fn session_doc(session_id: &str, doc: &HeadDoc) -> session::Session {
-    let agentloop = (|| {
-        Some(
-            match doc
-                .prefix
-                .agentloop
-                .clone()
-                .unwrap_or_else(crate::journal::AgentloopSelectorDoc::official_aex)
-            {
-                crate::journal::AgentloopSelectorDoc::Official { name, version } => {
-                    session::AgentloopInfo::Official {
-                        name: name.parse().ok()?,
-                        version: version.parse().ok()?,
-                    }
+/// Builds the contract Session document from the head. A sealed value that no longer parses
+/// as its contract type is journal corruption and errors loudly, naming the field — the REST
+/// read never substitutes placeholders or omits sealed identity.
+pub fn session_doc(session_id: &str, doc: &HeadDoc) -> Result<session::Session> {
+    let corrupt = |what: &str| {
+        BrainError::Journal(format!(
+            "session {session_id}: journaled {what} violates the public contract"
+        ))
+    };
+    let agentloop = Some(
+        match doc
+            .prefix
+            .agentloop
+            .clone()
+            .unwrap_or_else(crate::journal::AgentloopSelectorDoc::official_aex)
+        {
+            crate::journal::AgentloopSelectorDoc::Official { name, version } => {
+                session::AgentloopInfo::Official {
+                    name: name.parse().map_err(|_| corrupt("agentloop name"))?,
+                    version: version.parse().map_err(|_| corrupt("agentloop version"))?,
                 }
-                crate::journal::AgentloopSelectorDoc::Custom {
-                    source_bundle_sha256,
-                    toolchain,
-                    ..
-                } => session::AgentloopInfo::Custom {
-                    source_bundle_sha256: source_bundle_sha256.parse().ok()?,
-                    toolchain: toolchain.parse().ok()?,
-                },
+            }
+            crate::journal::AgentloopSelectorDoc::Custom {
+                source_bundle_sha256,
+                toolchain,
+                ..
+            } => session::AgentloopInfo::Custom {
+                source_bundle_sha256: source_bundle_sha256
+                    .parse()
+                    .map_err(|_| corrupt("agentloop bundle digest"))?,
+                toolchain: toolchain
+                    .parse()
+                    .map_err(|_| corrupt("agentloop toolchain"))?,
             },
-        )
-    })();
-    session::Session {
+        },
+    );
+    Ok(session::Session {
         agentloop,
         context_fork: doc.context_fork.as_ref().map(public_context_fork),
         created_at: crate::events::ts(doc.created_ms),
-        current_turn: doc.turn.as_deref().and_then(|t| t.parse().ok()),
+        current_turn: doc
+            .turn
+            .as_deref()
+            .map(|t| t.parse().map_err(|_| corrupt("turn id")))
+            .transpose()?,
         failure: doc.failure.as_ref().map(|f| session::SessionFailure {
             at: crate::events::ts(f.at_ms),
             code: match f.code.as_str() {
@@ -10614,14 +10634,16 @@ pub fn session_doc(session_id: &str, doc: &HeadDoc) -> session::Session {
             },
             message: f.message.clone(),
         }),
-        id: session_id
-            .parse()
-            .unwrap_or_else(|_| "ses_00000000000000000000".parse().expect("fallback id")),
-        parent_id: doc.parent_id.as_deref().and_then(|id| id.parse().ok()),
+        id: session_id.parse().map_err(|_| corrupt("session id"))?,
+        parent_id: doc
+            .parent_id
+            .as_deref()
+            .map(|id| id.parse().map_err(|_| corrupt("parent session id")))
+            .transpose()?,
         root_id: doc
             .root_id
             .parse()
-            .unwrap_or_else(|_| "ses_00000000000000000000".parse().expect("fallback id")),
+            .map_err(|_| corrupt("root session id"))?,
         depth: i64::from(doc.depth),
         last_seq: doc.last_seq,
         last_message_at: doc.last_message_ms.map(crate::events::ts),
@@ -10654,14 +10676,19 @@ pub fn session_doc(session_id: &str, doc: &HeadDoc) -> session::Session {
                 _ => ApiProvider::OpenaiCompatible,
             },
         },
-        name: doc.child_name.as_deref().and_then(|name| name.parse().ok()),
+        name: doc
+            .child_name
+            .as_deref()
+            .map(|name| name.parse().map_err(|_| corrupt("child name")))
+            .transpose()?,
         object: session::SessionObject::Session,
         state: crate::events::session_state(&doc.state)
             .expect("journal session lifecycle is a closed enum"),
         turn_phase: doc
             .active_phase
             .as_deref()
-            .and_then(|phase| phase.parse().ok()),
+            .map(|phase| phase.parse().map_err(|_| corrupt("turn phase")))
+            .transpose()?,
         turn_state: crate::events::session_turn_state(&doc.state, doc.turn.as_deref()),
         shape: doc.prefix.shape.clone(),
         storage: session::StorageInfo {
@@ -10670,7 +10697,7 @@ pub fn session_doc(session_id: &str, doc: &HeadDoc) -> session::Session {
         },
         turns: doc.turns,
         updated_at: crate::events::ts(doc.updated_ms),
-    }
+    })
 }
 
 fn session_doc_summary(summary: &crate::journal::SessionSummary) -> session::Session {
@@ -11312,7 +11339,7 @@ mod tests {
         // Persist a depth-two descendant so admission has to evaluate the immutable ancestor
         // chain while the root actor itself is parked inside the resistant effect.
         let root_head = journal.get_head(&root_id).await.expect("root head");
-        let child_id = "ses_resistant_end_child";
+        let child_id = "ses_resistantendchild0000";
         let mut child = root_head.doc.clone();
         child.root_id = root_id.clone();
         child.parent_id = Some(root_id.clone());
@@ -11334,7 +11361,7 @@ mod tests {
             )
             .await
             .expect("create resistant-effect child");
-        let grandchild_id = "ses_resistant_end_grandchild";
+        let grandchild_id = "ses_resistantendgrand0000";
         let mut grandchild = child.clone();
         grandchild.parent_id = Some(child_id.into());
         grandchild.ancestor_ids = vec![root_id.clone(), child_id.into()];
@@ -11463,7 +11490,7 @@ mod tests {
             .expect("create sandbox teardown root");
         let root_id = root.id.to_string();
         let root_head = journal.get_head(&root_id).await.expect("root head");
-        let child_id = "ses_end_sandbox_child";
+        let child_id = "ses_endsandboxchild00000";
         let mut child = root_head.doc.clone();
         child.root_id = root_id.clone();
         child.parent_id = Some(root_id.clone());
@@ -15315,7 +15342,7 @@ mod tests {
         let root_id = root.id.to_string();
         let root_head = journal.get_head(&root_id).await.expect("root head");
 
-        let child_id = "ses_ancestor_fence_child";
+        let child_id = "ses_ancestorfencechild000";
         let mut child = root_head.doc.clone();
         child.root_id = root_id.clone();
         child.parent_id = Some(root_id.clone());
@@ -15340,7 +15367,7 @@ mod tests {
             .await
             .expect("create depth-one child");
 
-        let grandchild_id = "ses_ancestor_fence_grandchild";
+        let grandchild_id = "ses_ancestorfencegrand000";
         let mut grandchild = child.clone();
         grandchild.parent_id = Some(child_id.into());
         grandchild.ancestor_ids = vec![root_id.clone(), child_id.into()];

--- a/crates/brain/src/turn.rs
+++ b/crates/brain/src/turn.rs
@@ -493,12 +493,12 @@ impl LoopTurnCtx<'_> {
             let record = match entry {
                 al::LoopEntry::Custom { data } => Record::LoopCustom {
                     turn: turn.clone(),
-                    data: serde_json::Value::Object(data.0),
+                    data: data.0,
                 },
                 al::LoopEntry::Event { name, data } => Record::LoopEvent {
                     turn: turn.clone(),
                     name: name.to_string(),
-                    data: serde_json::Value::Object(data.0),
+                    data: data.0,
                 },
                 al::LoopEntry::Mark {
                     covers_through_seq,
@@ -506,7 +506,7 @@ impl LoopTurnCtx<'_> {
                 } => Record::LoopMark {
                     turn: turn.clone(),
                     covers_through_seq: covers_through_seq.0.get(),
-                    data: serde_json::Value::Object(data.0),
+                    data: data.0,
                 },
             };
             self.st.pending_loop.push((seq, record));
@@ -950,7 +950,7 @@ impl LoopTurnCtx<'_> {
     fn session_view(&self) -> Result<brain_protocol::agentloop::SessionContextView> {
         use brain_protocol::agentloop as al;
         let nonzero = |value: u64, what: &str| {
-            std::num::NonZeroU64::new(value.max(1))
+            std::num::NonZeroU64::new(value)
                 .ok_or_else(|| BrainError::Agentloop(format!("{what} limit cannot be zero")))
         };
         // The model-visible halves of the sealed grant ride the extensible metadata object, so
@@ -1021,7 +1021,7 @@ impl LoopTurnCtx<'_> {
                     .iter()
                     .find(|entry| entry.seq == mark_seq)
                     .and_then(|entry| match &entry.record {
-                        Record::LoopMark { data, .. } => data.as_object().cloned(),
+                        Record::LoopMark { data, .. } => Some(data.clone()),
                         _ => None,
                     })
                     .ok_or_else(|| {

--- a/crates/brain/tests/api_admission.rs
+++ b/crates/brain/tests/api_admission.rs
@@ -49,6 +49,7 @@ async fn unauthenticated_create_never_polls_the_body() {
     let app = router(AppState {
         brain,
         token: "operator-token".into(),
+        require_tenant: false,
     });
     let polls = Arc::new(AtomicUsize::new(0));
     let observed = polls.clone();
@@ -60,6 +61,23 @@ async fn unauthenticated_create_never_polls_the_body() {
     let response = app.oneshot(request(body, None)).await.unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(polls.load(Ordering::Relaxed), 0);
+}
+
+#[tokio::test]
+async fn a_tenanted_composition_refuses_requests_without_the_tenant_header() {
+    let temp = TempDir::new("require-tenant");
+    let brain = Brain::in_memory_test(temp.0.clone(), BrainConfig::default()).unwrap();
+    let app = router(AppState {
+        brain,
+        token: "operator-token".into(),
+        require_tenant: true,
+    });
+    // Authenticated but header-less: booked to no tenant, refused — never tenant "local".
+    let response = app
+        .oneshot(request(Body::from("{}"), Some("operator-token")))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]
@@ -76,6 +94,7 @@ async fn saturated_create_admission_rejects_before_polling_another_body() {
     let app = router(AppState {
         brain,
         token: "operator-token".into(),
+        require_tenant: false,
     });
 
     let first_polled = Arc::new(Notify::new());

--- a/crates/brain/tests/create_idempotency.rs
+++ b/crates/brain/tests/create_idempotency.rs
@@ -32,6 +32,7 @@ async fn create_replays_one_session_and_rejects_key_reuse_with_another_body() {
     let app = brain::api::router(brain::api::AppState {
         brain,
         token: token.clone(),
+        require_tenant: false,
     });
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
@@ -118,6 +119,7 @@ async fn create_session_accepts_tool_bundle_sized_http_bodies() {
     let app = brain::api::router(brain::api::AppState {
         brain,
         token: token.clone(),
+        require_tenant: false,
     });
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 

--- a/crates/brain/tests/discard_race.rs
+++ b/crates/brain/tests/discard_race.rs
@@ -41,6 +41,7 @@ async fn a_message_racing_the_idle_discard_always_lands() {
     let app = brain::api::router(brain::api::AppState {
         brain,
         token: token.clone(),
+        require_tenant: false,
     });
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     let http = reqwest::Client::new();

--- a/crates/brain/tests/external_e2e.rs
+++ b/crates/brain/tests/external_e2e.rs
@@ -182,6 +182,7 @@ async fn repair_then_return_direct_completes_without_an_extra_model_round() {
     let app = brain::api::router(brain::api::AppState {
         brain,
         token: token.into(),
+        require_tenant: false,
     });
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
     let client = reqwest::Client::new();

--- a/crates/brain/tests/message_idempotency.rs
+++ b/crates/brain/tests/message_idempotency.rs
@@ -71,6 +71,7 @@ async fn message_key_replays_while_active_after_completion_and_after_cold_hydrat
     let app = brain::api::router(brain::api::AppState {
         brain,
         token: token.clone(),
+        require_tenant: false,
     });
     tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 

--- a/packages/brain/schemas/session.v1.json
+++ b/packages/brain/schemas/session.v1.json
@@ -496,6 +496,9 @@
         "failure": {
           "$ref": "#/$defs/SessionFailure"
         },
+        "agentloop": {
+          "$ref": "#/$defs/AgentloopInfo"
+        },
         "metadata": {
           "type": "object",
           "maxProperties": 16,
@@ -609,6 +612,82 @@
         "submit_retries": { "type": "integer", "minimum": 0, "maximum": 8, "default": 1 }
       }
     },
+    "AgentloopConfig": {
+      "description": "Which agentloop drives this session's turns. Sealed at create for the life of the session; children inherit the parent's loop. Omission seals the official aex loop.",
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+          "description": "An official loop by name (e.g. \"aex\", \"pi\"), resolved to the composition's pinned version and sealed as (name, version)."
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source_bundle_sha256", "toolchain", "bundle_base64"],
+          "description": "A customer loop. The sealed identity is (source-bundle digest, toolchain); the composition componentizes the bundle server-side, cached by that pair.",
+          "properties": {
+            "source_bundle_sha256": {
+              "$ref": "#/$defs/Sha256Hex"
+            },
+            "toolchain": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+              "description": "The pinned loop-toolchain identity the bundle was built for."
+            },
+            "bundle_base64": {
+              "type": "string",
+              "maxLength": 11184812,
+              "writeOnly": true,
+              "description": "The deterministic esbuild source bundle, base64 (8 MiB decoded maximum). Create-time-only: staged outside the journal, never part of the model prefix."
+            }
+          }
+        }
+      ]
+    },
+    "AgentloopInfo": {
+      "description": "The sealed agentloop identity of a session.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "name", "version"],
+          "properties": {
+            "kind": { "type": "string", "const": "official" },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+            },
+            "version": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "source_bundle_sha256", "toolchain"],
+          "properties": {
+            "kind": { "type": "string", "const": "custom" },
+            "source_bundle_sha256": { "$ref": "#/$defs/Sha256Hex" },
+            "toolchain": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+            }
+          }
+        }
+      ]
+    },
     "ChildLimits": {
       "type": "object",
       "additionalProperties": false,
@@ -692,6 +771,9 @@
         },
         "client": {
           "$ref": "#/$defs/CustomerClientConfig"
+        },
+        "agentloop": {
+          "$ref": "#/$defs/AgentloopConfig"
         },
         "children": {
           "$ref": "#/$defs/ChildLimits"
@@ -1655,6 +1737,51 @@
             },
             "error": {
               "$ref": "#/$defs/ApiError"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "seq",
+            "at",
+            "session_id",
+            "turn_id",
+            "name",
+            "data"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "loop.event"
+              ]
+            },
+            "seq": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "at": {
+              "$ref": "#/$defs/Timestamp"
+            },
+            "session_id": {
+              "$ref": "#/$defs/SessionId"
+            },
+            "turn_id": {
+              "$ref": "#/$defs/TurnId"
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+              "description": "Loop-chosen event name."
+            },
+            "data": {
+              "type": "object",
+              "additionalProperties": true,
+              "description": "The loop-authored event payload, journaled as a loop `event` entry before it is delivered."
             }
           }
         }

--- a/packages/brain/src/generated/paths.ts
+++ b/packages/brain/src/generated/paths.ts
@@ -961,6 +961,19 @@ export type components = {
             message: string;
             at: components["schemas"]["Timestamp"];
         };
+        Sha256Hex: string;
+        /** @description The sealed agentloop identity of a session. */
+        AgentloopInfo: {
+            /** @constant */
+            kind: "official";
+            name: string;
+            version: string;
+        } | {
+            /** @constant */
+            kind: "custom";
+            source_bundle_sha256: components["schemas"]["Sha256Hex"];
+            toolchain: string;
+        };
         Session: {
             id: components["schemas"]["SessionId"];
             parent_id?: components["schemas"]["SessionId"];
@@ -990,6 +1003,7 @@ export type components = {
             turns: number;
             current_turn?: components["schemas"]["TurnId"];
             failure?: components["schemas"]["SessionFailure"];
+            agentloop?: components["schemas"]["AgentloopInfo"];
             /** @description Customer key/value; up to 16 pairs. */
             metadata: {
                 [key: string]: string;
@@ -1024,7 +1038,6 @@ export type components = {
             reasoning_effort?: "low" | "medium" | "high";
         };
         ToolName: string;
-        Sha256Hex: string;
         /** @description The model-visible half of one Tool. Array order is preserved exactly in the immutable model prefix. */
         ToolDefinition: {
             name: components["schemas"]["ToolName"];
@@ -1102,6 +1115,14 @@ export type components = {
             /** @default 1 */
             submit_retries?: number;
         };
+        /** @description Which agentloop drives this session's turns. Sealed at create for the life of the session; children inherit the parent's loop. Omission seals the official aex loop. */
+        AgentloopConfig: string | {
+            source_bundle_sha256: components["schemas"]["Sha256Hex"];
+            /** @description The pinned loop-toolchain identity the bundle was built for. */
+            toolchain: string;
+            /** @description The deterministic esbuild source bundle, base64 (8 MiB decoded maximum). Create-time-only: staged outside the journal, never part of the model prefix. */
+            bundle_base64: string;
+        };
         ChildLimits: {
             /** @default 4 */
             max_depth?: number;
@@ -1125,6 +1146,7 @@ export type components = {
             /** @default 1 */
             provider_recovery_retries?: number;
             client?: components["schemas"]["CustomerClientConfig"];
+            agentloop?: components["schemas"]["AgentloopConfig"];
             children?: components["schemas"]["ChildLimits"];
             metadata?: {
                 [key: string]: string;
@@ -1355,6 +1377,19 @@ export type components = {
             session_id: components["schemas"]["SessionId"];
             turn_id: components["schemas"]["TurnId"];
             error: components["schemas"]["ApiError"];
+        } | {
+            /** @enum {string} */
+            type: "loop.event";
+            seq: number;
+            at: components["schemas"]["Timestamp"];
+            session_id: components["schemas"]["SessionId"];
+            turn_id: components["schemas"]["TurnId"];
+            /** @description Loop-chosen event name. */
+            name: string;
+            /** @description The loop-authored event payload, journaled as a loop `event` entry before it is delivered. */
+            data: {
+                [key: string]: unknown;
+            };
         };
         /** @enum {string} */
         TargetKind: "default" | "additional";

--- a/packages/brain/src/generated/session.ts
+++ b/packages/brain/src/generated/session.ts
@@ -98,6 +98,23 @@ export type ExternalToolEffect = "opaque" | "replay_safe";
  */
 export type ToolExecutor = AexManagedToolExecutor | CustomerAppToolExecutor | EngineToolExecutor;
 /**
+ * The sealed agentloop identity of a session.
+ *
+ * This interface was referenced by `BrainSessionAPIV1Types`'s JSON-Schema
+ * via the `definition` "AgentloopInfo".
+ */
+export type AgentloopInfo =
+  | {
+      kind: "official";
+      name: string;
+      version: string;
+    }
+  | {
+      kind: "custom";
+      source_bundle_sha256: Sha256Hex;
+      toolchain: string;
+    };
+/**
  * Immutable direct outbound ceiling. Omission means none.
  *
  * This interface was referenced by `BrainSessionAPIV1Types`'s JSON-Schema
@@ -158,6 +175,25 @@ export type NetworkPolicy =
             }
         )[]
       ];
+    };
+/**
+ * Which agentloop drives this session's turns. Sealed at create for the life of the session; children inherit the parent's loop. Omission seals the official aex loop.
+ *
+ * This interface was referenced by `BrainSessionAPIV1Types`'s JSON-Schema
+ * via the `definition` "AgentloopConfig".
+ */
+export type AgentloopConfig =
+  | string
+  | {
+      source_bundle_sha256: Sha256Hex;
+      /**
+       * The pinned loop-toolchain identity the bundle was built for.
+       */
+      toolchain: string;
+      /**
+       * The deterministic esbuild source bundle, base64 (8 MiB decoded maximum). Create-time-only: staged outside the journal, never part of the model prefix.
+       */
+      bundle_base64: string;
     };
 /**
  * This interface was referenced by `BrainSessionAPIV1Types`'s JSON-Schema
@@ -387,6 +423,23 @@ export type Event =
       session_id: SessionId;
       turn_id: TurnId;
       error: ApiError1;
+    }
+  | {
+      type: "loop.event";
+      seq: number;
+      at: Timestamp;
+      session_id: SessionId;
+      turn_id: TurnId;
+      /**
+       * Loop-chosen event name.
+       */
+      name: string;
+      /**
+       * The loop-authored event payload, journaled as a loop `event` entry before it is delivered.
+       */
+      data: {
+        [k: string]: unknown | undefined;
+      };
     };
 
 /**
@@ -584,6 +637,7 @@ export interface Session {
   turns: number;
   current_turn?: TurnId;
   failure?: SessionFailure;
+  agentloop?: AgentloopInfo;
   /**
    * Customer key/value; up to 16 pairs.
    */
@@ -658,6 +712,7 @@ export interface CreateSessionRequest {
   network?: NetworkPolicy;
   provider_recovery_retries?: number;
   client?: CustomerClientConfig;
+  agentloop?: AgentloopConfig;
   children?: ChildLimits;
   metadata?: {
     [k: string]: string | undefined;


### PR DESCRIPTION
Findings B3-B7 of the 2026-08-22 audit (aex-research docs/audit-2026-08-22.md), owner verdict: strict pass, fail fast in hosted mode, fix all deadlines and constants.

- session_doc errors name the corrupt field — no placeholder ids, no omitted sealed loop identity; loop entry data typed as the contract's object shape; timestamps/seqs panic on corruption instead of fabricating now/1; None==None no longer reports a bundle match; dead .max(1) clamps removed; SSE projection drops carry deliberate-drop comments.
- Hosted fail-fast: AWS_REGION required at boot; x-brain-tenant-id refused when absent behind AppState.require_tenant (new field, tested; local mode keeps its default).
- Deadlines: wire connect/hello 10s, 120s activation idle limit, componentize spawn already bounded in #21.
- One authority per constant: MAX_CTX_OP_BYTES imported, 8 MiB bundle bound pinned to the frozen contract by test, componentize-one asserts the installed componentizer matches the toolchain string it seals.
- @aexhq/brain generated types regenerated (previously could not express agentloop) + CI gen-and-diff gate.
- Folded nits: strict Last-Event-ID, wait_child ceiling rejects, S3 HEAD/Dynamo recovery fail closed, contract-envelope diagnostics.

Note: brain-standalone's local-sandbox bash test fails on this Windows dev machine (spawn os error 267) before and after this change; Linux CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)