### PR TITLE
r6: cancelled managed submits conclude immediately

### DIFF
--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -1112,6 +1112,9 @@ struct DirectTransferFiles {
 struct UnknownManagedPorts {
     submits: AtomicUsize,
     status_calls: AtomicUsize,
+    /// When set, `status` answers the retryable materialization-in-progress error the
+    /// live plane returns while the detached submit still drives the launch.
+    status_materializing: AtomicBool,
     dematerialize_calls: AtomicUsize,
     fail_next_dematerialize: AtomicBool,
     block_submit: AtomicBool,
@@ -1385,6 +1388,15 @@ impl crate::hand::SandboxFilesPort for UnknownManagedPorts {
         target: brain_protocol::hand::SandboxTarget,
     ) -> crate::hand::HandResult<brain_protocol::hand::SandboxStatus> {
         self.status_calls.fetch_add(1, Ordering::AcqRel);
+        if self.status_materializing.load(Ordering::Acquire) {
+            return Err(serde_json::from_value(json!({
+                "code": "temporarily_unavailable",
+                "retryable": true,
+                "message": "sandbox materialization is in progress",
+                "details": {}
+            }))
+            .expect("retryable status error"));
+        }
         Ok(serde_json::from_value(json!({
             "state":"running",
             "target":target,
@@ -5782,6 +5794,148 @@ async fn cancellation_during_managed_submit_is_durable_before_cleanup() {
                 "model":{"provider":"anthropic","name":"managed-cancel","api_key":"key"}
             })),
             Some("managed-submit-live-cancel"),
+        )
+        .await
+        .expect("create live cancellation session");
+    let session_id = created.id.to_string();
+    let mut resident = hydrate(&brain, &session_id)
+        .await
+        .expect("claim live cancellation session");
+    let bundle_digest = "a".repeat(64);
+    resident.st.head.prefix.hand_enabled = true;
+    resident.st.head.prefix.tools = serde_json::from_value(json!([{
+        "definition": {
+            "name":name,
+            "description":"block until cancellation",
+            "contract_digest":"b".repeat(64),
+            "input_schema":{"type":"object"},
+            "output_schema":{}
+        },
+        "executor": {
+            "kind":"aex_managed",
+            "bundle_digest":bundle_digest,
+            "required_env":[]
+        }
+    }]))
+    .expect("managed Tool seal");
+    let binding: brain_protocol::hand::ResolvedBinding = serde_json::from_value(json!({
+        "binding_ref":"bnd_managedcancel0000",
+        "capabilities":["execution","session_preparation"],
+        "hand_id":"hand_managedcancel",
+        "limits":{
+            "max_inline_input_bytes":brain_protocol::MAX_MANAGED_TOOL_INPUT_BYTES,
+            "max_inline_result_bytes":brain_protocol::MAX_TOOL_TERMINAL_INLINE_BYTES,
+            "max_wait_ms":1
+        },
+        "realm":"aex_managed",
+        "recovery":"retained"
+    }))
+    .expect("valid managed binding");
+    resident.managed_bindings = Arc::new(HashMap::from([(name, binding)]));
+
+    let content = vec![ContentBlock::text("run the managed effect")];
+    let (turn, user_seq, cancel) = admit(
+        &brain,
+        &session_id,
+        &mut resident,
+        content.clone(),
+        HashMap::new(),
+        None,
+    )
+    .await
+    .expect("admit managed turn");
+    let run = turn_run(
+        &brain,
+        &session_id,
+        &turn,
+        &resident,
+        HashMap::new(),
+        cancel.clone(),
+        Some(crate::turn::AdmittedMessage {
+            seq: user_seq,
+            at_ms: crate::wall_ms(),
+            content,
+        }),
+    )
+    .expect("build managed turn");
+    let mut state = resident.st;
+    let running = tokio::spawn(async move {
+        let outcome = run.run(&mut state).await;
+        (state, outcome)
+    });
+    tokio::time::timeout(Duration::from_secs(5), ports.submit_started.notified())
+        .await
+        .expect("managed Submit began");
+    cancel.cancel();
+
+    let (state, report) = tokio::time::timeout(Duration::from_secs(5), running)
+        .await
+        .expect("cancelled managed turn completed")
+        .expect("managed turn task");
+    let report = report.expect("cancelled turn report");
+    assert_eq!(report.stop_reason, TurnStopReason::Cancelled);
+    assert_eq!(ports.submits.load(Ordering::Acquire), 1);
+    let records = journal.read_records(&session_id, 0).await.unwrap();
+    assert_eq!(
+        records
+            .iter()
+            .filter(|entry| matches!(entry.record, Record::ManagedCallUnknown { .. }))
+            .count(),
+        1,
+        "cancellation durably revokes every future Submit replay"
+    );
+    assert_eq!(
+        records
+            .iter()
+            .filter(|entry| matches!(
+                &entry.record,
+                Record::TurnCompleted { stop_reason, .. }
+                    if *stop_reason == TurnStopReason::Cancelled
+            ))
+            .count(),
+        1
+    );
+    fake.assert_drained(1, "live managed cancellation").unwrap();
+    journal
+        .release(&session_id, &state.lease)
+        .await
+        .expect("release cancelled managed turn owner");
+}
+
+#[tokio::test]
+async fn a_cancelled_submit_concludes_before_sandbox_reconciliation() {
+    let journal = Journal::new_memory("brain-managed-submit-cancel-materializing");
+    let ports = Arc::new(UnknownManagedPorts::default());
+    ports.block_submit.store(true, Ordering::Release);
+    // The live plane answers status with retryable materialization-in-progress while the
+    // detached submit still drives the launch; a cancelled turn must conclude anyway.
+    ports.status_materializing.store(true, Ordering::Release);
+    let fake = Arc::new(FakeProvider::new(Dialect::AnthropicMessages));
+    let name = "managed_cancel_test".to_owned();
+    fake.script([Scripted::tool(&name, json!({"sleep":30}))]);
+    let provider = fake.clone();
+    let brain = Brain::with_parts_and_services(
+        BrainConfig {
+            idle_discard: Duration::from_secs(300),
+            ..BrainConfig::default()
+        },
+        journal.clone(),
+        Arc::new(crate::keys::PlainCustody),
+        Arc::new(crate::adapter::DisabledToolExecutor),
+        BrainServices {
+            hand: Some(ports.clone()),
+            session_preparation: Some(ports.clone()),
+            sandbox_files: Some(ports.clone()),
+            ..BrainServices::default()
+        },
+        Arc::new(move |_| provider.clone()),
+    );
+    let created = brain
+        .create_session(
+            typed_create(json!({
+                "model":{"provider":"anthropic","name":"managed-cancel","api_key":"key"}
+            })),
+            Some("managed-submit-cancel-mat"),
         )
         .await
         .expect("create live cancellation session");

--- a/crates/brain/src/turn.rs
+++ b/crates/brain/src/turn.rs
@@ -2136,9 +2136,30 @@ impl TurnRun {
                 "managed Tool unknown-outcome reconciliation coordinator is unavailable".into(),
             )
         })?;
-        brain
+        match brain
             .reconcile_managed_unknown_default_sandbox(&self.session_id, st)
-            .await?;
+            .await
+        {
+            Ok(()) => {}
+            Err(BrainError::HandUnavailable(message)) if self.cancel.is_cancelled() => {
+                // The unknown marker is durable and revokes every future Submit replay;
+                // the target may still be materializing under the detached submit task. A
+                // cancelled turn concludes NOW — holding its terminal hostage to the
+                // launch (up to the full materialization time) is what kept cancelled
+                // turns open for minutes. Deferred recovery finishes the exact
+                // status/dematerialization reconciliation.
+                // No recovery anchor is written here: a mid-turn defer_recovery would
+                // race this turn's own lease. The end/delete path drives the exact
+                // dematerialization (as the canaries prove), and an untouched target
+                // expires on its own lease.
+                tracing::warn!(
+                    session = %self.session_id,
+                    error = %message,
+                    "cancelled managed submit leaves sandbox reconciliation to end-driven recovery"
+                );
+            }
+            Err(error) => return Err(error),
+        }
         Ok(DispatchedOutcome::from(managed_unknown_call_outcome(name)))
     }
 


### PR DESCRIPTION
The last red canary: a cancelled submit's turn waited out the entire sandbox materialization because the unknown-outcome path reconciled status synchronously (retryable materialization-in-progress for the whole launch). The cancelled conclusion now lands as soon as ManagedCallUnknown is durable; reconciliation stays with end-driven recovery. New regression gate with a retryable-status port. 201 lib, 12/12 loophost e2e, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrqbMXpmiyxkdazrkGz9d