### PR TITLE
brain-tools 0.2.2: immutable-version bump

### DIFF
--- a/packages/brain-tools/package.json
+++ b/packages/brain-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain-tools",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Portable, explicit Tool values for Brain",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
0.2.1 already exists on the registry with different bytes; versions are immutable, so the exact-dep change ships as 0.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrqbMXpmiyxkdazrkGz9d