### PR TITLE
journal: identify a commit by its content, not only its position

### DIFF
--- a/crates/brain-aws/src/dynamo.rs
+++ b/crates/brain-aws/src/dynamo.rs
@@ -1069,6 +1069,7 @@ impl JournalStore for DynamoJournal {
         .ok_or_else(|| {
             BrainError::Journal("journal retention delta does not match the projection".into())
         })?;
+        let control_doc_json = serde_json::to_string(&doc.control_doc())?;
         let mut tx = self.db.transact_write_items();
         if requires_ancestor_admission(records) {
             for ancestor_id in &doc.ancestor_ids {
@@ -1132,10 +1133,7 @@ impl JournalStore for DynamoJournal {
                 AttributeValue::N(old_journal_meter.to_string()),
             )
             .expression_attribute_values(":hw", AttributeValue::N(high_water.to_string()))
-            .expression_attribute_values(
-                ":doc",
-                AttributeValue::S(serde_json::to_string(&doc.control_doc())?),
-            )
+            .expression_attribute_values(":doc", AttributeValue::S(control_doc_json.clone()))
             .expression_attribute_values(
                 ":listing",
                 AttributeValue::S(serde_json::to_string(&SessionSummary::from_head(
@@ -1246,10 +1244,16 @@ impl JournalStore for DynamoJournal {
             true => BrainError::Fenced,
             false => BrainError::Journal(format!("commit: {}", describe(&error))),
         };
+        // Recovery and the turn loop both write doc-only commits, so session, fence and high
+        // water alone do not identify one transaction. Two different commits sharing that
+        // position would reuse a token, which the provider rejects with
+        // IdempotentParameterMismatch; including the head document keeps an identical retry
+        // deduped while giving a genuinely different commit its own token.
         let token = transaction_token(&[
             session_id.as_bytes(),
             &fence.to_be_bytes(),
             &high_water.to_be_bytes(),
+            control_doc_json.as_bytes(),
         ]);
         let mut attempt = 0u32;
         loop {
@@ -2025,6 +2029,14 @@ fn transaction_conflicted<R>(
     let SdkError::ServiceError(service) = error else {
         return false;
     };
+    // The stable client request token means a concurrent identical attempt can still be in
+    // flight. Retrying it settles as that attempt's own success.
+    if matches!(
+        service.err(),
+        TransactWriteItemsError::TransactionInProgressException(_)
+    ) {
+        return true;
+    }
     let TransactWriteItemsError::TransactionCanceledException(cancelled) = service.err() else {
         return false;
     };
@@ -2100,6 +2112,20 @@ mod conflict_tests {
     }
 
     #[test]
+    fn an_in_flight_identical_transaction_is_retryable() {
+        use aws_sdk_dynamodb::types::error::TransactionInProgressException;
+        let error = SdkError::service_error(
+            TransactWriteItemsError::TransactionInProgressException(
+                TransactionInProgressException::builder()
+                    .message("Transaction from previous request is still in progress")
+                    .build(),
+            ),
+            (),
+        );
+        assert!(transaction_conflicted(&error));
+    }
+
+    #[test]
     fn pure_conflict_is_retryable() {
         assert!(transaction_conflicted(&cancelled(&[
             "None",
@@ -2140,6 +2166,13 @@ mod conflict_tests {
         let c = transaction_token(&[b"ses_x", &2u64.to_be_bytes()]);
         assert_eq!(a, b);
         assert_ne!(a, c);
+        // Two commits at the same position but with different head documents must not share a
+        // token: the provider rejects the second as IdempotentParameterMismatch.
+        let position: &[&[u8]] = &[b"ses_x", &1u64.to_be_bytes()];
+        let one = transaction_token(&[position[0], position[1], br#"{"state":"ending"}"#]);
+        let two = transaction_token(&[position[0], position[1], br#"{"state":"ended"}"#]);
+        assert_ne!(one, two);
+        assert_ne!(one, a);
         // DynamoDB ClientRequestToken allows at most 36 characters.
         assert_eq!(a.len(), 32);
     }


### PR DESCRIPTION
Both defects appeared in the release's development customer canary once the AWS environment image stopped dying ~70 seconds into a session. With MicroVMs living their full lifetime, durable recovery and the turn loop now overlap on the same session, and the journal's transaction identity was not precise enough for that.

**`TransactionInProgressException` reached a customer as a failed turn.**

```
WARN brain::session: turn failed session=ses_1ff97d8cf009f04dacceb808 turn=trn_8noEhxlwK5WHvk071vF3GKnN
  error=journal: commit: TransactionInProgressException: Transaction from previous request is still in progress
```

The commit path deliberately sends a stable `ClientRequestToken` so that a retry of an invisibly-committed attempt settles as success. That design makes a concurrent identical attempt an expected state, and the provider reports it with this exact error. It now joins `TransactionConflict` in the bounded conflict-retry loop instead of being classified as a journal failure.

**The token could not tell two different commits apart.**

```
WARN brain::session: eager hydrate failed; durable recovery remains due session=ses_53b6c2dec00a9dae7774d0de
  error=journal: commit: IdempotentParameterMismatchException: Specified idempotent token was used with
  different request parameters within the idempotency window
```

The token was derived from session, fence and high water. A doc-only commit — recovery updating the head without appending records — has the same position as the turn loop's commit under the same lease, so two different transactions reused one token. The token now also covers the serialized head document. An identical retry still produces an identical token and dedupes; a genuinely different commit gets its own token and is decided by its own fence and meter conditions rather than by a false idempotency hit.

Both are covered by unit tests: an in-flight transaction classifies as retryable, and two commits at the same position with different head documents produce different tokens.
