### PR TITLE
r5: journal-tail rebuilds + spawn self-delivery deadlock fix

### DIFF
--- a/crates/brain-loophost/guest/loop-aex.mjs
+++ b/crates/brain-loophost/guest/loop-aex.mjs
@@ -10,7 +10,8 @@
 //   - parallel dispatch of each round's whole tool batch;
 //   - at the sealed round ceiling, one graceful closing round (tool_choice none) and a
 //     max_rounds finish; refusal rounds finish as refusal;
-//   - a summary mark per turn so rehydration never replays from zero;
+//   - no per-turn marks: rehydration replays the kernel's bounded journal tail, so
+//     every prior turn's exact content survives; compaction is re-derived in-turn;
 //   - on budget_exceeded, loop-side compaction: summarize everything but a recent tail
 //     through the sealed model and continue on summary + tail;
 //   - provider failures fail the turn honestly through turn_fail (the kernel maps an
@@ -55,16 +56,6 @@ function messageFromView(view) {
 // Loop-owned conversation memory, cached for this resident instance and rebuilt from the
 // delivered hydration (summary mark first, then the tail) on a fresh one.
 let memory = [];
-
-const writeMark = async (ctx, admitted, summary) => {
-  await ctx.journal.append([
-    {
-      kind: "mark",
-      covers_through_seq: admitted.seq,
-      data: { summary: summary.slice(0, 4000) },
-    },
-  ]);
-};
 
 /** Loop-side compaction; returns the replacement memory or null when the conversation
  * cannot be compacted further. */
@@ -162,18 +153,15 @@ export const { activate } = defineAgentloop({
         rounds += 1;
         memory.push({ role: "assistant", content: round.content });
         if (closing) {
-          await writeMark(ctx, admitted, textOf(round.content));
           await ctx.turn.finish(undefined, { stopReason: "max_rounds" });
           return;
         }
         if (round.stop_reason === "refusal") {
-          await writeMark(ctx, admitted, textOf(round.content));
           await ctx.turn.finish(undefined, { stopReason: "refusal" });
           return;
         }
         const calls = round.content.filter((block) => block.type === "tool_call");
         if (calls.length === 0) {
-          await writeMark(ctx, admitted, textOf(round.content));
           await ctx.turn.finish(undefined, { stopReason: "end_turn" });
           return;
         }

--- a/crates/brain/src/agentloop.rs
+++ b/crates/brain/src/agentloop.rs
@@ -281,27 +281,6 @@ impl BuiltinAexLoop {
         ctx.contract_op(op).await
     }
 
-    async fn write_mark(
-        ctx: &mut dyn TurnCtx,
-        covers_through_seq: u64,
-        summary: &str,
-    ) -> Result<()> {
-        let summary: String = summary.chars().take(4000).collect();
-        let _ = Self::op(
-            ctx,
-            serde_json::json!({
-                "op": "journal_append",
-                "entries": [{
-                    "kind": "mark",
-                    "covers_through_seq": covers_through_seq,
-                    "data": { "summary": summary },
-                }],
-            }),
-        )
-        .await?;
-        Ok(())
-    }
-
     async fn finish(ctx: &mut dyn TurnCtx, stop_reason: &str) -> Result<()> {
         let _ = Self::op(
             ctx,
@@ -404,7 +383,6 @@ impl Agentloop for BuiltinAexLoop {
             }
         }
         let admitted = &activation["message"];
-        let covers_through_seq = admitted["seq"].as_u64().unwrap_or(0);
         memory.push(serde_json::json!({"role": "user", "content": admitted["content"]}));
         let max_rounds = activation["session"]["limits"]["max_rounds_per_turn"]
             .as_u64()
@@ -462,14 +440,10 @@ impl Agentloop for BuiltinAexLoop {
                 "role": "assistant", "content": message["content"],
             }));
             if closing {
-                Self::write_mark(ctx, covers_through_seq, &Self::text_of(&message["content"]))
-                    .await?;
                 Self::finish(ctx, "max_rounds").await?;
                 return Ok(LoopVerdict::stop(TurnStopReason::MaxRounds));
             }
             if message["stop_reason"] == "refusal" {
-                Self::write_mark(ctx, covers_through_seq, &Self::text_of(&message["content"]))
-                    .await?;
                 Self::finish(ctx, "refusal").await?;
                 return Ok(LoopVerdict::stop(TurnStopReason::Refusal));
             }
@@ -487,8 +461,6 @@ impl Agentloop for BuiltinAexLoop {
                 })
                 .collect();
             if calls.is_empty() {
-                Self::write_mark(ctx, covers_through_seq, &Self::text_of(&message["content"]))
-                    .await?;
                 Self::finish(ctx, "end_turn").await?;
                 return Ok(LoopVerdict::stop(TurnStopReason::EndTurn));
             }
@@ -746,12 +718,9 @@ mod tests {
         let mut ctx = Scripted::new(vec![tool_message("echo"), text_message("done")]);
         let verdict = drive(&mut ctx);
         assert_eq!(verdict.stop_reason, TurnStopReason::EndTurn);
-        assert_eq!(
-            ctx.calls,
-            vec!["model", "dispatch", "model", "mark", "finish"]
-        );
+        assert_eq!(ctx.calls, vec!["model", "dispatch", "model", "finish"]);
         assert_eq!(ctx.finish.as_ref().unwrap().1, "end_turn");
-        assert_eq!(ctx.marks.len(), 1, "one summary mark per turn");
+        assert!(ctx.marks.is_empty(), "ordinary turns write no marks");
     }
 
     #[test]
@@ -768,10 +737,7 @@ mod tests {
         ctx.max_rounds = 1;
         let verdict = drive(&mut ctx);
         assert_eq!(verdict.stop_reason, TurnStopReason::MaxRounds);
-        assert_eq!(
-            ctx.calls,
-            vec!["model", "dispatch", "model", "mark", "finish"]
-        );
+        assert_eq!(ctx.calls, vec!["model", "dispatch", "model", "finish"]);
         assert_eq!(
             ctx.model_requests[1]["tool_choice"], "none",
             "the closing round constrains tool choice"
@@ -841,7 +807,7 @@ mod tests {
             .collect();
         let verdict = drive(&mut ctx);
         assert_eq!(verdict.stop_reason, TurnStopReason::EndTurn);
-        assert_eq!(ctx.calls, vec!["model", "model", "model", "mark", "finish"]);
+        assert_eq!(ctx.calls, vec!["model", "model", "model", "finish"]);
         assert!(
             ctx.model_requests[1]["system"].as_str().is_some(),
             "the compaction round overrides the system text"

--- a/crates/brain/src/session/engine/subagents.rs
+++ b/crates/brain/src/session/engine/subagents.rs
@@ -25,15 +25,19 @@ impl Brain {
                         .get("fork_turns")
                         .and_then(serde_json::Value::as_str)
                         .map(str::to_owned);
-                    let child = self
-                        .create_child(
-                            parent_id,
-                            message,
-                            Some(task_name),
-                            fork_turns,
-                            Some(operation_id),
-                        )
-                        .await?;
+                    // Direct creation, never a command to this session's own actor: the
+                    // spawning turn may itself be the actor's inline hydration turn (a
+                    // child's first turn runs during attach), and a self-delivered
+                    // CreateChild would deadlock the session — the 2026-08-23 dev wedge.
+                    let child = create_child_session(
+                        self,
+                        parent_id,
+                        message,
+                        Some(task_name),
+                        ForkTurns::parse(fork_turns.as_deref())?,
+                        Some(operation_id),
+                    )
+                    .await?;
                     Ok(serde_json::to_value(child)?)
                 }
                 Some("send_message" | "follow_up") => {

--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -4609,6 +4609,148 @@ async fn run_one_turn(brain: &Arc<Brain>, journal: &Journal, session_id: &str) {
     panic!("the turn never reached a terminal");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_spawned_child_whose_first_turn_spawns_again_never_deadlocks() {
+    // The r4 dev wedge: a child session starts with its first turn already active, and
+    // that turn is driven during actor hydration. When the child's model answered with a
+    // subagents spawn, the intrinsic delivered a command to the child's own actor — which
+    // was busy driving the turn — and the tree deadlocked; END then queued forever behind
+    // it. The spawn intrinsic now creates the grandchild directly, no self-delivery.
+    let journal = Journal::new_memory("brain-child-self-spawn");
+    let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+    fake.script([
+        // Only the child's turn consumes scripts: round one spawns a grandchild with a
+        // mid-turn fork of the child itself, round two answers.
+        Scripted::tool(
+            "subagents",
+            json!({
+                "action": "spawn_agent", "task_name": "grandchild", "message": "grand prompt",
+                "fork_turns": "1"
+            }),
+        ),
+        Scripted::Text("child done".into()),
+        Scripted::Text("grandchild done".into()),
+    ]);
+    let provider = fake.clone();
+    let brain = Brain::with_parts_and_services(
+        BrainConfig {
+            idle_discard: Duration::from_secs(300),
+            ..BrainConfig::default()
+        },
+        journal.clone(),
+        Arc::new(crate::keys::PlainCustody),
+        Arc::new(crate::adapter::DisabledToolExecutor),
+        BrainServices::default(),
+        Arc::new(move |_| provider.clone() as Arc<dyn Provider>),
+    );
+    let created = brain
+        .create_session(
+            serde_json::from_value(json!({
+                "model": {"provider":"anthropic","name":"m","api_key":"sk-test"},
+                "tools": {"items": [{
+                    "definition": {
+                        "name":"subagents", "description":"children",
+                        "contract_digest": "d".repeat(64),
+                        "input_schema": {"type":"object","additionalProperties":true},
+                        "output_schema": {"type":"object","additionalProperties":true}
+                    },
+                    "executor": {"kind":"engine", "capability":"brain.subagents"}
+                }]}
+            }))
+            .unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+    let root_id = created.id.to_string();
+    let child = brain
+        .create_child(&root_id, "run".into(), Some("child".into()), None, None)
+        .await
+        .unwrap();
+    let child_id = serde_json::to_value(&child).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let settled = tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let head = journal.get_head(&child_id).await.unwrap();
+            if head.doc.turn.is_none() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await;
+    assert!(
+        settled.is_ok(),
+        "the child's first turn deadlocked on its own spawn delivery"
+    );
+    let (grandchildren, _) = brain.list_children(&child_id, None, 10).await.unwrap();
+    assert_eq!(grandchildren.len(), 1, "the grandchild exists");
+    let records = journal.read_records(&child_id, 0).await.unwrap();
+    let failure = records.iter().find_map(|entry| match &entry.record {
+        Record::TurnFailed { code, message, .. } => Some(format!("{code}: {message}")),
+        _ => None,
+    });
+    assert!(failure.is_none(), "child turn failed: {}", failure.unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_later_turn_still_sees_earlier_turns_verbatim() {
+    // The r4 continuation canary regression: per-turn summary marks replaced real history
+    // with the previous answer's text, so "remember CEDAR" vanished from turn two's
+    // context. Rebuilds now replay the journal tail; the exact user words must reach the
+    // provider on the later turn.
+    let journal = Journal::new_memory("brain-continuation");
+    let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+    fake.script([
+        Scripted::Text("noted".into()),
+        Scripted::Text("the word is CEDAR".into()),
+    ]);
+    let provider = fake.clone();
+    let brain = Brain::with_parts_and_services(
+        BrainConfig {
+            idle_discard: Duration::from_secs(300),
+            ..BrainConfig::default()
+        },
+        journal.clone(),
+        Arc::new(crate::keys::PlainCustody),
+        Arc::new(crate::adapter::DisabledToolExecutor),
+        BrainServices::default(),
+        Arc::new(move |_| provider.clone() as Arc<dyn Provider>),
+    );
+    let created = brain
+        .create_session(
+            serde_json::from_value(json!({
+                "model": {"provider":"anthropic","name":"m","api_key":"sk-test"}
+            }))
+            .unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+    let session_id = created.id.to_string();
+    for message in ["Remember the word CEDAR.", "What was the word?"] {
+        let (_, admitted) = brain
+            .message(&session_id, serde_json::from_value(json!(message)).unwrap())
+            .await
+            .unwrap();
+        for _ in 0..1000 {
+            let head = journal.get_head(&session_id).await.unwrap();
+            if head.doc.turn.is_none() && head.last_seq > admitted {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+    }
+    let arrivals = fake.arrivals.lock().expect("arrivals");
+    assert_eq!(arrivals.len(), 2);
+    assert_eq!(
+        arrivals[1].message_count, 3,
+        "turn two must carry turn one's user message and answer verbatim          (a summary-mark rebuild would collapse them to 2 messages)"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn gateway_style_model_names_cross_the_loop_contract() {
     // Hosted models arrive as gateway paths ("openai/gpt-4.1-nano"); the loop contract's
@@ -4683,10 +4825,10 @@ async fn self_compaction_summarizes_installs_a_mark_and_continues() {
         "two tool rounds, two summarization rounds, one continuation"
     );
     assert!(
-        records
+        !records
             .iter()
             .any(|entry| matches!(&entry.record, Record::LoopMark { .. })),
-        "the compacting turn still installs its mark"
+        "the loop writes no per-turn marks; rebuilds replay the journal tail"
     );
     assert!(
         records.iter().any(|entry| matches!(

--- a/crates/brain/tests/builtin_smoke.rs
+++ b/crates/brain/tests/builtin_smoke.rs
@@ -110,9 +110,9 @@ async fn builtin_contract_loop_completes_text_and_tool_turns() {
     });
     assert!(failure.is_none(), "turn failed: {}", failure.unwrap());
     assert!(
-        records
+        !records
             .iter()
             .any(|entry| matches!(&entry.record, Record::LoopMark { .. })),
-        "no mark journaled"
+        "ordinary turns journal no marks; rehydration replays the journal tail"
     );
 }


### PR DESCRIPTION
Fixes the two r4 canary regressions: per-turn summary marks losing prior turns' exact content (rebuilds now replay the journal tail; no ordinary marks), and the child-first-turn subagents spawn deadlocking its own actor (the intrinsic creates the child directly). Both have deterministic regression gates. 200 lib tests, 12/12 loophost e2e with a rebuilt guest, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrqbMXpmiyxkdazrkGz9d