### PR TITLE
image: drop npm (Trivy CRITICAL CVE-2026-59873)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,10 @@ RUN apt-get update \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get purge -y curl gnupg \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \r
+    # The runtime executes prebuilt tool bundles with node alone; npm (and its vendored
+    # node-tar, the standing Trivy CRITICAL) never belongs in the image.
+    && rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx
 COPY --from=build /src/target/release/brain /usr/local/bin/brain
 EXPOSE 3210
 ENTRYPOINT ["/usr/local/bin/brain"]


### PR DESCRIPTION
The main-branch image publish fails Trivy on npm's vendored node-tar 7.5.11 (CVE-2026-59873). The runtime only needs node for prebuilt bundles; npm/npx are removed from the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrqbMXpmiyxkdazrkGz9d