### PR TITLE
runtime: cancelled managed submits journal before cleanup

### DIFF
--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -4344,11 +4344,13 @@ async fn settle_running(
                 outcome: Err(error),
                 ..
             },
-        )) if st.head.active_phase == Some(TurnPhase::ManagedRunning)
-            && matches!(
-                error,
-                BrainError::HandUnavailable(_) | BrainError::Cancelled
-            ) =>
+        )) if matches!(
+            st.head.active_phase,
+            Some(TurnPhase::ManagedRunning | TurnPhase::ManagedCancelling)
+        ) && matches!(
+            error,
+            BrainError::HandUnavailable(_) | BrainError::Cancelled
+        ) =>
         {
             // The managed intent is already durable and the effect may have crossed the Hand
             // boundary. Never manufacture a failed turn here. Release the lease with a due

--- a/crates/brain/src/session/recovery.rs
+++ b/crates/brain/src/session/recovery.rs
@@ -530,6 +530,8 @@ pub(super) async fn recover_managed_calls(
     let active_turn = resident.st.head.turn.clone();
     let rounds = resident.st.head.active_rounds;
     let tool_calls = resident.st.head.active_tool_calls;
+    let cancellation_requested =
+        resident.st.head.active_phase == Some(TurnPhase::ManagedCancelling);
     let mut recovered = Vec::new();
     let mut sandbox_gone = None;
 
@@ -748,8 +750,60 @@ pub(super) async fn recover_managed_calls(
         }
 
         crate::turn::verify_managed_observation(&observation, &operation)?;
+        if cancellation_requested && observation.state != OperationState::Terminal {
+            let cancel: brain_protocol::hand::CancelRequest =
+                serde_json::from_value(serde_json::json!({
+                    "operation": operation,
+                    "reason": "turn_cancelled",
+                }))?;
+            match hand.cancel(cancel).await {
+                Ok(_) => {}
+                Err(error) if error.code == HandErrorCode::OperationUnknown => {
+                    let unknown = vec![(
+                        resident.st.take_seq(),
+                        Record::ManagedCallUnknown {
+                            turn: call.turn.clone(),
+                            call: call.call.clone(),
+                            request_digest: call.envelope.request_digest.to_string(),
+                        },
+                    )];
+                    commit(brain, session_id, &mut resident.st, unknown).await?;
+                    reconcile_managed_unknown_default_sandbox(brain, session_id, &mut resident.st)
+                        .await?;
+                    recovered.push((
+                        call.clone(),
+                        Some(operation),
+                        crate::turn::managed_unknown_call_outcome(&call.name),
+                        None,
+                    ));
+                    continue 'managed_calls;
+                }
+                Err(error) if error.code == HandErrorCode::SandboxGone => {
+                    sandbox_gone = Some(managed_operation_gone_status(&operation)?);
+                    recovered.push((
+                        call,
+                        Some(operation),
+                        CallOutcome {
+                            outcome: TerminalOutcome::Interrupted,
+                            value: None,
+                            content:
+                                "managed Tool target disappeared while cancellation was pending"
+                                    .into(),
+                            is_error: true,
+                            exit_code: None,
+                            duration_ms: 0,
+                            truncated: false,
+                            terminal: None,
+                        },
+                        None,
+                    ));
+                    continue 'managed_calls;
+                }
+                Err(error) => return Err(map_hand_port_error(error)),
+            }
+        }
         if observation.state != OperationState::Terminal {
-            if crate::wall_ms() >= call.envelope.deadline_at_ms.get() {
+            if !cancellation_requested && crate::wall_ms() >= call.envelope.deadline_at_ms.get() {
                 let cancel: brain_protocol::hand::CancelRequest =
                     serde_json::from_value(serde_json::json!({
                         "operation": operation,
@@ -882,7 +936,33 @@ pub(super) async fn recover_managed_calls(
             Record::DefaultSandboxChanged { status },
         ));
     }
-    if let Some((call, name, terminal)) = terminal {
+    if cancellation_requested {
+        let turn = active_turn.expect("pending managed cancellation required an active turn");
+        resident.st.head.state = resident.st.head.lifecycle_after_turn();
+        resident.st.head.turn = None;
+        resident.st.head.active_phase = None;
+        resident.st.head.provider_attempt = None;
+        resident.st.head.active_context.clear();
+        resident.st.head.active_rounds = 0;
+        resident.st.head.active_tool_calls = 0;
+        records.push((
+            resident.st.take_seq(),
+            Record::TurnCompleted {
+                turn,
+                stop_reason: TurnStopReason::Cancelled,
+                rounds,
+                tool_calls,
+                result: None,
+            },
+        ));
+        records.push((
+            resident.st.take_seq(),
+            Record::State {
+                state: resident.st.head.state,
+                turn: None,
+            },
+        ));
+    } else if let Some((call, name, terminal)) = terminal {
         let turn = active_turn.expect("pending managed call required an active turn");
         resident.st.head.state = resident.st.head.lifecycle_after_turn();
         resident.st.head.turn = None;

--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -1114,6 +1114,9 @@ struct UnknownManagedPorts {
     status_calls: AtomicUsize,
     dematerialize_calls: AtomicUsize,
     fail_next_dematerialize: AtomicBool,
+    block_submit: AtomicBool,
+    submit_started: tokio::sync::Notify,
+    release_submit: tokio::sync::Notify,
 }
 
 struct ScriptedCompactor {
@@ -1335,6 +1338,10 @@ impl crate::hand::HandPort for UnknownManagedPorts {
         _request: brain_protocol::hand::SubmitRequest,
     ) -> crate::hand::HandResult<brain_protocol::hand::SubmitReceipt> {
         self.submits.fetch_add(1, Ordering::AcqRel);
+        if self.block_submit.load(Ordering::Acquire) {
+            self.submit_started.notify_one();
+            self.release_submit.notified().await;
+        }
         Err(serde_json::from_value(json!({
             "code":"operation_unknown",
             "message":"guest Submit may have run before the physical generation was lost",
@@ -3238,11 +3245,27 @@ async fn journaled_customer_terminal_is_reacked_after_process_restart() {
 
 #[tokio::test]
 async fn managed_submit_unknown_survives_cleanup_crash_without_resubmission() {
-    let journal = Journal::new_memory("brain-managed-submit-unknown");
+    assert_managed_submit_unknown_recovery(false).await;
+}
+
+#[tokio::test]
+async fn cancelled_managed_submit_stays_cancelled_across_cleanup_crash() {
+    assert_managed_submit_unknown_recovery(true).await;
+}
+
+async fn assert_managed_submit_unknown_recovery(cancellation_requested: bool) {
+    let case = if cancellation_requested {
+        "brain-managed-submit-cancelled"
+    } else {
+        "brain-managed-submit-unknown"
+    };
+    let journal = Journal::new_memory(case);
     let ports = Arc::new(UnknownManagedPorts::default());
     ports.fail_next_dematerialize.store(true, Ordering::Release);
     let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
-    fake.script([Scripted::Text("continued after an honest unknown".into())]);
+    if !cancellation_requested {
+        fake.script([Scripted::Text("continued after an honest unknown".into())]);
+    }
     let provider = fake.clone();
     let brain = Brain::with_parts_and_services(
         BrainConfig {
@@ -3315,7 +3338,11 @@ async fn managed_submit_unknown_survives_cleanup_crash_without_resubmission() {
     resident.managed_bindings = Arc::new(HashMap::from([(name.clone(), binding)]));
     resident.st.head.state = SessionLifecycle::Open;
     resident.st.head.turn = Some(turn.clone());
-    resident.st.head.active_phase = Some(TurnPhase::ManagedRunning);
+    resident.st.head.active_phase = Some(if cancellation_requested {
+        TurnPhase::ManagedCancelling
+    } else {
+        TurnPhase::ManagedRunning
+    });
     resident.st.head.active_rounds = 1;
     resident.st.head.active_tool_calls = 1;
     resident.st.head.turns += 1;
@@ -3421,7 +3448,7 @@ async fn managed_submit_unknown_survives_cleanup_crash_without_resubmission() {
             idle_discard: Duration::from_secs(300),
             ..BrainConfig::default()
         },
-        journal.cloned_as("brain-managed-submit-unknown-restart"),
+        journal.cloned_as(format!("{case}-restart")),
         Arc::new(crate::keys::PlainCustody),
         Arc::new(crate::adapter::DisabledToolExecutor),
         BrainServices {
@@ -3464,8 +3491,27 @@ async fn managed_submit_unknown_survives_cleanup_crash_without_resubmission() {
             .count(),
         1
     );
-    fake.assert_drained(1, "managed OperationUnknown recovery")
-        .unwrap();
+    let expected_stop = if cancellation_requested {
+        TurnStopReason::Cancelled
+    } else {
+        TurnStopReason::EndTurn
+    };
+    assert_eq!(
+        final_records
+            .iter()
+            .filter(|entry| matches!(
+                &entry.record,
+                Record::TurnCompleted { stop_reason, .. } if *stop_reason == expected_stop
+            ))
+            .count(),
+        1,
+        "the recovered turn must preserve its requested terminal disposition"
+    );
+    fake.assert_drained(
+        u64::from(!cancellation_requested),
+        "managed OperationUnknown recovery",
+    )
+    .unwrap();
     recovering
         .journal
         .release(&session_id, &recovered.st.lease)
@@ -5486,4 +5532,143 @@ async fn storage_upload_reservation_is_durable_bounded_and_retried_after_restart
         .collect();
     assert_eq!(gauges, vec![(0, 8), (0, 0)]);
     let _ = std::fs::remove_dir_all(data_dir);
+}
+
+#[tokio::test]
+async fn cancellation_during_managed_submit_is_durable_before_cleanup() {
+    let journal = Journal::new_memory("brain-managed-submit-live-cancel");
+    let ports = Arc::new(UnknownManagedPorts::default());
+    ports.block_submit.store(true, Ordering::Release);
+    let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+    let name = "managed_cancel_test".to_owned();
+    fake.script([Scripted::tool(&name, json!({"sleep":30}))]);
+    let provider = fake.clone();
+    let brain = Brain::with_parts_and_services(
+        BrainConfig {
+            idle_discard: Duration::from_secs(300),
+            ..BrainConfig::default()
+        },
+        journal.clone(),
+        Arc::new(crate::keys::PlainCustody),
+        Arc::new(crate::adapter::DisabledToolExecutor),
+        BrainServices {
+            hand: Some(ports.clone()),
+            session_preparation: Some(ports.clone()),
+            sandbox_files: Some(ports.clone()),
+            ..BrainServices::default()
+        },
+        Arc::new(move |_| provider.clone()),
+    );
+    let created = brain
+        .create_session(
+            typed_create(json!({
+                "model":{"provider":"anthropic","name":"managed-cancel","api_key":"key"}
+            })),
+            Some("managed-submit-live-cancel"),
+        )
+        .await
+        .expect("create live cancellation session");
+    let session_id = created.id.to_string();
+    let mut resident = hydrate(&brain, &session_id)
+        .await
+        .expect("claim live cancellation session");
+    let bundle_digest = "a".repeat(64);
+    resident.st.head.prefix.hand_enabled = true;
+    resident.st.head.prefix.tools = serde_json::from_value(json!([{
+        "definition": {
+            "name":name,
+            "description":"block until cancellation",
+            "contract_digest":"b".repeat(64),
+            "input_schema":{"type":"object"},
+            "output_schema":{}
+        },
+        "executor": {
+            "kind":"aex_managed",
+            "bundle_digest":bundle_digest,
+            "required_env":[]
+        }
+    }]))
+    .expect("managed Tool seal");
+    let binding: brain_protocol::hand::ResolvedBinding = serde_json::from_value(json!({
+        "binding_ref":"bnd_managedcancel0000",
+        "capabilities":["execution","session_preparation"],
+        "hand_id":"hand_managedcancel",
+        "limits":{
+            "max_inline_input_bytes":brain_protocol::MAX_MANAGED_TOOL_INPUT_BYTES,
+            "max_inline_result_bytes":brain_protocol::MAX_TOOL_TERMINAL_INLINE_BYTES,
+            "max_wait_ms":1
+        },
+        "realm":"aex_managed",
+        "recovery":"retained"
+    }))
+    .expect("valid managed binding");
+    resident.managed_bindings = Arc::new(HashMap::from([(name, binding)]));
+
+    let content = vec![ContentBlock::text("run the managed effect")];
+    let (turn, user_seq, cancel) = admit(
+        &brain,
+        &session_id,
+        &mut resident,
+        content.clone(),
+        HashMap::new(),
+        None,
+    )
+    .await
+    .expect("admit managed turn");
+    let run = turn_run(
+        &brain,
+        &session_id,
+        &turn,
+        &resident,
+        HashMap::new(),
+        cancel.clone(),
+        Some(crate::turn::AdmittedMessage {
+            seq: user_seq,
+            at_ms: crate::wall_ms(),
+            content,
+        }),
+    )
+    .expect("build managed turn");
+    let mut state = resident.st;
+    let running = tokio::spawn(async move {
+        let outcome = run.run(&mut state).await;
+        (state, outcome)
+    });
+    tokio::time::timeout(Duration::from_secs(5), ports.submit_started.notified())
+        .await
+        .expect("managed Submit began");
+    cancel.cancel();
+
+    let (state, report) = tokio::time::timeout(Duration::from_secs(5), running)
+        .await
+        .expect("cancelled managed turn completed")
+        .expect("managed turn task");
+    let report = report.expect("cancelled turn report");
+    assert_eq!(report.stop_reason, TurnStopReason::Cancelled);
+    assert_eq!(ports.submits.load(Ordering::Acquire), 1);
+    let records = journal.read_records(&session_id, 0).await.unwrap();
+    assert_eq!(
+        records
+            .iter()
+            .filter(|entry| matches!(entry.record, Record::ManagedCallUnknown { .. }))
+            .count(),
+        1,
+        "cancellation durably revokes every future Submit replay"
+    );
+    assert_eq!(
+        records
+            .iter()
+            .filter(|entry| matches!(
+                &entry.record,
+                Record::TurnCompleted { stop_reason, .. }
+                    if *stop_reason == TurnStopReason::Cancelled
+            ))
+            .count(),
+        1
+    );
+    fake.assert_drained(1, "live managed cancellation").unwrap();
+    journal
+        .release(&session_id, &state.lease)
+        .await
+        .expect("release cancelled managed turn owner");
 }

--- a/crates/brain/src/turn.rs
+++ b/crates/brain/src/turn.rs
@@ -2543,7 +2543,11 @@ impl TurnRun {
                 result = submit => result.map_err(|_| BrainError::HandUnavailable(
                     "managed Tool submit exceeded its sealed deadline".into()
                 ))?,
-                () = self.cancel.cancelled() => return Err(BrainError::Cancelled),
+                () = self.cancel.cancelled() => {
+                    return self
+                        .finish_managed_submit_unknown(st, operation_id, name, &request_digest)
+                        .await;
+                }
             };
             match result {
                 Ok(receipt) => break receipt,
@@ -2663,6 +2667,8 @@ impl TurnRun {
                 ));
             }
             if self.cancel.is_cancelled() && !cancellation_sent {
+                st.head.active_phase = Some(TurnPhase::ManagedCancelling);
+                self.commit(st, vec![]).await?;
                 let request: brain_protocol::hand::CancelRequest =
                     serde_json::from_value(serde_json::json!({
                         "operation": receipt.operation,
@@ -2717,6 +2723,9 @@ impl TurnRun {
         name: &str,
         request_digest: &str,
     ) -> Result<DispatchedOutcome> {
+        if self.cancel.is_cancelled() {
+            st.head.active_phase = Some(TurnPhase::ManagedCancelling);
+        }
         self.commit(
             st,
             vec![(

--- a/crates/brain/tests/task_e2e.rs
+++ b/crates/brain/tests/task_e2e.rs
@@ -11,16 +11,46 @@ use brain_protocol::session::{CreateSessionRequest, MessageRequestContent};
 use futures_util::stream::BoxStream;
 use serde_json::{Value, json};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+use tokio::sync::Notify;
 
 #[derive(Debug, Default)]
 struct OrdinaryChildProvider {
     requests: Mutex<Vec<Value>>,
+    block_root_continuation: AtomicBool,
+    root_continuation_started: AtomicBool,
+    root_continuation_notify: Notify,
+    root_continuation_release: Notify,
 }
 
 impl OrdinaryChildProvider {
+    fn is_root_continuation(request: &Value) -> bool {
+        let messages = request["messages"].as_array().into_iter().flatten();
+        messages
+            .filter_map(|message| message["content"].as_array())
+            .flatten()
+            .any(|block| block["type"] == "tool_use" && block["name"] == "subagents")
+    }
+
+    async fn wait_for_root_continuation(&self) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if self.root_continuation_started.load(Ordering::Acquire) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "root provider continuation did not start"
+            );
+            tokio::select! {
+                () = self.root_continuation_notify.notified() => {}
+                () = tokio::time::sleep(Duration::from_millis(20)) => {}
+            }
+        }
+    }
+
     fn response(request: &Value) -> Result<BoxStream<'static, Result<ProviderEvent>>> {
         let messages = request["messages"]
             .as_array()
@@ -115,6 +145,13 @@ impl Provider for OrdinaryChildProvider {
             .lock()
             .expect("provider requests")
             .push(body.clone());
+        if self.block_root_continuation.load(Ordering::Acquire) && Self::is_root_continuation(&body)
+        {
+            self.root_continuation_started
+                .store(true, Ordering::Release);
+            self.root_continuation_notify.notify_waiters();
+            self.root_continuation_release.notified().await;
+        }
         Self::response(&body)
     }
 }
@@ -317,4 +354,63 @@ async fn official_spawn_creates_an_ordinary_child_at_a_complete_fork_boundary() 
             .iter()
             .all(|block| block["type"] != "tool_result")
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn end_fences_a_root_while_its_post_spawn_provider_call_is_stalled() {
+    let _tmp = TempDir::new();
+    let journal = Journal::new_memory("ordinary-child-stalled-root-e2e");
+    let provider = Arc::new(OrdinaryChildProvider::default());
+    provider
+        .block_root_continuation
+        .store(true, Ordering::Release);
+    let provider_factory = provider.clone();
+    let brain = Brain::with_parts_and_services(
+        BrainConfig {
+            max_concurrent_model_rounds: 2,
+            max_concurrent_turns: 2,
+            idle_discard: Duration::from_secs(60),
+            ..BrainConfig::default()
+        },
+        journal.clone(),
+        Arc::new(brain::keys::PlainCustody),
+        Arc::new(DisabledToolExecutor),
+        BrainServices::default(),
+        Arc::new(move |_| provider_factory.clone() as Arc<dyn Provider>),
+    );
+
+    let root = brain
+        .create_session(create_request(), Some("ordinary-child-stalled-root"))
+        .await
+        .expect("create root");
+    let root_id = root.id.to_string();
+    brain
+        .message(
+            &root_id,
+            MessageRequestContent::String("root prompt".parse().expect("message")),
+        )
+        .await
+        .expect("start root turn");
+    provider.wait_for_root_continuation().await;
+
+    let (children, _) = brain
+        .list_children(&root_id, None, 100)
+        .await
+        .expect("list direct children");
+    assert_eq!(
+        children.len(),
+        1,
+        "spawn committed before the provider stall"
+    );
+
+    let accepted = tokio::time::timeout(Duration::from_secs(1), brain.end(&root_id))
+        .await
+        .expect("END must not wait for the stalled provider")
+        .expect("END admission fence");
+    assert_eq!(
+        accepted.state,
+        brain_protocol::session::SessionState::Ending
+    );
+
+    provider.root_continuation_release.notify_waiters();
 }


### PR DESCRIPTION
Ports 6e3fdac (codex/fix-subagent-cancel-dev-canary, preserved on that branch) onto the refactored tree - the repair for the dev-canary subagent/cancellation ensured-deletion timeouts.

Cancellation racing a managed Submit committed nothing durable: the turn returned Cancelled while the operation was ambiguously in flight, and recovery could neither cancel nor complete it. Now the turn journals the managed-cancelling phase before any Hand cancel, an interrupted submit finishes as a durable unknown outcome, and recovery re-sends the idempotent cancel and completes the turn as cancelled. The port uses the typed TurnPhase::ManagedCancelling / TurnStopReason::Cancelled instead of the original string constants.

Tests: two crash-recovery tests, a live-cancellation test, and an end-fence-during-stalled-spawn e2e - all passing on this tree (250 total; the 1 failure is the known Windows-only bash-spawn issue).