### PR TITLE
environment: align secret scope and cancellation

### DIFF
--- a/crates/brain-standalone/src/local_environment.rs
+++ b/crates/brain-standalone/src/local_environment.rs
@@ -2342,13 +2342,6 @@ impl SessionPreparationPort for LocalEnvironment {
                             "local secret delivery is not attached",
                         )
                     })?;
-                let first_binding = request.bindings.first().ok_or_else(|| {
-                    environment_error(
-                        EnvironmentErrorCode::BindingConflict,
-                        false,
-                        "secret capability requires a prepared binding",
-                    )
-                })?;
                 let generation = format!("prep_{}", &hash_component(&session_id)[..24]);
                 let secret_request = typed(json!({
                     "capability_ref": capability.capability_ref,
@@ -2360,7 +2353,7 @@ impl SessionPreparationPort for LocalEnvironment {
                         "kind": "environment",
                         "session_id": request.session_id,
                         "root_id": request.root_id,
-                        "binding_ref": first_binding.binding_ref,
+                        "binding_ref": environment_binding_ref,
                     }
                 }))?;
                 let values = delivery.redeem(secret_request).await?.into_env();

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -129,9 +129,22 @@ struct ManagedSecretGrant {
     root_id: String,
     session_id: String,
     environment_id: String,
-    binding_refs: HashSet<String>,
+    target_binding_ref: String,
     env_names: Vec<String>,
     expires_at_ms: u64,
+}
+
+fn managed_secret_scope_matches(
+    grant: &ManagedSecretGrant,
+    request: &brain_protocol::environment::SecretDeliveryRequest,
+) -> bool {
+    grant.root_id == request.root_id.as_str()
+        && grant.session_id == request.session_id.as_str()
+        && grant.environment_id == request.environment_id.as_str()
+        && request.target.root_id.as_str() == grant.root_id
+        && request.target.session_id.as_str() == grant.session_id
+        && grant.target_binding_ref == request.target.binding_ref.as_str()
+        && request.target.kind == brain_protocol::environment::TargetKind::Environment
 }
 
 #[derive(Clone)]
@@ -748,7 +761,7 @@ impl Brain {
         session_id: &str,
         doc: &HeadDoc,
         environment_id: &str,
-        binding_refs: HashSet<String>,
+        target_binding_ref: String,
         mut env_names: Vec<String>,
     ) -> Result<Option<brain_protocol::environment::SecretCapability>> {
         env_names.sort_unstable();
@@ -783,7 +796,7 @@ impl Brain {
                     root_id: doc.root_id.clone(),
                     session_id: session_id.to_owned(),
                     environment_id: environment_id.to_owned(),
-                    binding_refs,
+                    target_binding_ref,
                     env_names: env_names.clone(),
                     expires_at_ms,
                 },
@@ -906,7 +919,7 @@ impl Brain {
             );
         }
 
-        for (_, preparation) in preparations {
+        for (environment_name, preparation) in preparations {
             let mut seen = HashSet::new();
             let mut bundles = Vec::new();
             for digest in preparation.bundle_digests {
@@ -922,7 +935,8 @@ impl Brain {
                 session_id,
                 doc,
                 &preparation.environment_id,
-                preparation.binding_refs,
+                brain_protocol::contract::environment_binding_ref(&doc.root_id, &environment_name)
+                    .to_string(),
                 preparation.env_names,
             )?;
             let request: brain_protocol::environment::PrepareSessionRequest =
@@ -3267,16 +3281,7 @@ impl crate::environment::SecretDeliveryPort for Brain {
             )
         })?;
 
-        if grant.root_id != request.root_id.as_str()
-            || grant.session_id != request.session_id.as_str()
-            || grant.environment_id != request.environment_id.as_str()
-            || request.target.root_id.as_str() != grant.root_id
-            || request.target.session_id.as_str() != grant.session_id
-            || !grant
-                .binding_refs
-                .contains(request.target.binding_ref.as_str())
-            || request.target.kind != brain_protocol::environment::TargetKind::Environment
-        {
+        if !managed_secret_scope_matches(&grant, &request) {
             return Err(secret_delivery_error(
                 EnvironmentErrorCode::BindingConflict,
                 false,

--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -6,6 +6,50 @@ use brain_protocol::session::{ExternalToolCallRequest, ExternalToolCallResponse}
 use serde_json::json;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+#[test]
+fn managed_secret_grant_is_scoped_to_the_environment_target() {
+    let root_id = "ses_rootsecret000000";
+    let session_id = "ses_childsecret0000";
+    let target_binding_ref =
+        brain_protocol::contract::environment_binding_ref(root_id, "workspace").to_string();
+    let grant = ManagedSecretGrant {
+        root_id: root_id.into(),
+        session_id: session_id.into(),
+        environment_id: "environment_secret_test".into(),
+        target_binding_ref: target_binding_ref.clone(),
+        env_names: vec!["SUBAGENT_TOKEN".into()],
+        expires_at_ms: crate::wall_ms() + 1_000,
+    };
+    let request: brain_protocol::environment::SecretDeliveryRequest =
+        serde_json::from_value(json!({
+            "capability_ref":"secret_scope_test",
+            "environment_id":"environment_secret_test",
+            "generation_intent":"generation_secret_test",
+            "root_id":root_id,
+            "session_id":session_id,
+            "target":{
+                "binding_ref":target_binding_ref,
+                "kind":"environment",
+                "root_id":root_id,
+                "session_id":session_id
+            }
+        }))
+        .expect("valid secret delivery request");
+
+    assert!(managed_secret_scope_matches(&grant, &request));
+
+    let mut tool_binding_request = request.clone();
+    tool_binding_request.target.binding_ref = "bnd_sessiontool0000".parse().unwrap();
+    assert!(!managed_secret_scope_matches(&grant, &tool_binding_request));
+
+    let mut other_session_request = request;
+    other_session_request.session_id = "ses_othersecret0000".parse().unwrap();
+    assert!(!managed_secret_scope_matches(
+        &grant,
+        &other_session_request
+    ));
+}
+
 fn test_environment_registry(
     extension: &str,
     execution: Arc<dyn crate::environment::EnvironmentPort>,

--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -5714,6 +5714,17 @@ async fn cancellation_during_managed_submit_is_durable_before_cleanup() {
                 .contract_op(CtxOp::ToolsDispatch { calls: vec![call] })
                 .await?
             {
+                Err(error) if error.code == AgentloopErrorCode::Aborted => {}
+                outcome => Err(BrainError::Agentloop(format!(
+                    "cancelled dispatch returned {outcome:?}"
+                )))?,
+            }
+            let failure = crate::agentloop::op_error(
+                AgentloopErrorCode::Internal,
+                "a loop must not override cancellation",
+                false,
+            );
+            match ctx.contract_op(CtxOp::TurnFail { error: failure }).await? {
                 Err(error) if error.code == AgentloopErrorCode::Aborted => {
                     Ok(crate::agentloop::LoopVerdict {
                         stop_reason: TurnStopReason::Cancelled,
@@ -5721,7 +5732,7 @@ async fn cancellation_during_managed_submit_is_durable_before_cleanup() {
                     })
                 }
                 outcome => Err(BrainError::Agentloop(format!(
-                    "cancelled dispatch returned {outcome:?}"
+                    "terminal after cancellation returned {outcome:?}"
                 ))),
             }
         }

--- a/crates/brain/src/turn.rs
+++ b/crates/brain/src/turn.rs
@@ -265,6 +265,13 @@ impl crate::agentloop::TurnCtx for LoopTurnCtx<'_> {
                 false,
             )));
         }
+        if self.run.cancel.is_cancelled() {
+            return Ok(Err(crate::agentloop::op_error(
+                AgentloopErrorCode::Aborted,
+                "the turn was cancelled",
+                false,
+            )));
+        }
         match op {
             CtxOp::JournalAppend { entries } => self.op_journal_append(entries).await,
             CtxOp::KvGet { keys } => Ok(Ok(CtxOpResult::KvGet {


### PR DESCRIPTION
Fixes the two hosted dev canary failures at their current contract boundaries.\n\n- scope one-time secret grants to the logical environment target presented by environment providers\n- align the standalone environment adapter with that target identity\n- make Brain's cancellation latch reject later loop operations so agent loops cannot overwrite cancellation with failure\n- add focused scope and cancellation regressions\n\nValidation:\n- cargo test --workspace --all-targets\n- cargo clippy --workspace --all-targets -- -D warnings\n- standalone end-to-end rerun after the provider-neutral target correction