### PR TITLE
turn: complete requested cancellation after loop errors

### DIFF
--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -5725,12 +5725,9 @@ async fn cancellation_during_managed_submit_is_durable_before_cleanup() {
                 false,
             );
             match ctx.contract_op(CtxOp::TurnFail { error: failure }).await? {
-                Err(error) if error.code == AgentloopErrorCode::Aborted => {
-                    Ok(crate::agentloop::LoopVerdict {
-                        stop_reason: TurnStopReason::Cancelled,
-                        terminal_committed: false,
-                    })
-                }
+                Err(error) if error.code == AgentloopErrorCode::Aborted => Err(
+                    BrainError::Agentloop("loop surfaced cancellation as an error".into()),
+                ),
                 outcome => Err(BrainError::Agentloop(format!(
                     "terminal after cancellation returned {outcome:?}"
                 ))),

--- a/crates/brain/src/turn.rs
+++ b/crates/brain/src/turn.rs
@@ -1192,7 +1192,17 @@ impl TurnRun {
         rounds: u64,
         tool_calls: u64,
     ) -> Result<TurnReport> {
-        let report = self.run_work_from(st, rounds, tool_calls).await?;
+        let report = match self.run_work_from(st, rounds, tool_calls).await {
+            Ok(report) => report,
+            Err(_) if self.cancel.is_cancelled() => TurnReport {
+                stop_reason: TurnStopReason::Cancelled,
+                rounds: st.head.active_rounds,
+                tool_calls: st.head.active_tool_calls,
+                terminal_committed: false,
+                result: None,
+            },
+            Err(error) => return Err(error),
+        };
         if report.terminal_committed {
             return Ok(report);
         }


### PR DESCRIPTION
## Summary
- normalize a loop error to a cancelled turn when the turn cancellation token has fired
- preserve the durable cancellation terminal path and operation cleanup
- cover the hosted failure shape where the loop surfaces cancellation as an error

## Validation
- cargo test --workspace --all-targets --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- git diff --check