### PR TITLE
storage: preserve Tool layer media types

### DIFF
--- a/crates/brain-aws/src/s3.rs
+++ b/crates/brain-aws/src/s3.rs
@@ -234,6 +234,7 @@ impl BundleStoragePort for S3SessionStorage {
         &self,
         root_id: &str,
         bundle_digest: &str,
+        media_type: &str,
         bytes: &[u8],
     ) -> Result<brain_protocol::environment::ObjectReference> {
         validate_bundle_digest(bundle_digest)?;
@@ -254,14 +255,14 @@ impl BundleStoragePort for S3SessionStorage {
             .bucket(&self.bucket)
             .key(&key)
             .body(ByteStream::from(bytes.to_vec()))
-            .content_type("application/javascript+esm")
+            .content_type(media_type)
             .metadata("sha256", bundle_digest)
             .send()
             .await
             .map_err(|error| s3_error("store immutable Tool bundle", error))?;
         self.delete_exact_versions(&key, Some(current_version_id(written.version_id())))
             .await?;
-        bundle_object_reference(bundle_digest, bytes.len() as u64)
+        bundle_object_reference(bundle_digest, media_type, bytes.len() as u64)
     }
 
     async fn prepare_bundle_fetch(
@@ -361,13 +362,14 @@ fn validate_bundle_digest(bundle_digest: &str) -> Result<()> {
 
 fn bundle_object_reference(
     bundle_digest: &str,
+    media_type: &str,
     bytes: u64,
 ) -> Result<brain_protocol::environment::ObjectReference> {
     serde_json::from_value(serde_json::json!({
         "object_id": format!("bundle_{bundle_digest}"),
         "bytes": bytes,
         "sha256": bundle_digest,
-        "media_type": "application/javascript+esm",
+        "media_type": media_type,
     }))
     .map_err(BrainError::from)
 }
@@ -848,5 +850,14 @@ mod tests {
         assert!(validate_sha256(&"A".repeat(64)).is_err());
         validate_transfer_id("xfer_12345678").unwrap();
         assert!(validate_transfer_id("../escape").is_err());
+    }
+
+    #[test]
+    fn bundle_references_preserve_the_declared_media_type() {
+        let object = bundle_object_reference(&"a".repeat(64), "application/x-xz", 42).unwrap();
+        assert_eq!(
+            object.media_type.as_deref().map(String::as_str),
+            Some("application/x-xz")
+        );
     }
 }

--- a/crates/brain-standalone/src/storage.rs
+++ b/crates/brain-standalone/src/storage.rs
@@ -85,6 +85,7 @@ impl BundleStoragePort for LocalSessionStorage {
         &self,
         root_id: &str,
         bundle_digest: &str,
+        media_type: &str,
         bytes: &[u8],
     ) -> Result<brain_protocol::environment::ObjectReference> {
         validate_bundle_digest(bundle_digest)?;
@@ -101,7 +102,7 @@ impl BundleStoragePort for LocalSessionStorage {
         let path = self.bundle_path(root_id, bundle_digest)?;
         if let Ok(existing) = tokio::fs::read(&path).await {
             if existing == bytes {
-                return bundle_object_reference(bundle_digest, bytes.len() as u64);
+                return bundle_object_reference(bundle_digest, media_type, bytes.len() as u64);
             }
             return Err(BrainError::Journal(
                 "immutable local Tool bundle digest collision".into(),
@@ -113,7 +114,7 @@ impl BundleStoragePort for LocalSessionStorage {
                 BrainError::Journal(format!("create local bundle directory: {error}"))
             })?;
         atomic_write(&path, bytes).await?;
-        bundle_object_reference(bundle_digest, bytes.len() as u64)
+        bundle_object_reference(bundle_digest, media_type, bytes.len() as u64)
     }
 
     async fn prepare_bundle_fetch(
@@ -172,13 +173,14 @@ fn validate_bundle_digest(bundle_digest: &str) -> Result<()> {
 
 fn bundle_object_reference(
     bundle_digest: &str,
+    media_type: &str,
     bytes: u64,
 ) -> Result<brain_protocol::environment::ObjectReference> {
     serde_json::from_value(serde_json::json!({
         "object_id": format!("bundle_{bundle_digest}"),
         "bytes": bytes,
         "sha256": bundle_digest,
-        "media_type": "application/javascript+esm",
+        "media_type": media_type,
     }))
     .map_err(BrainError::from)
 }
@@ -449,7 +451,7 @@ mod tests {
         let digest = hex::encode(Sha256::digest(bytes));
         let first = LocalSessionStorage::open(&root).unwrap();
         let object = first
-            .store_bundle("ses_bundle_root", &digest, bytes)
+            .store_bundle("ses_bundle_root", &digest, "application/x-xz", bytes)
             .await
             .unwrap();
         assert_eq!(object.object_id.as_str(), format!("bundle_{digest}"));
@@ -457,7 +459,7 @@ mod tests {
         assert_eq!(object.bytes, bytes.len() as u64);
         assert_eq!(
             object.media_type.as_deref().map(String::as_str),
-            Some("application/javascript+esm")
+            Some("application/x-xz")
         );
         assert!(
             first

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -1480,8 +1480,9 @@ impl Brain {
                     if !stored_layers.insert(layer.checksum.clone()) {
                         continue;
                     }
+                    let media_type = layer.media_type.to_string();
                     let object = bundle_storage
-                        .store_bundle(&session_id, &layer.checksum, &layer.bytes)
+                        .store_bundle(&session_id, &layer.checksum, &media_type, &layer.bytes)
                         .await?;
                     let layer_descriptor = descriptor
                         .layers

--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -980,6 +980,7 @@ impl crate::storage::BundleStoragePort for TestBundleStorage {
         &self,
         _root_id: &str,
         _bundle_digest: &str,
+        _media_type: &str,
         _bytes: &[u8],
     ) -> Result<brain_protocol::environment::ObjectReference> {
         panic!("test bundle storage does not accept writes")

--- a/crates/brain/src/storage.rs
+++ b/crates/brain/src/storage.rs
@@ -14,6 +14,7 @@ pub trait BundleStoragePort: Send + Sync {
         &self,
         root_id: &str,
         bundle_digest: &str,
+        media_type: &str,
         bytes: &[u8],
     ) -> Result<brain_protocol::environment::ObjectReference>;
 


### PR DESCRIPTION
## Summary
- preserve each validated Tool artifact layer media type through bundle custody
- set the same media type on S3 writes and returned immutable object references
- cover AWS and standalone storage behavior with regression assertions

## Failure fixed
Environment-backed session creation uploaded a tar.xz runtime layer, but S3 storage rewrote its object reference to application/javascript+esm. Brain then correctly rejected the stored reference because it no longer matched the immutable artifact descriptor, surfacing an internal journal failure.

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- protocol generator plus clean diff
- postprocessor check
- cargo test --workspace --exclude brain-loophost
- cargo test -p brain-loophost
- cargo test -p brain-aws
- release benchmark/leakage gate (throughput and latency passed; Linux CI owns the smaps density measurement)