### PR TITLE
image: repair the npm-removal continuation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,15 @@ RUN cargo build --locked --release -p brain-server --bin brain
 
 FROM debian:bookworm-slim
 # Local mode executes managed Tool bundles through the host node runtime (and bash for shell
-# tools); pin the same node major the repository's JS toolchain uses.
+# tools); pin the same node major the repository's JS toolchain uses. The runtime executes
+# prebuilt bundles with node alone: npm (and its vendored node-tar, the standing Trivy
+# CRITICAL) never belongs in the image.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get purge -y curl gnupg \
-    && rm -rf /var/lib/apt/lists/* \r
-    # The runtime executes prebuilt tool bundles with node alone; npm (and its vendored
-    # node-tar, the standing Trivy CRITICAL) never belongs in the image.
-    && rm -rf /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx
+    && rm -rf /var/lib/apt/lists/* /usr/lib/node_modules/npm /usr/bin/npm /usr/bin/npx
 COPY --from=build /src/target/release/brain /usr/local/bin/brain
 EXPOSE 3210
 ENTRYPOINT ["/usr/local/bin/brain"]


### PR DESCRIPTION
The npm-removal commit mangled the RUN continuation (literal backslash-r) and the image build failed to parse; rewritten cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQrqbMXpmiyxkdazrkGz9d