### PR TITLE
customer: keep callback setup alive

### DIFF
--- a/crates/brain-server/src/api/customer_ws.rs
+++ b/crates/brain-server/src/api/customer_ws.rs
@@ -398,7 +398,7 @@ pub(super) async fn customer_environment_gateway(
     brain::customer::CustomerEnvironmentIngressPort::receive(
         coordinator.as_ref(),
         brain::customer::CustomerGatewayInput {
-            route,
+            route: route.clone(),
             connection_id,
             request_id,
             route_key,
@@ -409,7 +409,19 @@ pub(super) async fn customer_environment_gateway(
     )
     .await
     .map_err(map_err)?;
-    let mut response = StatusCode::NO_CONTENT.into_response();
+    customer_gateway_response(route, subprotocol)
+}
+
+pub(super) fn customer_gateway_response(
+    route: brain::customer::CustomerGatewayRoute,
+    subprotocol: Option<String>,
+) -> Result<Response, Failure> {
+    let status = if route == brain::customer::CustomerGatewayRoute::Connect {
+        StatusCode::OK
+    } else {
+        StatusCode::NO_CONTENT
+    };
+    let mut response = status.into_response();
     if let Some(protocol) = subprotocol {
         response.headers_mut().insert(
             header::SEC_WEBSOCKET_PROTOCOL,

--- a/crates/brain-server/src/api_tests/observation_auth.rs
+++ b/crates/brain-server/src/api_tests/observation_auth.rs
@@ -1,5 +1,7 @@
-use super::customer_ws::{bearer_token, customer_grant_subprotocol, observation_grant_header};
-use axum::http::{HeaderMap, HeaderValue, header};
+use super::customer_ws::{
+    bearer_token, customer_gateway_response, customer_grant_subprotocol, observation_grant_header,
+};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 
 #[test]
 fn internal_observation_keeps_operator_and_scoped_grant_separate() {
@@ -83,4 +85,28 @@ fn customer_socket_rejects_missing_extra_or_duplicate_subprotocols() {
         HeaderValue::from_static("environment-grant."),
     );
     assert!(customer_grant_subprotocol(&empty_grant).is_err());
+}
+
+#[test]
+fn customer_gateway_connect_acknowledges_upgrade_and_message_acknowledges_delivery() {
+    let protocol = "environment-grant.valid-token";
+    let connect = customer_gateway_response(
+        brain::customer::CustomerGatewayRoute::Connect,
+        Some(protocol.into()),
+    )
+    .unwrap();
+    assert_eq!(connect.status(), StatusCode::OK);
+    assert_eq!(
+        connect.headers().get(header::SEC_WEBSOCKET_PROTOCOL),
+        Some(&HeaderValue::from_static(protocol))
+    );
+
+    let message =
+        customer_gateway_response(brain::customer::CustomerGatewayRoute::Message, None).unwrap();
+    assert_eq!(message.status(), StatusCode::NO_CONTENT);
+    assert!(
+        !message
+            .headers()
+            .contains_key(header::SEC_WEBSOCKET_PROTOCOL)
+    );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,7 +1080,7 @@
     },
     "packages/brain": {
       "name": "@aexhq/brain",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.25.9"

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Client, tool authoring API, and local builder for the independent Brain session server",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/brain/src/customer.ts
+++ b/packages/brain/src/customer.ts
@@ -220,7 +220,7 @@ export class CustomerEnvironment {
       throw new TypeError("Customer Environment heartbeat bounds are invalid");
     }
     this.#closedPromise = new Promise<void>((resolve) => { this.#resolveClosed = resolve; });
-    this.ready = this.#connectUntilReady();
+    this.ready = this.#connectUntilReady(true);
     // Keep a caller that intentionally closes before awaiting readiness from creating a process-
     // level unhandled rejection. The original promise remains rejecting for explicit awaiters.
     void this.ready.catch(() => undefined);
@@ -297,13 +297,13 @@ export class CustomerEnvironment {
     return this.#opening;
   }
 
-  async #connectUntilReady(): Promise<void> {
+  async #connectUntilReady(keepProcessAlive = false): Promise<void> {
     while (!this.#closed) {
       try {
         await this.#ensureOpen();
         return;
       } catch {
-        await this.#waitReconnect(this.#nextReconnectDelay());
+        await this.#waitReconnect(this.#nextReconnectDelay(), keepProcessAlive);
       }
     }
     throw new Error("Customer Environment is closed");
@@ -482,7 +482,7 @@ export class CustomerEnvironment {
     this.#pendingHeartbeatNonce = undefined;
   }
 
-  async #waitReconnect(delayMs: number): Promise<void> {
+  async #waitReconnect(delayMs: number, keepProcessAlive = false): Promise<void> {
     if (this.#closed) return;
     await new Promise<void>((resolve) => {
       let done = false;
@@ -496,7 +496,7 @@ export class CustomerEnvironment {
       };
       this.#wakeReconnectSleep = finish;
       this.#reconnectSleepTimer = setTimeout(finish, delayMs);
-      unrefTimer(this.#reconnectSleepTimer);
+      if (!keepProcessAlive) unrefTimer(this.#reconnectSleepTimer);
     });
   }
 

--- a/packages/brain/test/customer.test.mjs
+++ b/packages/brain/test/customer.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import test from "node:test";
 
 import { z } from "zod";
@@ -539,4 +540,35 @@ test("close interrupts a pending connector without leaving a reconnect timer", a
     request: { url: "wss://environment.invalid", protocol: "grant.too-late" },
     async observe() {},
   });
+});
+
+test("initial readiness keeps Node alive while the gateway is retrying", async () => {
+  const moduleUrl = new URL("../dist/index.js", import.meta.url).href;
+  const source = `
+    import { CustomerEnvironment } from ${JSON.stringify(moduleUrl)};
+    const environment = new CustomerEnvironment(
+      async () => { throw new Error("gateway unavailable"); },
+      [],
+      () => { throw new Error("socket must not be created"); },
+      { clientId: "app.primary", reconnectDelayMs: 1_000, maxReconnectDelayMs: 1_000 },
+    );
+    await environment.ready;
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "--eval", source], {
+    stdio: "ignore",
+  });
+  const closed = new Promise((resolve) => {
+    child.once("close", (code, signal) => resolve({ code, signal }));
+  });
+  const stillRunning = Symbol("still running");
+  try {
+    const outcome = await Promise.race([
+      closed,
+      new Promise((resolve) => setTimeout(() => resolve(stillRunning), 500)),
+    ]);
+    assert.equal(outcome, stillRunning, `child exited before initial readiness: ${JSON.stringify(outcome)}`);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+    await closed;
+  }
 });


### PR DESCRIPTION
Fix the hosted customer Environment callback handshake and its initial process liveness.\n\n- return HTTP 200 for accepted API Gateway $connect callbacks while preserving the negotiated subprotocol\n- retain HTTP 204 for ordinary message delivery\n- keep initial readiness retry timers referenced until ready or closed; leave post-ready reconnect timers unref'd\n- bump @aexhq/brain to 0.3.2\n- cover the route response contract and Node process liveness regression\n\nLocal verification: scoped rustfmt, workspace clippy with warnings denied, full workspace tests after component build, Brain benchmark CI gates, npm tests, and packed-package smoke.