### PR TITLE
brain(npm): 0.3.0 — the published types can express agentloop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2307,7 +2307,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -2330,7 +2329,7 @@
     },
     "packages/brain": {
       "name": "@aexhq/brain",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.25.9"
@@ -2361,6 +2360,21 @@
         "@types/node": "^24.3.0",
         "typescript": "^5.9.2",
         "zod": "4.4.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "zod": ">=4.4.3 <5"
+      }
+    },
+    "packages/brain-tools/node_modules/@aexhq/brain": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aexhq/brain/-/brain-0.2.0.tgz",
+      "integrity": "sha512-oBVrVNLzmkMObIToHGU5WyV8XFdGHZkYHJc6J/u738u4YXQkLlf/YhX2JVMWE13d5yFCQOmKk2nATxDHVuZLtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esbuild": "0.25.9"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Client, tool authoring API, and local builder for the independent Brain session server",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Release step: @aexhq/brain 0.2.0 is immutable and predates the agentloop-capable regenerated types; 0.3.0 carries them. No code change beyond the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)