### PR TITLE
brain-tools: exact @aexhq/brain release dep

### DIFF
--- a/packages/brain-tools/package.json
+++ b/packages/brain-tools/package.json
@@ -23,7 +23,7 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@aexhq/brain": "^0.3.0"
+    "@aexhq/brain": "0.3.0"
   },
   "peerDependencies": {
     "zod": ">=4.4.3 <5"


### PR DESCRIPTION
The npm release script fails staging on a caret range; the gate wants the exact release version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrqbMXpmiyxkdazrkGz9d