### PR TITLE
W6.1: per-tool network declarations + session deny rules

### DIFF
--- a/contracts/session/v1/schemas.json
+++ b/contracts/session/v1/schemas.json
@@ -298,6 +298,24 @@
         },
         "executor": {
           "$ref": "#/$defs/ToolExecutor"
+        },
+        "network": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "destinations"
+          ],
+          "properties": {
+            "destinations": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 32,
+              "items": {
+                "$ref": "#/$defs/NetworkDestination"
+              }
+            }
+          },
+          "description": "The tool's declared outbound needs. Merged at create: effective allowlist = (union of tool declarations and session allows) minus session denies; Aex infra is always denied. Declaration and merge only - no per-tool runtime isolation is claimed."
         }
       }
     },
@@ -545,6 +563,16 @@
           "properties": {
             "outbound": {
               "const": "none"
+            },
+            "deny": {
+              "type": "array",
+              "maxItems": 128,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 253
+              },
+              "description": "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."
             }
           }
         },
@@ -557,6 +585,16 @@
           "properties": {
             "outbound": {
               "const": "public"
+            },
+            "deny": {
+              "type": "array",
+              "maxItems": 128,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 253
+              },
+              "description": "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."
             }
           }
         },
@@ -576,69 +614,18 @@
               "minItems": 1,
               "maxItems": 128,
               "items": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "host",
-                      "ports",
-                      "protocol"
-                    ],
-                    "properties": {
-                      "host": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 253
-                      },
-                      "ports": {
-                        "type": "array",
-                        "prefixItems": [
-                          {
-                            "type": "integer",
-                            "const": 443
-                          }
-                        ],
-                        "minItems": 1,
-                        "maxItems": 1
-                      },
-                      "protocol": {
-                        "const": "tls"
-                      }
-                    }
-                  },
-                  {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "cidr",
-                      "ports",
-                      "protocol"
-                    ],
-                    "properties": {
-                      "cidr": {
-                        "type": "string",
-                        "minLength": 3,
-                        "maxLength": 49
-                      },
-                      "ports": {
-                        "type": "array",
-                        "minItems": 1,
-                        "maxItems": 32,
-                        "uniqueItems": true,
-                        "items": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 65535
-                        }
-                      },
-                      "protocol": {
-                        "const": "tcp"
-                      }
-                    }
-                  }
-                ]
+                "$ref": "#/$defs/NetworkDestination"
               }
+            },
+            "deny": {
+              "type": "array",
+              "maxItems": 128,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 253
+              },
+              "description": "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."
             }
           }
         }
@@ -1115,7 +1102,7 @@
     },
     "ProviderUsage": {
       "type": "object",
-      "description": "Raw provider counters for one model call. A counter the provider did not send is absent here — never reported as 0.",
+      "description": "Raw provider counters for one model call. A counter the provider did not send is absent here \u2014 never reported as 0.",
       "properties": {
         "input_tokens": {
           "type": "integer",
@@ -1964,6 +1951,70 @@
           "$ref": "#/$defs/ApiError"
         }
       }
+    },
+    "NetworkDestination": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "host",
+            "ports",
+            "protocol"
+          ],
+          "properties": {
+            "host": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 253
+            },
+            "ports": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "integer",
+                  "const": 443
+                }
+              ],
+              "minItems": 1,
+              "maxItems": 1
+            },
+            "protocol": {
+              "const": "tls"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cidr",
+            "ports",
+            "protocol"
+          ],
+          "properties": {
+            "cidr": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 49
+            },
+            "ports": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 32,
+              "uniqueItems": true,
+              "items": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              }
+            },
+            "protocol": {
+              "const": "tcp"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/crates/brain-protocol/src/session.rs
+++ b/crates/brain-protocol/src/session.rs
@@ -4439,140 +4439,7 @@ pub struct ModelInfo {
     pub name: ::std::string::String,
     pub provider: Provider,
 }
-#[doc = "Immutable direct outbound ceiling. Omission means none."]
-#[doc = r""]
-#[doc = r" <details><summary>JSON schema</summary>"]
-#[doc = r""]
-#[doc = r" ```json"]
-#[doc = "{"]
-#[doc = "  \"description\": \"Immutable direct outbound ceiling. Omission means none.\","]
-#[doc = "  \"oneOf\": ["]
-#[doc = "    {"]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"required\": ["]
-#[doc = "        \"outbound\""]
-#[doc = "      ],"]
-#[doc = "      \"properties\": {"]
-#[doc = "        \"outbound\": {"]
-#[doc = "          \"const\": \"none\""]
-#[doc = "        }"]
-#[doc = "      },"]
-#[doc = "      \"additionalProperties\": false"]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"required\": ["]
-#[doc = "        \"outbound\""]
-#[doc = "      ],"]
-#[doc = "      \"properties\": {"]
-#[doc = "        \"outbound\": {"]
-#[doc = "          \"const\": \"public\""]
-#[doc = "        }"]
-#[doc = "      },"]
-#[doc = "      \"additionalProperties\": false"]
-#[doc = "    },"]
-#[doc = "    {"]
-#[doc = "      \"type\": \"object\","]
-#[doc = "      \"required\": ["]
-#[doc = "        \"destinations\","]
-#[doc = "        \"outbound\""]
-#[doc = "      ],"]
-#[doc = "      \"properties\": {"]
-#[doc = "        \"destinations\": {"]
-#[doc = "          \"type\": \"array\","]
-#[doc = "          \"items\": {"]
-#[doc = "            \"oneOf\": ["]
-#[doc = "              {"]
-#[doc = "                \"type\": \"object\","]
-#[doc = "                \"required\": ["]
-#[doc = "                  \"host\","]
-#[doc = "                  \"ports\","]
-#[doc = "                  \"protocol\""]
-#[doc = "                ],"]
-#[doc = "                \"properties\": {"]
-#[doc = "                  \"host\": {"]
-#[doc = "                    \"type\": \"string\","]
-#[doc = "                    \"maxLength\": 253,"]
-#[doc = "                    \"minLength\": 1"]
-#[doc = "                  },"]
-#[doc = "                  \"ports\": {"]
-#[doc = "                    \"type\": \"array\","]
-#[doc = "                    \"maxItems\": 1,"]
-#[doc = "                    \"minItems\": 1,"]
-#[doc = "                    \"prefixItems\": ["]
-#[doc = "                      {"]
-#[doc = "                        \"const\": 443,"]
-#[doc = "                        \"type\": \"integer\""]
-#[doc = "                      }"]
-#[doc = "                    ]"]
-#[doc = "                  },"]
-#[doc = "                  \"protocol\": {"]
-#[doc = "                    \"const\": \"tls\""]
-#[doc = "                  }"]
-#[doc = "                },"]
-#[doc = "                \"additionalProperties\": false"]
-#[doc = "              },"]
-#[doc = "              {"]
-#[doc = "                \"type\": \"object\","]
-#[doc = "                \"required\": ["]
-#[doc = "                  \"cidr\","]
-#[doc = "                  \"ports\","]
-#[doc = "                  \"protocol\""]
-#[doc = "                ],"]
-#[doc = "                \"properties\": {"]
-#[doc = "                  \"cidr\": {"]
-#[doc = "                    \"type\": \"string\","]
-#[doc = "                    \"maxLength\": 49,"]
-#[doc = "                    \"minLength\": 3"]
-#[doc = "                  },"]
-#[doc = "                  \"ports\": {"]
-#[doc = "                    \"type\": \"array\","]
-#[doc = "                    \"items\": {"]
-#[doc = "                      \"type\": \"integer\","]
-#[doc = "                      \"maximum\": 65535.0,"]
-#[doc = "                      \"minimum\": 1.0"]
-#[doc = "                    },"]
-#[doc = "                    \"maxItems\": 32,"]
-#[doc = "                    \"minItems\": 1,"]
-#[doc = "                    \"uniqueItems\": true"]
-#[doc = "                  },"]
-#[doc = "                  \"protocol\": {"]
-#[doc = "                    \"const\": \"tcp\""]
-#[doc = "                  }"]
-#[doc = "                },"]
-#[doc = "                \"additionalProperties\": false"]
-#[doc = "              }"]
-#[doc = "            ]"]
-#[doc = "          },"]
-#[doc = "          \"maxItems\": 128,"]
-#[doc = "          \"minItems\": 1"]
-#[doc = "        },"]
-#[doc = "        \"outbound\": {"]
-#[doc = "          \"const\": \"allowlist\""]
-#[doc = "        }"]
-#[doc = "      },"]
-#[doc = "      \"additionalProperties\": false"]
-#[doc = "    }"]
-#[doc = "  ]"]
-#[doc = "}"]
-#[doc = r" ```"]
-#[doc = r" </details>"]
-#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-#[serde(tag = "outbound", content = "destinations")]
-pub enum NetworkPolicy {
-    #[serde(rename = "none")]
-    None,
-    #[serde(rename = "public")]
-    Public,
-    #[serde(rename = "allowlist")]
-    Allowlist(::std::vec::Vec<NetworkPolicyDestinationsItem>),
-}
-impl ::std::convert::From<::std::vec::Vec<NetworkPolicyDestinationsItem>> for NetworkPolicy {
-    fn from(value: ::std::vec::Vec<NetworkPolicyDestinationsItem>) -> Self {
-        Self::Allowlist(value)
-    }
-}
-#[doc = "`NetworkPolicyDestinationsItem`"]
+#[doc = "`NetworkDestination`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4645,19 +4512,19 @@ impl ::std::convert::From<::std::vec::Vec<NetworkPolicyDestinationsItem>> for Ne
 #[doc = r" </details>"]
 #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
 #[serde(tag = "protocol", deny_unknown_fields)]
-pub enum NetworkPolicyDestinationsItem {
+pub enum NetworkDestination {
     #[serde(rename = "tls")]
     Tls {
-        host: NetworkPolicyDestinationsItemHost,
+        host: NetworkDestinationHost,
         ports: [::serde_json::Value; 1usize],
     },
     #[serde(rename = "tcp")]
     Tcp {
-        cidr: NetworkPolicyDestinationsItemCidr,
+        cidr: NetworkDestinationCidr,
         ports: Vec<::std::num::NonZeroU64>,
     },
 }
-#[doc = "`NetworkPolicyDestinationsItemCidr`"]
+#[doc = "`NetworkDestinationCidr`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4671,19 +4538,19 @@ pub enum NetworkPolicyDestinationsItem {
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[serde(transparent)]
-pub struct NetworkPolicyDestinationsItemCidr(::std::string::String);
-impl ::std::ops::Deref for NetworkPolicyDestinationsItemCidr {
+pub struct NetworkDestinationCidr(::std::string::String);
+impl ::std::ops::Deref for NetworkDestinationCidr {
     type Target = ::std::string::String;
     fn deref(&self) -> &::std::string::String {
         &self.0
     }
 }
-impl ::std::convert::From<NetworkPolicyDestinationsItemCidr> for ::std::string::String {
-    fn from(value: NetworkPolicyDestinationsItemCidr) -> Self {
+impl ::std::convert::From<NetworkDestinationCidr> for ::std::string::String {
+    fn from(value: NetworkDestinationCidr) -> Self {
         value.0
     }
 }
-impl ::std::str::FromStr for NetworkPolicyDestinationsItemCidr {
+impl ::std::str::FromStr for NetworkDestinationCidr {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if value.chars().count() > 49usize {
@@ -4695,13 +4562,13 @@ impl ::std::str::FromStr for NetworkPolicyDestinationsItemCidr {
         Ok(Self(value.to_string()))
     }
 }
-impl ::std::convert::TryFrom<&str> for NetworkPolicyDestinationsItemCidr {
+impl ::std::convert::TryFrom<&str> for NetworkDestinationCidr {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for NetworkPolicyDestinationsItemCidr {
+impl ::std::convert::TryFrom<&::std::string::String> for NetworkDestinationCidr {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -4709,7 +4576,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for NetworkPolicyDestinatio
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for NetworkPolicyDestinationsItemCidr {
+impl ::std::convert::TryFrom<::std::string::String> for NetworkDestinationCidr {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -4717,7 +4584,7 @@ impl ::std::convert::TryFrom<::std::string::String> for NetworkPolicyDestination
         value.parse()
     }
 }
-impl<'de> ::serde::Deserialize<'de> for NetworkPolicyDestinationsItemCidr {
+impl<'de> ::serde::Deserialize<'de> for NetworkDestinationCidr {
     fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,
@@ -4729,7 +4596,7 @@ impl<'de> ::serde::Deserialize<'de> for NetworkPolicyDestinationsItemCidr {
             })
     }
 }
-#[doc = "`NetworkPolicyDestinationsItemHost`"]
+#[doc = "`NetworkDestinationHost`"]
 #[doc = r""]
 #[doc = r" <details><summary>JSON schema</summary>"]
 #[doc = r""]
@@ -4743,19 +4610,19 @@ impl<'de> ::serde::Deserialize<'de> for NetworkPolicyDestinationsItemCidr {
 #[doc = r" </details>"]
 #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[serde(transparent)]
-pub struct NetworkPolicyDestinationsItemHost(::std::string::String);
-impl ::std::ops::Deref for NetworkPolicyDestinationsItemHost {
+pub struct NetworkDestinationHost(::std::string::String);
+impl ::std::ops::Deref for NetworkDestinationHost {
     type Target = ::std::string::String;
     fn deref(&self) -> &::std::string::String {
         &self.0
     }
 }
-impl ::std::convert::From<NetworkPolicyDestinationsItemHost> for ::std::string::String {
-    fn from(value: NetworkPolicyDestinationsItemHost) -> Self {
+impl ::std::convert::From<NetworkDestinationHost> for ::std::string::String {
+    fn from(value: NetworkDestinationHost) -> Self {
         value.0
     }
 }
-impl ::std::str::FromStr for NetworkPolicyDestinationsItemHost {
+impl ::std::str::FromStr for NetworkDestinationHost {
     type Err = self::error::ConversionError;
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         if value.chars().count() > 253usize {
@@ -4767,13 +4634,13 @@ impl ::std::str::FromStr for NetworkPolicyDestinationsItemHost {
         Ok(Self(value.to_string()))
     }
 }
-impl ::std::convert::TryFrom<&str> for NetworkPolicyDestinationsItemHost {
+impl ::std::convert::TryFrom<&str> for NetworkDestinationHost {
     type Error = self::error::ConversionError;
     fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<&::std::string::String> for NetworkPolicyDestinationsItemHost {
+impl ::std::convert::TryFrom<&::std::string::String> for NetworkDestinationHost {
     type Error = self::error::ConversionError;
     fn try_from(
         value: &::std::string::String,
@@ -4781,7 +4648,7 @@ impl ::std::convert::TryFrom<&::std::string::String> for NetworkPolicyDestinatio
         value.parse()
     }
 }
-impl ::std::convert::TryFrom<::std::string::String> for NetworkPolicyDestinationsItemHost {
+impl ::std::convert::TryFrom<::std::string::String> for NetworkDestinationHost {
     type Error = self::error::ConversionError;
     fn try_from(
         value: ::std::string::String,
@@ -4789,7 +4656,189 @@ impl ::std::convert::TryFrom<::std::string::String> for NetworkPolicyDestination
         value.parse()
     }
 }
-impl<'de> ::serde::Deserialize<'de> for NetworkPolicyDestinationsItemHost {
+impl<'de> ::serde::Deserialize<'de> for NetworkDestinationHost {
+    fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+    {
+        ::std::string::String::deserialize(deserializer)?
+            .parse()
+            .map_err(|e: self::error::ConversionError| {
+                <D::Error as ::serde::de::Error>::custom(e.to_string())
+            })
+    }
+}
+#[doc = "Immutable direct outbound ceiling. Omission means none."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"Immutable direct outbound ceiling. Omission means none.\","]
+#[doc = "  \"oneOf\": ["]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"outbound\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"deny\": {"]
+#[doc = "          \"description\": \"Hosts the session explicitly refuses (exact, or \\\"*.suffix\\\"). Subtracted from the merged allowlist at create; incompatible with outbound \\\"public\\\" (nothing enforces a deny off the gateway path).\","]
+#[doc = "          \"type\": \"array\","]
+#[doc = "          \"items\": {"]
+#[doc = "            \"type\": \"string\","]
+#[doc = "            \"maxLength\": 253,"]
+#[doc = "            \"minLength\": 1"]
+#[doc = "          },"]
+#[doc = "          \"maxItems\": 128"]
+#[doc = "        },"]
+#[doc = "        \"outbound\": {"]
+#[doc = "          \"const\": \"none\""]
+#[doc = "        }"]
+#[doc = "      },"]
+#[doc = "      \"additionalProperties\": false"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"outbound\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"deny\": {"]
+#[doc = "          \"description\": \"Hosts the session explicitly refuses (exact, or \\\"*.suffix\\\"). Subtracted from the merged allowlist at create; incompatible with outbound \\\"public\\\" (nothing enforces a deny off the gateway path).\","]
+#[doc = "          \"type\": \"array\","]
+#[doc = "          \"items\": {"]
+#[doc = "            \"type\": \"string\","]
+#[doc = "            \"maxLength\": 253,"]
+#[doc = "            \"minLength\": 1"]
+#[doc = "          },"]
+#[doc = "          \"maxItems\": 128"]
+#[doc = "        },"]
+#[doc = "        \"outbound\": {"]
+#[doc = "          \"const\": \"public\""]
+#[doc = "        }"]
+#[doc = "      },"]
+#[doc = "      \"additionalProperties\": false"]
+#[doc = "    },"]
+#[doc = "    {"]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"destinations\","]
+#[doc = "        \"outbound\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"deny\": {"]
+#[doc = "          \"description\": \"Hosts the session explicitly refuses (exact, or \\\"*.suffix\\\"). Subtracted from the merged allowlist at create; incompatible with outbound \\\"public\\\" (nothing enforces a deny off the gateway path).\","]
+#[doc = "          \"type\": \"array\","]
+#[doc = "          \"items\": {"]
+#[doc = "            \"type\": \"string\","]
+#[doc = "            \"maxLength\": 253,"]
+#[doc = "            \"minLength\": 1"]
+#[doc = "          },"]
+#[doc = "          \"maxItems\": 128"]
+#[doc = "        },"]
+#[doc = "        \"destinations\": {"]
+#[doc = "          \"type\": \"array\","]
+#[doc = "          \"items\": {"]
+#[doc = "            \"$ref\": \"#/$defs/NetworkDestination\""]
+#[doc = "          },"]
+#[doc = "          \"maxItems\": 128,"]
+#[doc = "          \"minItems\": 1"]
+#[doc = "        },"]
+#[doc = "        \"outbound\": {"]
+#[doc = "          \"const\": \"allowlist\""]
+#[doc = "        }"]
+#[doc = "      },"]
+#[doc = "      \"additionalProperties\": false"]
+#[doc = "    }"]
+#[doc = "  ]"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(tag = "outbound", deny_unknown_fields)]
+pub enum NetworkPolicy {
+    #[serde(rename = "none")]
+    None {
+        #[doc = "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."]
+        #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+        deny: ::std::vec::Vec<NetworkPolicyDenyItem>,
+    },
+    #[serde(rename = "public")]
+    Public {
+        #[doc = "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."]
+        #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+        deny: ::std::vec::Vec<NetworkPolicyDenyItem>,
+    },
+    #[serde(rename = "allowlist")]
+    Allowlist {
+        #[doc = "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."]
+        #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+        deny: ::std::vec::Vec<NetworkPolicyDenyItem>,
+        destinations: ::std::vec::Vec<NetworkDestination>,
+    },
+}
+#[doc = "`NetworkPolicyDenyItem`"]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"type\": \"string\","]
+#[doc = "  \"maxLength\": 253,"]
+#[doc = "  \"minLength\": 1"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[serde(transparent)]
+pub struct NetworkPolicyDenyItem(::std::string::String);
+impl ::std::ops::Deref for NetworkPolicyDenyItem {
+    type Target = ::std::string::String;
+    fn deref(&self) -> &::std::string::String {
+        &self.0
+    }
+}
+impl ::std::convert::From<NetworkPolicyDenyItem> for ::std::string::String {
+    fn from(value: NetworkPolicyDenyItem) -> Self {
+        value.0
+    }
+}
+impl ::std::str::FromStr for NetworkPolicyDenyItem {
+    type Err = self::error::ConversionError;
+    fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        if value.chars().count() > 253usize {
+            return Err("longer than 253 characters".into());
+        }
+        if value.chars().count() < 1usize {
+            return Err("shorter than 1 characters".into());
+        }
+        Ok(Self(value.to_string()))
+    }
+}
+impl ::std::convert::TryFrom<&str> for NetworkPolicyDenyItem {
+    type Error = self::error::ConversionError;
+    fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<&::std::string::String> for NetworkPolicyDenyItem {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: &::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl ::std::convert::TryFrom<::std::string::String> for NetworkPolicyDenyItem {
+    type Error = self::error::ConversionError;
+    fn try_from(
+        value: ::std::string::String,
+    ) -> ::std::result::Result<Self, self::error::ConversionError> {
+        value.parse()
+    }
+}
+impl<'de> ::serde::Deserialize<'de> for NetworkPolicyDenyItem {
     fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,
@@ -6309,6 +6358,24 @@ impl<'de> ::serde::Deserialize<'de> for ToolBundleContentBase64 {
 #[doc = "    },"]
 #[doc = "    \"executor\": {"]
 #[doc = "      \"$ref\": \"#/$defs/ToolExecutor\""]
+#[doc = "    },"]
+#[doc = "    \"network\": {"]
+#[doc = "      \"description\": \"The tool's declared outbound needs. Merged at create: effective allowlist = (union of tool declarations and session allows) minus session denies; Aex infra is always denied. Declaration and merge only - no per-tool runtime isolation is claimed.\","]
+#[doc = "      \"type\": \"object\","]
+#[doc = "      \"required\": ["]
+#[doc = "        \"destinations\""]
+#[doc = "      ],"]
+#[doc = "      \"properties\": {"]
+#[doc = "        \"destinations\": {"]
+#[doc = "          \"type\": \"array\","]
+#[doc = "          \"items\": {"]
+#[doc = "            \"$ref\": \"#/$defs/NetworkDestination\""]
+#[doc = "          },"]
+#[doc = "          \"maxItems\": 32,"]
+#[doc = "          \"minItems\": 1"]
+#[doc = "        }"]
+#[doc = "      },"]
+#[doc = "      \"additionalProperties\": false"]
 #[doc = "    }"]
 #[doc = "  },"]
 #[doc = "  \"additionalProperties\": false"]
@@ -6320,6 +6387,38 @@ impl<'de> ::serde::Deserialize<'de> for ToolBundleContentBase64 {
 pub struct ToolConfig {
     pub definition: ToolDefinition,
     pub executor: ToolExecutor,
+    #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
+    pub network: ::std::option::Option<ToolConfigNetwork>,
+}
+#[doc = "The tool's declared outbound needs. Merged at create: effective allowlist = (union of tool declarations and session allows) minus session denies; Aex infra is always denied. Declaration and merge only - no per-tool runtime isolation is claimed."]
+#[doc = r""]
+#[doc = r" <details><summary>JSON schema</summary>"]
+#[doc = r""]
+#[doc = r" ```json"]
+#[doc = "{"]
+#[doc = "  \"description\": \"The tool's declared outbound needs. Merged at create: effective allowlist = (union of tool declarations and session allows) minus session denies; Aex infra is always denied. Declaration and merge only - no per-tool runtime isolation is claimed.\","]
+#[doc = "  \"type\": \"object\","]
+#[doc = "  \"required\": ["]
+#[doc = "    \"destinations\""]
+#[doc = "  ],"]
+#[doc = "  \"properties\": {"]
+#[doc = "    \"destinations\": {"]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"$ref\": \"#/$defs/NetworkDestination\""]
+#[doc = "      },"]
+#[doc = "      \"maxItems\": 32,"]
+#[doc = "      \"minItems\": 1"]
+#[doc = "    }"]
+#[doc = "  },"]
+#[doc = "  \"additionalProperties\": false"]
+#[doc = "}"]
+#[doc = r" ```"]
+#[doc = r" </details>"]
+#[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct ToolConfigNetwork {
+    pub destinations: ::std::vec::Vec<NetworkDestination>,
 }
 #[doc = "The model-visible half of one Tool. Array order is preserved exactly in the immutable model prefix."]
 #[doc = r""]

--- a/crates/brain/src/config.rs
+++ b/crates/brain/src/config.rs
@@ -67,6 +67,11 @@ pub struct ToolDecl {
     /// prefix content.
     #[serde(skip)]
     pub route: ToolRoute,
+    /// The tool's declared outbound needs (contract `ToolConfig.network.destinations`).
+    /// Not digested: the create-time merge seals the effective policy into the prefix
+    /// network; the raw declaration is input, not model-visible content.
+    #[serde(skip)]
+    pub network_needs: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -459,6 +464,7 @@ mod tests {
 
     fn def() -> AgentDef {
         AgentDef::new("you are a test", "test-model", Dialect::AnthropicMessages).tool(ToolDecl {
+            network_needs: Vec::new(),
             name: "read".into(),
             description: "read a file".into(),
             contract_digest: "a".repeat(64),
@@ -490,6 +496,7 @@ mod tests {
     fn appending_a_tool_changes_the_digest() {
         let base = prefix_digest(&def());
         let more = def().tool(ToolDecl {
+            network_needs: Vec::new(),
             name: "write".into(),
             description: "write a file".into(),
             contract_digest: "b".repeat(64),
@@ -507,6 +514,7 @@ mod tests {
     #[test]
     fn tool_order_is_significant() {
         let mut swapped = def().tool(ToolDecl {
+            network_needs: Vec::new(),
             name: "write".into(),
             description: "write a file".into(),
             contract_digest: "b".repeat(64),

--- a/crates/brain/src/provider/anthropic.rs
+++ b/crates/brain/src/provider/anthropic.rs
@@ -292,6 +292,7 @@ mod tests {
     fn prefix() -> std::sync::Arc<SealedPrefix> {
         AgentDef::new("sys", "claude-test", Dialect::AnthropicMessages)
             .tool(ToolDecl {
+                network_needs: Vec::new(),
                 name: "read".into(),
                 description: "read".into(),
                 contract_digest: "a".repeat(64),

--- a/crates/brain/src/provider/openai.rs
+++ b/crates/brain/src/provider/openai.rs
@@ -452,6 +452,7 @@ mod tests {
     fn prefix() -> std::sync::Arc<SealedPrefix> {
         AgentDef::new("sys", "fake-1", Dialect::OpenAiChat)
             .tool(ToolDecl {
+                network_needs: Vec::new(),
                 name: "read".into(),
                 description: "read".into(),
                 contract_digest: "a".repeat(64),
@@ -592,6 +593,7 @@ mod tests {
         });
         let prefix = AgentDef::new("sys", "fake-1", Dialect::OpenAiChat)
             .tool(ToolDecl {
+                network_needs: Vec::new(),
                 name: "todo".into(),
                 description: "todo".into(),
                 contract_digest: "a".repeat(64),

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -1248,12 +1248,7 @@ impl Brain {
             storage_max_session_bytes: self.cfg.storage_max_session_bytes,
             storage_transfer_ttl_ms: self.cfg.storage_transfer_ttl.as_millis() as u64,
             max_additional_sandboxes_per_root: self.cfg.max_additional_sandboxes_per_root,
-            network: req
-                .network
-                .as_ref()
-                .map(serde_json::to_value)
-                .transpose()?
-                .unwrap_or_else(|| serde_json::json!({"outbound": "none"})),
+            network: merge_session_network(req.network.as_ref(), &decls)?,
             max_child_depth: req.children.as_ref().map_or(4, |limits| {
                 u32::try_from(limits.max_depth)
                     .expect("CreateSessionRequest schema validated children.max_depth")
@@ -5693,6 +5688,128 @@ fn fork_mode_doc(fork_turns: &ForkTurns) -> (&'static str, Option<u32>) {
         ForkTurns::All => ("all", None),
         ForkTurns::None => ("none", None),
         ForkTurns::Last(turns) => ("last_n", Some(*turns)),
+    }
+}
+
+/// W6.1: the sealed session network is the create-time merge of the session's requested
+/// policy with every granted tool's declared needs. Effective allowlist =
+/// (union of tool declarations and session allows) minus session denies; Aex infra is
+/// always refused at declaration time (the egress gateway enforces it again at runtime).
+/// Declaration and merge only — no per-tool runtime isolation is claimed.
+pub(crate) fn merge_session_network(
+    requested: Option<&brain_protocol::session::NetworkPolicy>,
+    decls: &[crate::config::ToolDecl],
+) -> Result<serde_json::Value> {
+    fn host_of(destination: &serde_json::Value) -> Option<&str> {
+        destination.get("host").and_then(serde_json::Value::as_str)
+    }
+    fn is_aex_infra(host: &str) -> bool {
+        host.eq_ignore_ascii_case("aex.dev") || host.to_ascii_lowercase().ends_with(".aex.dev")
+    }
+    fn denied(host: &str, deny: &[String]) -> bool {
+        deny.iter().any(|rule| {
+            if let Some(suffix) = rule.strip_prefix("*.") {
+                host.len() > suffix.len() + 1
+                    && host
+                        .to_ascii_lowercase()
+                        .ends_with(&suffix.to_ascii_lowercase())
+                    && host.as_bytes()[host.len() - suffix.len() - 1] == b'.'
+            } else {
+                host.eq_ignore_ascii_case(rule)
+            }
+        })
+    }
+
+    let mut declared: Vec<serde_json::Value> = Vec::new();
+    let mut seen: std::collections::HashSet<Vec<u8>> = std::collections::HashSet::new();
+    for decl in decls {
+        for destination in &decl.network_needs {
+            if let Some(host) = host_of(destination)
+                && is_aex_infra(host)
+            {
+                return Err(BrainError::Invalid(format!(
+                    "tool {} declares Aex infrastructure host {host:?}; Aex infra is always denied",
+                    decl.name
+                )));
+            }
+            if seen.insert(serde_jcs::to_vec(destination)?) {
+                declared.push(destination.clone());
+            }
+        }
+    }
+
+    let requested = requested.map(serde_json::to_value).transpose()?;
+    let (outbound, session_destinations, deny): (&str, Vec<serde_json::Value>, Vec<String>) =
+        match &requested {
+            None => ("none", Vec::new(), Vec::new()),
+            Some(value) => {
+                let outbound = value
+                    .get("outbound")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| {
+                        BrainError::Invalid("network policy needs an outbound mode".into())
+                    })?;
+                let destinations = value
+                    .get("destinations")
+                    .and_then(serde_json::Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                let deny = value
+                    .get("deny")
+                    .and_then(serde_json::Value::as_array)
+                    .map(|rules| {
+                        rules
+                            .iter()
+                            .filter_map(serde_json::Value::as_str)
+                            .map(str::to_owned)
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                (outbound, destinations, deny)
+            }
+        };
+
+    match outbound {
+        "public" => {
+            if !deny.is_empty() {
+                return Err(BrainError::Invalid(
+                    "network deny rules require outbound \"none\" or \"allowlist\": nothing enforces a deny off the gateway path".into(),
+                ));
+            }
+            // Public already covers every declared need.
+            Ok(serde_json::json!({"outbound": "public"}))
+        }
+        "none" | "allowlist" => {
+            let mut merged: Vec<serde_json::Value> = Vec::new();
+            for destination in session_destinations.into_iter().chain(declared) {
+                if let Some(host) = host_of(&destination) {
+                    if is_aex_infra(host) {
+                        return Err(BrainError::Invalid(format!(
+                            "network allowlist names Aex infrastructure host {host:?}; Aex infra is always denied"
+                        )));
+                    }
+                    if denied(host, &deny) {
+                        continue;
+                    }
+                }
+                if !merged.contains(&destination) {
+                    merged.push(destination);
+                }
+            }
+            if merged.is_empty() {
+                if outbound == "allowlist" {
+                    return Err(BrainError::Invalid(
+                        "the merged network allowlist is empty after session denies".into(),
+                    ));
+                }
+                Ok(serde_json::json!({"outbound": "none"}))
+            } else {
+                Ok(serde_json::json!({"outbound": "allowlist", "destinations": merged}))
+            }
+        }
+        other => Err(BrainError::Invalid(format!(
+            "unknown network outbound mode {other:?}"
+        ))),
     }
 }
 

--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -4724,6 +4724,80 @@ async fn a_clean_summarization_failure_fails_the_turn_honestly() {
     );
 }
 
+fn declared_tool(host: &str) -> crate::config::ToolDecl {
+    crate::config::ToolDecl {
+        name: "fetcher".into(),
+        description: "fetches".into(),
+        contract_digest: "b".repeat(64),
+        input_schema: json!({"type":"object"}),
+        output_schema: json!({"type":"object"}),
+        route: crate::config::ToolRoute::Customer {
+            registration: "reg".into(),
+        },
+        network_needs: vec![json!({"host": host, "ports": [443], "protocol": "tls"})],
+    }
+}
+
+fn network_policy(value: serde_json::Value) -> brain_protocol::session::NetworkPolicy {
+    serde_json::from_value(value).expect("network policy parses the public contract")
+}
+
+#[test]
+fn tool_network_declarations_merge_into_the_sealed_allowlist() {
+    let sealed = merge_session_network(None, &[declared_tool("api.example.com")]).expect("merged");
+    assert_eq!(sealed["outbound"], "allowlist");
+    assert_eq!(sealed["destinations"][0]["host"], "api.example.com");
+
+    // Session allows union with declarations, deduplicated.
+    let policy = network_policy(json!({
+        "outbound": "allowlist",
+        "destinations": [
+            {"host": "api.example.com", "ports": [443], "protocol": "tls"},
+            {"host": "cdn.example.com", "ports": [443], "protocol": "tls"}
+        ]
+    }));
+    let sealed =
+        merge_session_network(Some(&policy), &[declared_tool("api.example.com")]).expect("merged");
+    let hosts: Vec<&str> = sealed["destinations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|destination| destination["host"].as_str().unwrap())
+        .collect();
+    assert_eq!(hosts, ["api.example.com", "cdn.example.com"]);
+}
+
+#[test]
+fn a_session_deny_beats_a_tool_declaration() {
+    let policy = network_policy(json!({"outbound": "none", "deny": ["api.example.com"]}));
+    let sealed =
+        merge_session_network(Some(&policy), &[declared_tool("api.example.com")]).expect("merged");
+    assert_eq!(sealed, json!({"outbound": "none"}));
+
+    // A wildcard deny removes the whole subtree; an empty allowlist result is refused.
+    let policy = network_policy(json!({
+        "outbound": "allowlist",
+        "destinations": [{"host": "a.svc.example.com", "ports": [443], "protocol": "tls"}],
+        "deny": ["*.example.com"]
+    }));
+    let error = merge_session_network(Some(&policy), &[]).expect_err("empty after denies");
+    assert!(error.to_string().contains("empty after"), "{error}");
+}
+
+#[test]
+fn aex_infrastructure_hosts_are_always_denied_at_create() {
+    let error = merge_session_network(None, &[declared_tool("api.aex.dev")])
+        .expect_err("aex infra refused");
+    assert!(error.to_string().contains("always denied"), "{error}");
+}
+
+#[test]
+fn deny_rules_are_incompatible_with_public_outbound() {
+    let policy = network_policy(json!({"outbound": "public", "deny": ["evil.example.com"]}));
+    let error = merge_session_network(Some(&policy), &[]).expect_err("unenforceable");
+    assert!(error.to_string().contains("gateway path"), "{error}");
+}
+
 #[tokio::test]
 async fn tenant_storage_quota_rejection_restores_the_live_actor_fold() {
     let data_dir = std::env::temp_dir().join(format!(

--- a/crates/brain/src/tools.rs
+++ b/crates/brain/src/tools.rs
@@ -50,8 +50,22 @@ fn resolve_one(tool: &ToolConfig) -> Result<ToolDecl> {
         ToolExecutor::Engine { capability } => ToolRoute::Intrinsic(capability.to_string()),
     };
 
+    let network_needs = tool
+        .network
+        .as_ref()
+        .map(|network| {
+            network
+                .destinations
+                .iter()
+                .map(|destination| serde_json::to_value(destination).map_err(BrainError::from))
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()?
+        .unwrap_or_default();
+
     Ok(ToolDecl {
         name,
+        network_needs,
         description: tool
             .definition
             .description

--- a/packages/brain-tools/package.json
+++ b/packages/brain-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain-tools",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Portable, explicit Tool values for Brain",
   "license": "Apache-2.0",
   "repository": {
@@ -10,20 +10,32 @@
   },
   "type": "module",
   "sideEffects": false,
-  "engines": { "node": ">=22.0.0" },
-  "publishConfig": { "access": "public", "provenance": true, "tag": "next" },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "tag": "next"
+  },
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "tsc -p tsconfig.json && node --test",
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@aexhq/brain": "0.3.0"
+    "@aexhq/brain": "0.3.1"
   },
   "peerDependencies": {
     "zod": ">=4.4.3 <5"

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Client, tool authoring API, and local builder for the independent Brain session server",
   "license": "Apache-2.0",
   "repository": {
@@ -10,15 +10,34 @@
   },
   "type": "module",
   "sideEffects": false,
-  "engines": { "node": ">=22.0.0" },
-  "publishConfig": { "access": "public", "provenance": true, "tag": "next" },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true,
+    "tag": "next"
+  },
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
-    "./internal": { "types": "./dist/internal.d.ts", "import": "./dist/internal.js" },
-    "./session": { "types": "./dist/generated/session.d.ts", "import": "./dist/generated/session.js" },
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "import": "./dist/internal.js"
+    },
+    "./session": {
+      "types": "./dist/generated/session.d.ts",
+      "import": "./dist/generated/session.js"
+    },
     "./package.json": "./package.json"
   },
-  "files": ["dist", "schemas", "README.md"],
+  "files": [
+    "dist",
+    "schemas",
+    "README.md"
+  ],
   "scripts": {
     "gen": "node scripts/gen.mjs",
     "build": "tsc -p tsconfig.json",

--- a/packages/brain/schemas/session.v1.json
+++ b/packages/brain/schemas/session.v1.json
@@ -298,6 +298,24 @@
         },
         "executor": {
           "$ref": "#/$defs/ToolExecutor"
+        },
+        "network": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "destinations"
+          ],
+          "properties": {
+            "destinations": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 32,
+              "items": {
+                "$ref": "#/$defs/NetworkDestination"
+              }
+            }
+          },
+          "description": "The tool's declared outbound needs. Merged at create: effective allowlist = (union of tool declarations and session allows) minus session denies; Aex infra is always denied. Declaration and merge only - no per-tool runtime isolation is claimed."
         }
       }
     },
@@ -545,6 +563,16 @@
           "properties": {
             "outbound": {
               "const": "none"
+            },
+            "deny": {
+              "type": "array",
+              "maxItems": 128,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 253
+              },
+              "description": "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."
             }
           }
         },
@@ -557,6 +585,16 @@
           "properties": {
             "outbound": {
               "const": "public"
+            },
+            "deny": {
+              "type": "array",
+              "maxItems": 128,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 253
+              },
+              "description": "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."
             }
           }
         },
@@ -576,69 +614,18 @@
               "minItems": 1,
               "maxItems": 128,
               "items": {
-                "oneOf": [
-                  {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "host",
-                      "ports",
-                      "protocol"
-                    ],
-                    "properties": {
-                      "host": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 253
-                      },
-                      "ports": {
-                        "type": "array",
-                        "prefixItems": [
-                          {
-                            "type": "integer",
-                            "const": 443
-                          }
-                        ],
-                        "minItems": 1,
-                        "maxItems": 1
-                      },
-                      "protocol": {
-                        "const": "tls"
-                      }
-                    }
-                  },
-                  {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [
-                      "cidr",
-                      "ports",
-                      "protocol"
-                    ],
-                    "properties": {
-                      "cidr": {
-                        "type": "string",
-                        "minLength": 3,
-                        "maxLength": 49
-                      },
-                      "ports": {
-                        "type": "array",
-                        "minItems": 1,
-                        "maxItems": 32,
-                        "uniqueItems": true,
-                        "items": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 65535
-                        }
-                      },
-                      "protocol": {
-                        "const": "tcp"
-                      }
-                    }
-                  }
-                ]
+                "$ref": "#/$defs/NetworkDestination"
               }
+            },
+            "deny": {
+              "type": "array",
+              "maxItems": 128,
+              "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 253
+              },
+              "description": "Hosts the session explicitly refuses (exact, or \"*.suffix\"). Subtracted from the merged allowlist at create; incompatible with outbound \"public\" (nothing enforces a deny off the gateway path)."
             }
           }
         }
@@ -1115,7 +1102,7 @@
     },
     "ProviderUsage": {
       "type": "object",
-      "description": "Raw provider counters for one model call. A counter the provider did not send is absent here — never reported as 0.",
+      "description": "Raw provider counters for one model call. A counter the provider did not send is absent here \u2014 never reported as 0.",
       "properties": {
         "input_tokens": {
           "type": "integer",
@@ -1964,6 +1951,70 @@
           "$ref": "#/$defs/ApiError"
         }
       }
+    },
+    "NetworkDestination": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "host",
+            "ports",
+            "protocol"
+          ],
+          "properties": {
+            "host": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 253
+            },
+            "ports": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "integer",
+                  "const": 443
+                }
+              ],
+              "minItems": 1,
+              "maxItems": 1
+            },
+            "protocol": {
+              "const": "tls"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "cidr",
+            "ports",
+            "protocol"
+          ],
+          "properties": {
+            "cidr": {
+              "type": "string",
+              "minLength": 3,
+              "maxLength": 49
+            },
+            "ports": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 32,
+              "uniqueItems": true,
+              "items": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              }
+            },
+            "protocol": {
+              "const": "tcp"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/packages/brain/src/generated/paths.ts
+++ b/packages/brain/src/generated/paths.ts
@@ -1065,9 +1065,26 @@ export type components = {
             kind: "engine";
             capability: string;
         };
+        NetworkDestination: {
+            host: string;
+            ports: [
+                443
+            ];
+            /** @constant */
+            protocol: "tls";
+        } | {
+            cidr: string;
+            ports: number[];
+            /** @constant */
+            protocol: "tcp";
+        };
         ToolConfig: {
             definition: components["schemas"]["ToolDefinition"];
             executor: components["schemas"]["ToolExecutor"];
+            /** @description The tool's declared outbound needs. Merged at create: effective allowlist = (union of tool declarations and session allows) minus session denies; Aex infra is always denied. Declaration and merge only - no per-tool runtime isolation is claimed. */
+            network?: {
+                destinations: components["schemas"]["NetworkDestination"][];
+            };
         };
         /** @description Sealed at create with the rest of the prefix. Omitted tools default to an empty set. */
         ToolsConfig: {
@@ -1086,25 +1103,19 @@ export type components = {
         NetworkPolicy: {
             /** @constant */
             outbound: "none";
+            /** @description Hosts the session explicitly refuses (exact, or "*.suffix"). Subtracted from the merged allowlist at create; incompatible with outbound "public" (nothing enforces a deny off the gateway path). */
+            deny?: string[];
         } | {
             /** @constant */
             outbound: "public";
+            /** @description Hosts the session explicitly refuses (exact, or "*.suffix"). Subtracted from the merged allowlist at create; incompatible with outbound "public" (nothing enforces a deny off the gateway path). */
+            deny?: string[];
         } | {
             /** @constant */
             outbound: "allowlist";
-            destinations: ({
-                host: string;
-                ports: [
-                    443
-                ];
-                /** @constant */
-                protocol: "tls";
-            } | {
-                cidr: string;
-                ports: number[];
-                /** @constant */
-                protocol: "tcp";
-            })[];
+            destinations: components["schemas"]["NetworkDestination"][];
+            /** @description Hosts the session explicitly refuses (exact, or "*.suffix"). Subtracted from the merged allowlist at create; incompatible with outbound "public" (nothing enforces a deny off the gateway path). */
+            deny?: string[];
         };
         CustomerClientConfig: {
             id: string;

--- a/packages/brain/src/generated/session.ts
+++ b/packages/brain/src/generated/session.ts
@@ -116,6 +116,29 @@ export type ToolExecutor =
       capability: string;
     };
 /**
+ * This interface was referenced by `BrainSessionAPIV1Types`'s JSON-Schema
+ * via the `definition` "NetworkDestination".
+ */
+export type NetworkDestination =
+  | {
+      host: string;
+      /**
+       * @minItems 1
+       * @maxItems 1
+       */
+      ports: [unknown];
+      protocol: "tls";
+    }
+  | {
+      cidr: string;
+      /**
+       * @minItems 1
+       * @maxItems 32
+       */
+      ports: [number, ...number[]];
+      protocol: "tcp";
+    };
+/**
  * The sealed agentloop identity of a session.
  *
  * This interface was referenced by `BrainSessionAPIV1Types`'s JSON-Schema
@@ -141,9 +164,21 @@ export type AgentloopInfo =
 export type NetworkPolicy =
   | {
       outbound: "none";
+      /**
+       * Hosts the session explicitly refuses (exact, or "*.suffix"). Subtracted from the merged allowlist at create; incompatible with outbound "public" (nothing enforces a deny off the gateway path).
+       *
+       * @maxItems 128
+       */
+      deny?: string[];
     }
   | {
       outbound: "public";
+      /**
+       * Hosts the session explicitly refuses (exact, or "*.suffix"). Subtracted from the merged allowlist at create; incompatible with outbound "public" (nothing enforces a deny off the gateway path).
+       *
+       * @maxItems 128
+       */
+      deny?: string[];
     }
   | {
       outbound: "allowlist";
@@ -151,48 +186,13 @@ export type NetworkPolicy =
        * @minItems 1
        * @maxItems 128
        */
-      destinations: [
-        (
-          | {
-              host: string;
-              /**
-               * @minItems 1
-               * @maxItems 1
-               */
-              ports: [unknown];
-              protocol: "tls";
-            }
-          | {
-              cidr: string;
-              /**
-               * @minItems 1
-               * @maxItems 32
-               */
-              ports: [number, ...number[]];
-              protocol: "tcp";
-            }
-        ),
-        ...(
-          | {
-              host: string;
-              /**
-               * @minItems 1
-               * @maxItems 1
-               */
-              ports: [unknown];
-              protocol: "tls";
-            }
-          | {
-              cidr: string;
-              /**
-               * @minItems 1
-               * @maxItems 32
-               */
-              ports: [number, ...number[]];
-              protocol: "tcp";
-            }
-        )[]
-      ];
+      destinations: [NetworkDestination, ...NetworkDestination[]];
+      /**
+       * Hosts the session explicitly refuses (exact, or "*.suffix"). Subtracted from the merged allowlist at create; incompatible with outbound "public" (nothing enforces a deny off the gateway path).
+       *
+       * @maxItems 128
+       */
+      deny?: string[];
     };
 /**
  * Which agentloop drives this session's turns. Sealed at create for the life of the session; children inherit the parent's loop. Omission seals the official aex loop.
@@ -534,6 +534,16 @@ export interface ToolDefinition {
 export interface ToolConfig {
   definition: ToolDefinition;
   executor: ToolExecutor;
+  /**
+   * The tool's declared outbound needs. Merged at create: effective allowlist = (union of tool declarations and session allows) minus session denies; Aex infra is always denied. Declaration and merge only - no per-tool runtime isolation is claimed.
+   */
+  network?: {
+    /**
+     * @minItems 1
+     * @maxItems 32
+     */
+    destinations: [NetworkDestination, ...NetworkDestination[]];
+  };
 }
 /**
  * Create-time-only bundle bytes. Brain stages these outside the journal, then discards this representation.

--- a/packages/brain/src/tools.ts
+++ b/packages/brain/src/tools.ts
@@ -20,8 +20,21 @@ export type ToolHandler<Input extends z.ZodType, Output = unknown> = (
   context: ToolContext,
 ) => Output | Promise<Output>;
 
+/** One declared outbound destination (TLS to a host on 443, matching the session contract). */
+export interface NetworkDestination {
+  readonly host: string;
+  readonly ports: readonly [443];
+  readonly protocol: "tls";
+}
+
 export interface ServerToolOptions {
   readonly env?: readonly string[];
+  /**
+   * The tool's declared outbound needs. Merged at session create: effective allowlist =
+   * (union of tool declarations and session allows) minus session denies; Aex infra is
+   * always denied. Declaration and merge only — no per-tool runtime isolation is claimed.
+   */
+  readonly network?: { readonly destinations: readonly NetworkDestination[] };
 }
 
 export interface ClientToolOptions {
@@ -158,6 +171,7 @@ function makeBuilder<Input extends z.ZodType, Output>(draft: Draft<Input, Output
         requiredEnv: normalizeRequiredEnv(options.env),
         executor: { kind: "aex_managed", module },
         handlerKey: "execute",
+        ...(options.network === undefined ? {} : { network: normalizeNetwork(options.network) }),
       });
     },
   });
@@ -168,6 +182,7 @@ interface FreezeOptions<Input extends z.ZodType, Output> {
   contract: ToolContract;
   requiredEnv: readonly string[];
   executor: ToolExecutor;
+  network?: { readonly destinations: readonly NetworkDestination[] };
   handlerKey?: "handler" | "execute";
 }
 
@@ -182,6 +197,7 @@ function freezeTool<Input extends z.ZodType, Output>(options: FreezeOptions<Inpu
     requiredEnv: Object.freeze([...options.requiredEnv]),
     execution: options.executor.kind,
     executor: Object.freeze(options.executor),
+    ...(options.network === undefined ? {} : { network: Object.freeze(options.network) }),
     ...(options.handlerKey === undefined ? {} : { [options.handlerKey]: options.draft.handler }),
   });
 }
@@ -234,6 +250,7 @@ export type WireToolExecutor =
 export interface WireTool {
   definition: WireToolDefinition;
   executor: WireToolExecutor;
+  network?: { destinations: NetworkDestination[] };
 }
 
 export interface WireToolBundle {
@@ -327,7 +344,14 @@ export async function compileTools(selections: readonly Tool[] | undefined): Pro
         executor = { kind: "engine", capability: value.executor.capability };
         break;
     }
-    items.push({ definition, executor });
+    const declared = (value as { network?: { destinations: readonly NetworkDestination[] } }).network;
+    items.push({
+      definition,
+      executor,
+      ...(declared === undefined
+        ? {}
+        : { network: { destinations: declared.destinations.map((destination) => ({ ...destination })) } }),
+    });
   }
   return { items, bundles, clientRegistrations: Object.freeze(clientRegistrations) };
 }
@@ -469,6 +493,29 @@ function assertDescription(description: string): void {
   if (description.trim() === "" || description.length > 4096) {
     throw new TypeError("Tool description must contain 1 through 4096 characters");
   }
+}
+
+function normalizeNetwork(
+  network: NonNullable<ServerToolOptions["network"]>,
+): { readonly destinations: readonly NetworkDestination[] } {
+  const destinations = network.destinations ?? [];
+  if (destinations.length === 0 || destinations.length > 32) {
+    throw new TypeError("Tool network declarations need 1 through 32 destinations");
+  }
+  const seen = new Set<string>();
+  for (const destination of destinations) {
+    const host = destination.host;
+    if (typeof host !== "string" || host.length === 0 || host.length > 253) {
+      throw new TypeError("Tool network destination host must be 1 through 253 bytes");
+    }
+    const lowered = host.toLowerCase();
+    if (lowered === "aex.dev" || lowered.endsWith(".aex.dev")) {
+      throw new TypeError(`Tool network destination ${host} names Aex infrastructure; Aex infra is always denied`);
+    }
+    if (seen.has(lowered)) throw new TypeError(`Tool network destination ${host} was repeated`);
+    seen.add(lowered);
+  }
+  return { destinations: destinations.map((destination) => Object.freeze({ ...destination })) };
 }
 
 function normalizeRequiredEnv(values: readonly string[] | undefined): readonly string[] {

--- a/packages/brain/test/builder.test.mjs
+++ b/packages/brain/test/builder.test.mjs
@@ -87,6 +87,28 @@ test("custom and official values compile through one ordered Tool path", async (
   await assert.rejects(compileTools([one, one]), /selected more than once/u);
 });
 
+test("declared network needs ride the wire and refuse aex infrastructure", async () => {
+  const module = new URL("../fixtures/fixture-tool.mjs", import.meta.url).href;
+  const fetcher = tool(z.object({ url: z.string() }), async function fetcher({ url }) { return { url }; })
+    .describe("Fetch a thing.")
+    .server(module, {
+      network: { destinations: [{ host: "api.example.com", ports: [443], protocol: "tls" }] },
+    });
+  const compiled = await compileTools([fetcher]);
+  assert.deepEqual(compiled.items[0].network, {
+    destinations: [{ host: "api.example.com", ports: [443], protocol: "tls" }],
+  });
+
+  assert.throws(
+    () =>
+      tool(z.object({}), async function infra() { return {}; })
+        .server(module, {
+          network: { destinations: [{ host: "api.aex.dev", ports: [443], protocol: "tls" }] },
+        }),
+    /always denied/u,
+  );
+});
+
 test("function-first builders infer names and are immutable", async () => {
   const original = tool(async function ping() { return { ok: true }; });
   const described = original.describe("Check liveness.").returns(z.object({ ok: z.boolean() }));


### PR DESCRIPTION
Tools declare outbound needs; create seals (∪ declarations ∪ session allows) − session denies as the session's network ceiling. Aex infra refused at declaration time; deny+public refused as unenforceable. SDK: server(..., { network }) with wire compile; package versions bumped (brain 0.3.1, brain-tools 0.2.3) for the next npm leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrqbMXpmiyxkdazrkGz9d