### PR TITLE
runtime: forward component instance limits

### DIFF
--- a/crates/brain-component-host/src/worker.rs
+++ b/crates/brain-component-host/src/worker.rs
@@ -265,7 +265,13 @@ fn invocation_span(request: &WorkerRequest) -> tracing::Span {
 
 fn worker_env_allowed(name: &std::ffi::OsStr) -> bool {
     name.to_str().is_some_and(|name| {
-        name == "BRAIN_COMPONENT_CACHE_DIR" || name == "RUST_LOG" || name.starts_with("OTEL_")
+        matches!(
+            name,
+            "BRAIN_COMPONENT_CACHE_DIR"
+                | "BRAIN_COMPONENT_INSTANCE_IDLE_MS"
+                | "BRAIN_COMPONENT_INSTANCE_CAP"
+                | "RUST_LOG"
+        ) || name.starts_with("OTEL_")
     })
 }
 
@@ -965,6 +971,10 @@ mod tests {
     fn worker_only_inherits_observability_configuration() {
         assert!(worker_env_allowed("RUST_LOG".as_ref()));
         assert!(worker_env_allowed("BRAIN_COMPONENT_CACHE_DIR".as_ref()));
+        assert!(worker_env_allowed(
+            "BRAIN_COMPONENT_INSTANCE_IDLE_MS".as_ref()
+        ));
+        assert!(worker_env_allowed("BRAIN_COMPONENT_INSTANCE_CAP".as_ref()));
         assert!(worker_env_allowed("OTEL_EXPORTER_OTLP_ENDPOINT".as_ref()));
         assert!(!worker_env_allowed("AWS_SECRET_ACCESS_KEY".as_ref()));
         assert!(!worker_env_allowed("BRAIN_API_TOKEN".as_ref()));


### PR DESCRIPTION
## Summary

- forward the bounded component instance idle timeout to worker processes
- forward the bounded component instance capacity to worker processes
- retain the existing closed worker environment allowlist

## Verification

- focused brain-component-host test passed locally
- workspace Clippy passed locally
- Linux CI remains authoritative for formatting because the Windows checkout introduces repository-wide CRLF noise