### PR TITLE
tools: preserve portable contracts after bundling

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,14 @@ on:
         description: Exact 40-character Brain commit selected by the workflow ref
         type: string
         required: true
+      release_scope:
+        description: Package set to stage; promotion always consumes the selected stage artifact
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - brain-tools
       stage_run_id:
         description: Successful stage workflow run containing the immutable archives (promote only)
         type: string
@@ -97,9 +105,15 @@ jobs:
         shell: bash
         env:
           EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          RELEASE_SCOPE: ${{ inputs.release_scope }}
         run: |
           set -euo pipefail
           release_dir="$RUNNER_TEMP/brain-npm-release"
+          case "$RELEASE_SCOPE" in
+            all) unset RELEASE_WORKSPACES ;;
+            brain-tools) export RELEASE_WORKSPACES=brain-tools ;;
+            *) echo "unsupported release scope: $RELEASE_SCOPE" >&2; exit 1 ;;
+          esac
           node tools/npm-release.mjs pack "$release_dir"
           versions=$(node tools/npm-release.mjs versions "$release_dir/manifest.json")
           echo "versions=$versions" >> "$GITHUB_OUTPUT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2351,7 +2351,7 @@
     },
     "packages/brain-tools": {
       "name": "@aexhq/brain-tools",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aexhq/brain": "0.2.0"

--- a/packages/brain-tools/package.json
+++ b/packages/brain-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain-tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Portable, explicit Tool values for Brain",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/brain-tools/src/bash.ts
+++ b/packages/brain-tools/src/bash.ts
@@ -59,6 +59,7 @@ const bash = tool(bashInput, async function bash(input, context) {
       timer.unref();
     });
   })
+  .named("bash")
   .describe("Run a Bash command in the session Hand workspace.")
   .returns(bashOutput)
   .server(import.meta.url);

--- a/packages/brain-tools/src/edit.ts
+++ b/packages/brain-tools/src/edit.ts
@@ -19,6 +19,7 @@ const edit = tool(editInput, async function edit({ path, old_text, new_text }, c
     await writeFile(target, `${content.slice(0, first)}${new_text}${content.slice(first + old_text.length)}`, "utf8");
     return { path, replacements: 1 as const };
   })
+  .named("edit")
   .describe("Replace one exact occurrence of text in a Hand workspace file.")
   .returns(editOutput)
   .server(import.meta.url);

--- a/packages/brain-tools/src/glob.ts
+++ b/packages/brain-tools/src/glob.ts
@@ -19,6 +19,7 @@ const glob = tool(globInput, async function glob({ pattern, limit }, context) {
     paths.sort();
     return { paths: paths.slice(0, limit), truncated: paths.length > limit };
   })
+  .named("glob")
   .describe("List Hand workspace paths matching a glob pattern.")
   .returns(globOutput)
   .server(import.meta.url);

--- a/packages/brain-tools/src/grep.ts
+++ b/packages/brain-tools/src/grep.ts
@@ -27,6 +27,7 @@ const grep = tool(grepInput, async function grep({ pattern, path, limit }, conte
       });
     });
   })
+  .named("grep")
   .describe("Search text files in the Hand workspace with ripgrep.")
   .returns(grepOutput)
   .server(import.meta.url);

--- a/packages/brain-tools/src/ls.ts
+++ b/packages/brain-tools/src/ls.ts
@@ -18,6 +18,7 @@ const ls = tool(lsInput, async function ls({ path, limit }, context) {
       truncated: values.length > limit,
     };
   })
+  .named("ls")
   .describe("List entries in a Hand workspace directory.")
   .returns(lsOutput)
   .server(import.meta.url);

--- a/packages/brain-tools/src/read.ts
+++ b/packages/brain-tools/src/read.ts
@@ -24,6 +24,7 @@ const read = tool(readInput, async function read({ path, offset, limit }, contex
       await file.close();
     }
   })
+  .named("read")
   .describe("Read UTF-8 text from a file in the Hand workspace.")
   .returns(readOutput)
   .server(import.meta.url);

--- a/packages/brain-tools/src/subagents.ts
+++ b/packages/brain-tools/src/subagents.ts
@@ -3,25 +3,36 @@ import { z } from "zod";
 
 const childId = z.string().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/);
 const message = z.string().min(1).max(192 * 1024);
+const forkTurns = z.union([
+  z.literal("all"),
+  z.literal("none"),
+  z.string().max(10).regex(/^[1-9][0-9]*$/),
+]);
 
 const subagents = officialTool({
   name: "subagents",
   description: "Create and explicitly interact with durable direct child sessions.",
-  input: z.discriminatedUnion("action", [
-    z.object({
-      action: z.literal("spawn_agent"),
-      task_name: z.string().min(1).max(128),
-      message,
-      fork_turns: z.union([z.literal("all"), z.literal("none"), z.string().max(10).regex(/^[1-9][0-9]*$/)]).optional(),
-    }),
-    z.object({ action: z.literal("send_message"), child_id: childId, message }),
-    z.object({ action: z.literal("follow_up"), child_id: childId, message }),
-    z.object({ action: z.literal("wait"), child_id: childId, timeout_ms: z.number().int().nonnegative().max(300_000).optional() }),
-    z.object({ action: z.literal("peek"), child_id: childId }),
-    z.object({ action: z.literal("list_children"), cursor: z.string().max(4096).optional(), limit: z.number().int().positive().max(100).optional() }),
-    z.object({ action: z.literal("interrupt_agent"), child_id: childId }),
-    z.object({ action: z.literal("end_agent"), child_id: childId }),
-  ]),
+  // Keep one provider-friendly object schema. Brain's intrinsic dispatcher remains authoritative
+  // for which fields each action requires and ignores irrelevant optional fields.
+  input: z.object({
+    action: z.enum([
+      "spawn_agent",
+      "send_message",
+      "follow_up",
+      "wait",
+      "peek",
+      "list_children",
+      "interrupt_agent",
+      "end_agent",
+    ]),
+    task_name: z.string().min(1).max(128).optional(),
+    message: message.optional(),
+    fork_turns: forkTurns.optional(),
+    child_id: childId.optional(),
+    timeout_ms: z.number().int().nonnegative().max(300_000).optional(),
+    cursor: z.string().max(4096).optional(),
+    limit: z.number().int().positive().max(100).optional(),
+  }),
   output: z.unknown(),
   capability: "brain.subagents",
 });

--- a/packages/brain-tools/src/todo.ts
+++ b/packages/brain-tools/src/todo.ts
@@ -28,6 +28,7 @@ const todo = tool(todoInput, async function todo(input, context) {
       throw error;
     }
   })
+  .named("todo")
   .describe("Read or replace the session's portable to-do list.")
   .returns(todoOutput)
   .server(import.meta.url);

--- a/packages/brain-tools/src/write.ts
+++ b/packages/brain-tools/src/write.ts
@@ -15,6 +15,7 @@ const write = tool(writeInput, async function write({ path, content }, context) 
     await writeFile(target, content, "utf8");
     return { path, bytes: Buffer.byteLength(content) };
   })
+  .named("write")
   .describe("Write UTF-8 text to a file in the Hand workspace, creating parent directories.")
   .returns(writeOutput)
   .server(import.meta.url);

--- a/packages/brain-tools/test/tools.test.mjs
+++ b/packages/brain-tools/test/tools.test.mjs
@@ -12,3 +12,33 @@ test("portable tools are ordinary ordered Brain Tool values", async () => {
   assert.equal(compiled.items.at(-1).executor.kind, "engine");
   assert.equal(compiled.bundles.length, values.length - 3);
 });
+
+test("portable managed tools survive exact minified bundle evaluation", async () => {
+  const managed = [bash, read, write, edit, glob, grep, ls, todo];
+  const compiled = await compileTools(managed);
+  assert.equal(compiled.bundles.length, managed.length);
+
+  for (const [index, bundle] of compiled.bundles.entries()) {
+    const loaded = await import(`data:text/javascript;base64,${bundle.content_base64}`);
+    assert.equal(loaded.default.kind, "brain.tool-runtime");
+    assert.equal(loaded.default.name, managed[index].name);
+    assert.equal(typeof loaded.default.execute, "function");
+  }
+});
+
+test("subagents exposes one provider-friendly action object", async () => {
+  const compiled = await compileTools([subagents]);
+  const schema = compiled.items[0].definition.input_schema;
+  assert.equal(schema.type, "object");
+  assert.equal(schema.oneOf, undefined);
+  assert.doesNotThrow(() => subagents.input.parse({
+    action: "spawn_agent",
+    task_name: "smoke",
+    message: "Reply CHILD_OK",
+    fork_turns: "none",
+    child_id: "unused",
+    timeout_ms: 1,
+    cursor: "",
+    limit: 1,
+  }));
+});

--- a/tools/npm-release.mjs
+++ b/tools/npm-release.mjs
@@ -7,7 +7,15 @@ import process from "node:process";
 
 // Dependency order: the loop packages build against @aexhq/agentloop, so the SDK publishes
 // (and becomes registry-visible) first.
-const workspaces = ["brain", "brain-tools", "agentloop", "loop-pi", "loop-codex"];
+const allWorkspaces = ["brain", "brain-tools", "agentloop", "loop-pi", "loop-codex"];
+const requestedWorkspaces = process.env.RELEASE_WORKSPACES?.split(",").filter(Boolean);
+const workspaces = requestedWorkspaces?.length ? requestedWorkspaces : allWorkspaces;
+if (
+  new Set(workspaces).size !== workspaces.length ||
+  workspaces.some((workspace) => !allWorkspaces.includes(workspace))
+) {
+  throw new Error(`invalid RELEASE_WORKSPACES: ${process.env.RELEASE_WORKSPACES}`);
+}
 const root = path.resolve(import.meta.dirname, "..");
 const npmCli = [
   process.env.npm_execpath,


### PR DESCRIPTION
## Summary
- give every portable managed Tool an explicit stable name so minification cannot erase it
- expose subagent actions as one provider-friendly object while keeping Brain's intrinsic per-action validation authoritative
- allow the trusted npm stage workflow to publish the narrow brain-tools compatibility line without staging unrelated workspaces

## Evidence
- npm test
- npm run package-smoke
- actionlint .github/workflows/npm-publish.yml
- selective brain-tools release pack smoke
- git diff --check