### PR TITLE
protocol: admit composition capabilities

### DIFF
--- a/contracts/session/v1/schemas.json
+++ b/contracts/session/v1/schemas.json
@@ -349,7 +349,7 @@
             },
             "capability": {
               "type": "string",
-              "pattern": "^brain\\.[A-Za-z0-9_.:-]{1,120}$"
+              "pattern": "^[A-Za-z0-9_.-]{1,128}$"
             }
           }
         }

--- a/crates/brain-protocol/src/session.rs
+++ b/crates/brain-protocol/src/session.rs
@@ -7719,7 +7719,7 @@ impl<'de> ::serde::Deserialize<'de> for ToolDefinitionDescription {
 #[doc = "      \"properties\": {"]
 #[doc = "        \"capability\": {"]
 #[doc = "          \"type\": \"string\","]
-#[doc = "          \"pattern\": \"^brain\\\\.[A-Za-z0-9_.:-]{1,120}$\""]
+#[doc = "          \"pattern\": \"^[A-Za-z0-9_.-]{1,128}$\""]
 #[doc = "        },"]
 #[doc = "        \"kind\": {"]
 #[doc = "          \"type\": \"string\","]
@@ -7840,7 +7840,7 @@ impl<'de> ::serde::Deserialize<'de> for ToolExecutorCallbackRegistration {
 #[doc = r" ```json"]
 #[doc = "{"]
 #[doc = "  \"type\": \"string\","]
-#[doc = "  \"pattern\": \"^brain\\\\.[A-Za-z0-9_.:-]{1,120}$\""]
+#[doc = "  \"pattern\": \"^[A-Za-z0-9_.-]{1,128}$\""]
 #[doc = "}"]
 #[doc = r" ```"]
 #[doc = r" </details>"]
@@ -7863,10 +7863,10 @@ impl ::std::str::FromStr for ToolExecutorCapability {
     fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
         static PATTERN: ::std::sync::LazyLock<::regress::Regex> =
             ::std::sync::LazyLock::new(|| {
-                ::regress::Regex::new("^brain\\.[A-Za-z0-9_.:-]{1,120}$").unwrap()
+                ::regress::Regex::new("^[A-Za-z0-9_.-]{1,128}$").unwrap()
             });
         if PATTERN.find(value).is_none() {
-            return Err("doesn't match pattern \"^brain\\.[A-Za-z0-9_.:-]{1,120}$\"".into());
+            return Err("doesn't match pattern \"^[A-Za-z0-9_.-]{1,128}$\"".into());
         }
         Ok(Self(value.to_string()))
     }

--- a/crates/brain-protocol/tests/conformance.rs
+++ b/crates/brain-protocol/tests/conformance.rs
@@ -159,6 +159,23 @@ fn remote_mcp_is_absent_from_the_single_current_contract() {
 }
 
 #[test]
+fn engine_capabilities_accept_composition_owned_identifiers() {
+    let mut request: Value = serde_json::from_str(include_str!(
+        "../../../contracts/examples/session/CreateSessionRequest.full.json"
+    ))
+    .unwrap();
+    request["tools"]["items"][0]["executor"]["capability"] = Value::String("aex.output".into());
+
+    validate(
+        brain_protocol::SESSION_SCHEMA_JSON,
+        "composition engine capability",
+        "CreateSessionRequest",
+        &request,
+    );
+    serde_json::from_value::<session::CreateSessionRequest>(request).unwrap();
+}
+
+#[test]
 fn session_examples_validate_and_round_trip() {
     for (name, type_name, value) in examples("session") {
         validate(

--- a/crates/brain-server/src/api/customer_ws.rs
+++ b/crates/brain-server/src/api/customer_ws.rs
@@ -11,6 +11,17 @@ pub(super) async fn operator_auth_before_body(
     next.run(request).await
 }
 
+pub(super) async fn global_operator_auth_before_body(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if let Err(failure) = operator_auth(&state, request.headers()) {
+        return failure.into_response();
+    }
+    next.run(request).await
+}
+
 pub(super) async fn create_admission_before_body(
     State(state): State<AppState>,
     request: Request,
@@ -71,7 +82,7 @@ pub(super) async fn internal_observation_auth_before_body(
     request: Request,
     next: Next,
 ) -> Response {
-    if let Err(failure) = auth(&state, request.headers()) {
+    if let Err(failure) = operator_auth(&state, request.headers()) {
         return failure.into_response();
     }
     let grant_id = observation_grant_id(&request);
@@ -283,7 +294,7 @@ pub(super) async fn internal_customer_environment_observation(
     // Internal callers authenticate as the operator/service with Authorization. The scoped
     // customer observation grant is deliberately carried in a separate header so the two
     // authorities cannot be confused or substituted for one another.
-    auth(&state, &headers)?;
+    operator_auth(&state, &headers)?;
     let observation_token =
         observation_grant_header(&headers).ok_or_else(invalid_observation_grant)?;
     apply_customer_environment_observation(&state, &grant_id, observation_token, &body).await
@@ -350,7 +361,7 @@ pub(super) async fn customer_environment_gateway(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, Failure> {
-    auth(&state, &headers)?;
+    operator_auth(&state, &headers)?;
     let connection_id = trusted_header(&headers, "x-brain-connection-id")?;
     let request_id = trusted_header(&headers, "x-brain-request-id")?;
     let route_key = trusted_header(&headers, "x-brain-route-key")?;

--- a/crates/brain-server/src/api/mod.rs
+++ b/crates/brain-server/src/api/mod.rs
@@ -223,12 +223,6 @@ pub fn router(state: AppState) -> Router {
                 .layer(DefaultBodyLimit::max(SMALL_JSON_BODY_LIMIT_BYTES)),
         )
         .route(
-            "/internal/v1/customer-environment/gateway",
-            post(customer_environment_gateway).layer(DefaultBodyLimit::max(
-                brain_protocol::MAX_CUSTOMER_WS_FRAME_BYTES,
-            )),
-        )
-        .route(
             "/internal/v1/customer-environment/dispatch",
             post(customer_environment_dispatch)
                 .layer(DefaultBodyLimit::max(INLINE_FILE_BODY_LIMIT_BYTES)),
@@ -237,6 +231,17 @@ pub fn router(state: AppState) -> Router {
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             operator_auth_before_body,
+        ));
+    let customer_gateway = Router::new()
+        .route(
+            "/internal/v1/customer-environment/gateway",
+            post(customer_environment_gateway).layer(DefaultBodyLimit::max(
+                brain_protocol::MAX_CUSTOMER_WS_FRAME_BYTES,
+            )),
+        )
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            global_operator_auth_before_body,
         ));
 
     let public_observation = Router::new()
@@ -269,6 +274,7 @@ pub fn router(state: AppState) -> Router {
             get(customer_environment_socket),
         )
         .merge(operator)
+        .merge(customer_gateway)
         .merge(public_observation)
         .merge(internal_observation)
         .layer(middleware::from_fn_with_state(
@@ -388,33 +394,37 @@ pub fn nodelay(
 }
 
 fn auth(state: &AppState, headers: &HeaderMap) -> Result<TrustedPrincipal, Failure> {
-    if bearer_token(headers) == Some(state.token.as_str()) {
-        let tenant_id = match (
-            headers
-                .get("x-brain-tenant-id")
-                .and_then(|value| value.to_str().ok()),
-            &state.tenancy,
-        ) {
-            (Some(tenant), _) => tenant,
-            (None, Tenancy::Required) => {
-                return Err(Failure(
-                    StatusCode::BAD_REQUEST,
-                    api_code("invalid_request"),
-                    "x-brain-tenant-id header is required by this composition".into(),
-                ));
-            }
-            (None, Tenancy::Implicit(tenant)) => tenant.as_str(),
-        };
-        let principal = TrustedPrincipal::new(tenant_id).map_err(map_err)?;
-        tracing::Span::current().record("tenant.id", principal.as_str());
-        Ok(principal)
-    } else {
-        Err(Failure(
+    operator_auth(state, headers)?;
+    let tenant_id = match (
+        headers
+            .get("x-brain-tenant-id")
+            .and_then(|value| value.to_str().ok()),
+        &state.tenancy,
+    ) {
+        (Some(tenant), _) => tenant,
+        (None, Tenancy::Required) => {
+            return Err(Failure(
+                StatusCode::BAD_REQUEST,
+                api_code("invalid_request"),
+                "x-brain-tenant-id header is required by this composition".into(),
+            ));
+        }
+        (None, Tenancy::Implicit(tenant)) => tenant.as_str(),
+    };
+    let principal = TrustedPrincipal::new(tenant_id).map_err(map_err)?;
+    tracing::Span::current().record("tenant.id", principal.as_str());
+    Ok(principal)
+}
+
+fn operator_auth(state: &AppState, headers: &HeaderMap) -> Result<(), Failure> {
+    if bearer_token(headers) != Some(state.token.as_str()) {
+        return Err(Failure(
             StatusCode::UNAUTHORIZED,
             api_code("unauthorized"),
             "missing or invalid bearer token".into(),
-        ))
+        ));
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/brain-server/tests/api_admission.rs
+++ b/crates/brain-server/tests/api_admission.rs
@@ -91,6 +91,52 @@ async fn a_tenanted_composition_refuses_requests_without_the_tenant_header() {
 }
 
 #[tokio::test]
+async fn scoped_customer_ingress_does_not_require_a_tenant_header() {
+    let temp = TempDir::new("scoped-customer-ingress");
+    let brain = Brain::in_memory_test(
+        temp.0.clone(),
+        BrainConfig::default(),
+        brain::provider::fake::unscripted_factory(),
+    )
+    .unwrap();
+    let app = router(AppState {
+        brain,
+        token: "operator-token".into(),
+        tenancy: brain_server::api::Tenancy::Required,
+    });
+
+    let gateway = Request::builder()
+        .method("POST")
+        .uri("/internal/v1/customer-environment/gateway")
+        .header(header::AUTHORIZATION, "Bearer operator-token")
+        .header("x-brain-connection-id", "connection-1")
+        .header("x-brain-request-id", "request-1")
+        .header("x-brain-route-key", "$connect")
+        .header("x-brain-source-ip", "192.0.2.10")
+        .header(
+            header::SEC_WEBSOCKET_PROTOCOL,
+            "environment-grant.valid-token",
+        )
+        .body(Body::empty())
+        .unwrap();
+    let gateway_response = app.clone().oneshot(gateway).await.unwrap();
+    assert_eq!(gateway_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let observation = Request::builder()
+        .method("POST")
+        .uri("/internal/v1/customer-environment/observations/grant-1")
+        .header(header::AUTHORIZATION, "Bearer operator-token")
+        .header("x-brain-observation-grant", "observation-token")
+        .body(Body::from("{}"))
+        .unwrap();
+    let observation_response = app.oneshot(observation).await.unwrap();
+    assert_eq!(
+        observation_response.status(),
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+}
+
+#[tokio::test]
 async fn saturated_create_admission_rejects_before_polling_another_body() {
     let temp = TempDir::new("saturated");
     let brain = Brain::in_memory_test(

--- a/crates/brain/src/session_tests.rs
+++ b/crates/brain/src/session_tests.rs
@@ -2278,7 +2278,7 @@ async fn direct_sandbox_transfers_stage_hidden_bytes_and_replay_only_exact_succe
 #[async_trait::async_trait]
 impl ToolExecutor for RecoveryExecutor {
     fn supports(&self, capability: &str) -> bool {
-        capability == "brain.submit"
+        capability == "aex.submit"
     }
 
     async fn call(
@@ -2287,7 +2287,7 @@ impl ToolExecutor for RecoveryExecutor {
         request: ExternalToolCallRequest,
         _cancel: CancellationToken,
     ) -> Result<ExternalToolCallResponse> {
-        assert_eq!(capability, "brain.submit");
+        assert_eq!(capability, "aex.submit");
         self.calls.fetch_add(1, Ordering::Relaxed);
         self.call_ids
             .lock()
@@ -2901,10 +2901,12 @@ async fn hydrate_replays_a_pending_replay_safe_external_call_with_the_same_id() 
     std::fs::create_dir_all(&data_dir).expect("create recovery data dir");
     let journal = Journal::new_memory("brain-recovery-test");
     let executor = Arc::new(RecoveryExecutor::default());
+    let mut policy = submit_policy();
+    policy.capability = "aex.submit".into();
     let brain = Brain::with_parts_and_services(
         BrainConfig {
             idle_discard: Duration::from_secs(300),
-            official_capabilities: HashMap::from([("brain.submit".into(), submit_policy())]),
+            official_capabilities: HashMap::from([("aex.submit".into(), policy)]),
             ..BrainConfig::default()
         },
         journal.clone(),
@@ -2930,7 +2932,7 @@ async fn hydrate_replays_a_pending_replay_safe_external_call_with_the_same_id() 
                             "input_schema": {"type": "object"},
                             "output_schema": {"type": "object"}
                         },
-                        "executor": {"kind": "engine", "capability": "brain.submit"}
+                        "executor": {"kind": "engine", "capability": "aex.submit"}
                     }]
                 }
             }))
@@ -3025,7 +3027,7 @@ async fn hydrate_replays_a_pending_replay_safe_external_call_with_the_same_id() 
             tool.name == "submit"
                 && matches!(
                     &tool.route,
-                    crate::config::ToolRoute::Server(policy) if policy.capability == "brain.submit"
+                    crate::config::ToolRoute::Server(policy) if policy.capability == "aex.submit"
                 )
         }),
         "resolved tools: {resolved:?}; prefix tools: {:?}",
@@ -3041,7 +3043,7 @@ async fn hydrate_replays_a_pending_replay_safe_external_call_with_the_same_id() 
         1,
         "the committed server-tool intent is pending"
     );
-    assert_eq!(pending[0].policy.capability, "brain.submit");
+    assert_eq!(pending[0].policy.capability, "aex.submit");
     // Model the durable failure transition that follows an observed owner loss. It releases
     // the stale lease and installs the bounded retry due-time atomically, so the background
     // scheduler can resume without customer traffic and without waiting another lease term.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,7 +1080,7 @@
     },
     "packages/brain": {
       "name": "@aexhq/brain",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.25.9"

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Client, tool authoring API, and local builder for the independent Brain session server",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/brain/schemas/session.v1.json
+++ b/packages/brain/schemas/session.v1.json
@@ -349,7 +349,7 @@
             },
             "capability": {
               "type": "string",
-              "pattern": "^brain\\.[A-Za-z0-9_.:-]{1,120}$"
+              "pattern": "^[A-Za-z0-9_.-]{1,128}$"
             }
           }
         }


### PR DESCRIPTION
## Outcome

Repair the two Brain-owned boundaries exposed by the development customer canary.

- authenticate the global customer Environment gateway and scoped observation ingress with the operator token without requiring a tenant header; the grant and connection epoch remain the tenant authority
- admit composition-owned engine capability identifiers such as `aex.output`, while configured official-policy admission remains authoritative
- publish the materially changed schema in `@aexhq/brain@0.3.3`

## Live evidence

- callback connect reached Control and Brain, then Brain returned HTTP 400: `x-brain-tenant-id header is required by this composition`
- session create reached Brain, then protocol deserialization returned HTTP 422 because `aex.output` did not match the former Brain-only executor pattern

## Local verification

- generated Rust and TypeScript/package contract artifacts are fresh
- security postprocessor invariants
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- focused protocol, Required-tenancy ingress, and configured `aex.submit` recovery regressions
- non-component-host workspace Rust suite
- Brain Server library/binaries and API/idempotency/race/external suites
- all npm tests and packed empty-consumer smoke

Deployment and npm `latest` promotion remain held.
