### PR TITLE
ci: smoke the published Brain package before promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,12 +166,46 @@ jobs:
           shared-key: workspace-debug
       - run: cargo test -p brain-loophost
 
+  # The release gate itself, run here against the archives this tree would publish. The tagged
+  # publish workflow runs the same script against the staged registry versions, so a break in
+  # this machinery surfaces on a pull request instead of halfway through a release.
+  e2e-smoke:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: Configure the shared component compilation cache
+        run: echo "BRAIN_COMPONENT_CACHE_DIR=$HOME/.cache/aex-brain-components" >> "$GITHUB_ENV"
+      # Read-only: test-component-host owns this key and compiles all four guests into it.
+      - name: Restore compiled components
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/aex-brain-components
+          key: compiled-components-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/brain-component-host/guest/**') }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22.23.2"
+          cache: npm
+      - run: npm ci
+      - run: npm ci --prefix crates/brain-loophost/guest
+      - run: npm run build:components
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.97.1"
+      # Read-only for the same reason: two binaries would replace the full debug cache the
+      # ordinary test legs restore.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: workspace-debug
+          save-if: false
+      - run: cargo build -p brain-server --bin brain --bin brain-component-host
+      - run: npm run e2e-smoke
+
   # The branch-protection gate. Splitting the old serial job into the parallel legs above must
   # not silently weaken protection: this job keeps the required check name and fails unless
   # every leg succeeded (`if: always()` because a skipped required check would satisfy GitHub).
   build-test:
     if: always()
-    needs: [lint, protocol-gen, test, test-component-host, test-loophost]
+    needs: [lint, protocol-gen, test, test-component-host, test-loophost, e2e-smoke]
     runs-on: ubuntu-24.04
     steps:
       - name: every gate passed
@@ -181,6 +215,7 @@ jobs:
           test "${{ needs.test.result }}" = "success"
           test "${{ needs.test-component-host.result }}" = "success"
           test "${{ needs.test-loophost.result }}" = "success"
+          test "${{ needs.e2e-smoke.result }}" = "success"
 
   benchmark-leakage:
     # This release gate is deliberately independent from fmt/clippy/tests: release-mode density

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
   # this machinery surfaces on a pull request instead of halfway through a release.
   e2e-smoke:
     runs-on: ubuntu-24.04
+    # A turn that never terminates is exactly what this gate looks for; bound it like the
+    # publish workflow does instead of holding a runner for the six-hour default.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - name: Configure the shared component compilation cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,11 @@ jobs:
       - run: cargo test -p brain-component-host
       - run: cargo test -p brain-server --test component_tool_environment
       - run: cargo test -p brain-server --test standalone_e2e
+      # The release gate, run here against the archives this tree would publish. It lives in this
+      # job because componentize-js output is not reproducible, so the compilation cache above only
+      # helps a job that already warmed it; the publish workflow pays that warm itself.
+      - run: cargo build -p brain-server --bin brain --bin brain-component-host
+      - run: npm run e2e-smoke
 
   test-loophost:
     runs-on: ubuntu-24.04
@@ -166,49 +171,12 @@ jobs:
           shared-key: workspace-debug
       - run: cargo test -p brain-loophost
 
-  # The release gate itself, run here against the archives this tree would publish. The tagged
-  # publish workflow runs the same script against the staged registry versions, so a break in
-  # this machinery surfaces on a pull request instead of halfway through a release.
-  e2e-smoke:
-    runs-on: ubuntu-24.04
-    # A turn that never terminates is exactly what this gate looks for; bound it like the
-    # publish workflow does instead of holding a runner for the six-hour default.
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v7
-      - name: Configure the shared component compilation cache
-        run: echo "BRAIN_COMPONENT_CACHE_DIR=$HOME/.cache/aex-brain-components" >> "$GITHUB_ENV"
-      # Read-only: test-component-host owns this key and compiles all four guests into it.
-      - name: Restore compiled components
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/aex-brain-components
-          key: compiled-components-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/brain-component-host/guest/**') }}
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "22.23.2"
-          cache: npm
-      - run: npm ci
-      - run: npm ci --prefix crates/brain-loophost/guest
-      - run: npm run build:components
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.97.1"
-      # Read-only for the same reason: two binaries would replace the full debug cache the
-      # ordinary test legs restore.
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: workspace-debug
-          save-if: false
-      - run: cargo build -p brain-server --bin brain --bin brain-component-host
-      - run: npm run e2e-smoke
-
   # The branch-protection gate. Splitting the old serial job into the parallel legs above must
   # not silently weaken protection: this job keeps the required check name and fails unless
   # every leg succeeded (`if: always()` because a skipped required check would satisfy GitHub).
   build-test:
     if: always()
-    needs: [lint, protocol-gen, test, test-component-host, test-loophost, e2e-smoke]
+    needs: [lint, protocol-gen, test, test-component-host, test-loophost]
     runs-on: ubuntu-24.04
     steps:
       - name: every gate passed
@@ -218,7 +186,6 @@ jobs:
           test "${{ needs.test.result }}" = "success"
           test "${{ needs.test-component-host.result }}" = "success"
           test "${{ needs.test-loophost.result }}" = "success"
-          test "${{ needs.e2e-smoke.result }}" = "success"
 
   benchmark-leakage:
     # This release gate is deliberately independent from fmt/clippy/tests: release-mode density

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -178,11 +178,6 @@ jobs:
           path: ${{ runner.temp }}/brain-npm-release
       - name: Configure the shared component compilation cache
         run: echo "BRAIN_COMPONENT_CACHE_DIR=$HOME/.cache/aex-brain-components" >> "$GITHUB_ENV"
-      - name: Restore compiled components
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.cache/aex-brain-components
-          key: compiled-components-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/brain-component-host/guest/**') }}
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
@@ -200,6 +195,13 @@ jobs:
         with:
           shared-key: workspace-debug
           save-if: false
+      # componentize-js emits different bytes every build, so no compilation cache carries across
+      # runs. Compile the guests once here, outside the component host's per-request wall-time
+      # bound, exactly as the ordinary component-host job does before its own end-to-end gates.
+      - name: Warm the component compilation cache
+        run: >-
+          cargo test -p brain-component-host --test vertical_slice
+          four_worlds_execute_without_ambient_authority -- --exact
       - run: cargo build -p brain-server --bin brain --bin brain-component-host
       - name: Run the staged packages against the built server
         shell: bash

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -159,6 +159,65 @@ jobs:
         run: |
           echo "Staged exact versions under npm dist-tag \`next\`: \`$VERSIONS\`" >> "$GITHUB_STEP_SUMMARY"
 
+  # A published package and the built server otherwise meet for the first time in a tagged
+  # platform deployment, where a broken publish costs a whole release cycle to find.
+  smoke:
+    if: inputs.operation == 'stage'
+    needs: stage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v7
+        with:
+          name: brain-npm-release-${{ inputs.expected_commit }}
+          path: ${{ runner.temp }}/brain-npm-release
+      - name: Configure the shared component compilation cache
+        run: echo "BRAIN_COMPONENT_CACHE_DIR=$HOME/.cache/aex-brain-components" >> "$GITHUB_ENV"
+      - name: Restore compiled components
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/aex-brain-components
+          key: compiled-components-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/brain-component-host/guest/**') }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - run: npm ci
+      - run: npm ci --prefix crates/brain-loophost/guest
+      - run: npm run build:components
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.97.1"
+      # Read-only: this job builds two binaries, so saving would replace the full debug cache
+      # that the ordinary test matrix depends on with a much thinner one.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: workspace-debug
+          save-if: false
+      - run: cargo build -p brain-server --bin brain --bin brain-component-host
+      - name: Run the staged packages against the built server
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+        run: |
+          set -euo pipefail
+          node tools/e2e-smoke.mjs \
+            "$RUNNER_TEMP/brain-npm-release/manifest.json" \
+            "$RUNNER_TEMP/brain-e2e-smoke/smoke.json" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v6
+        with:
+          name: brain-e2e-smoke-${{ inputs.expected_commit }}
+          path: ${{ runner.temp }}/brain-e2e-smoke
+          if-no-files-found: error
+          retention-days: 30
+
   promote:
     if: inputs.operation == 'promote'
     needs: validate
@@ -172,6 +231,14 @@ jobs:
       - uses: actions/download-artifact@v7
         with:
           name: brain-npm-release-${{ inputs.expected_commit }}
+          path: ${{ runner.temp }}/brain-npm-release
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.stage_run_id }}
+      # Absent evidence fails this step, and publish.mjs re-checks that it names exactly the
+      # versions being promoted. A stage run that skipped the smoke can never promote.
+      - uses: actions/download-artifact@v7
+        with:
+          name: brain-e2e-smoke-${{ inputs.expected_commit }}
           path: ${{ runner.temp }}/brain-npm-release
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.stage_run_id }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,11 @@
 - `crates/brain-server/tests/standalone_e2e.rs` covers real HTTP, finite SSE, durable SQLite
   journal/storage reopen, and real Node managed-tool subprocesses with a scripted model provider.
   Hosted infrastructure and MicroVM gates belong downstream.
-- `tools/e2e-smoke.mjs` is the release gate for the published pair: it drives a composed session
-  through the installed `@aexhq/brain` archive and the built server. The tagged publish workflow
-  runs it against the exact staged versions between `stage` and `promote`, and promotion fails
-  closed without that evidence.
+- `tools/e2e-smoke.mjs` is the release gate for the published pair: through the installed
+  `@aexhq/brain` archive and the built server it drives a hosted engine capability and the full
+  four-component composition, a Tool running its sealed bundle in a bound component Environment,
+  then ends past a release the Environment refuses. The tagged publish workflow runs it against
+  the exact staged versions between `stage` and `promote`, and promotion fails closed without
+  that evidence.
 - Fail fast, keep comments self-contained, and use plain English.
 - Commit style: `area: imperative summary`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,5 +15,9 @@
 - `crates/brain-server/tests/standalone_e2e.rs` covers real HTTP, finite SSE, durable SQLite
   journal/storage reopen, and real Node managed-tool subprocesses with a scripted model provider.
   Hosted infrastructure and MicroVM gates belong downstream.
+- `tools/e2e-smoke.mjs` is the release gate for the published pair: it drives a composed session
+  through the installed `@aexhq/brain` archive and the built server. The tagged publish workflow
+  runs it against the exact staged versions between `stage` and `promote`, and promotion fails
+  closed without that evidence.
 - Fail fast, keep comments self-contained, and use plain English.
 - Commit style: `area: imperative summary`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "npm run build --workspaces --if-present",
     "build:components": "node crates/brain-component-host/guest/build.mjs",
     "test": "npm test --workspaces --if-present",
-    "package-smoke": "node tools/package-smoke.mjs"
+    "package-smoke": "node tools/package-smoke.mjs",
+    "e2e-smoke": "node tools/e2e-smoke.mjs"
   },
   "engines": { "node": ">=22" }
 }

--- a/tools/e2e-smoke.mjs
+++ b/tools/e2e-smoke.mjs
@@ -1,0 +1,276 @@
+// usage: e2e-smoke.mjs [<release manifest.json> [<smoke evidence path>]]
+//
+// Drives one composed session end to end through an installed @aexhq/brain archive and the
+// binaries this tree builds. With a release manifest it installs exactly those registry versions
+// and records the evidence promotion requires; without one it installs what this tree would
+// publish. Nothing here reaches a model provider, a cloud service or any host but loopback.
+
+import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { createServer as createSocketServer } from "node:net";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const root = path.resolve(import.meta.dirname, "..");
+const npmCli = [
+  process.env.npm_execpath,
+  path.join(path.dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+  path.resolve(path.dirname(process.execPath), "../lib/node_modules/npm/bin/npm-cli.js"),
+].find((candidate) => candidate !== undefined && existsSync(candidate));
+if (npmCli === undefined) throw new Error("could not locate npm-cli.js for the active Node runtime");
+
+// The one hosted engine capability this gate proves Brain admits. Deployment policy still seals
+// the identifier: a request schema that accepts composition-owned names must not widen it.
+const HOSTED_CAPABILITY = "aex.output";
+const UNSEALED_CAPABILITY = "aex.smoke.unsealed";
+const ANSWER = "brain-e2e-smoke-answer";
+const OPERATOR_TOKEN = "brain-e2e-smoke-operator";
+const EXECUTOR_TOKEN = "brain-e2e-smoke-executor";
+
+const workspace = mkdtempSync(path.join(os.tmpdir(), "brain-e2e-smoke-"));
+const consumer = path.join(workspace, "consumer");
+
+const run = (args, cwd = root, stdio = "pipe") =>
+  execFileSync(process.execPath, [npmCli, ...args], { cwd, encoding: "utf8", stdio }).trim();
+
+const binary = (name) => {
+  const file = process.platform === "win32" ? `${name}.exe` : name;
+  const found = ["debug", "release"]
+    .map((profile) => path.join(root, "target", profile, file))
+    .find((candidate) => existsSync(candidate));
+  if (found === undefined) {
+    throw new Error(
+      `build ${name} first: cargo build -p brain-server --bin brain --bin brain-component-host`,
+    );
+  }
+  return found;
+};
+
+const component = (kind) => {
+  const file = path.join(root, "crates/brain-component-host/guest/dist", `${kind}.component.wasm`);
+  if (!existsSync(file)) throw new Error("run npm run build:components before the e2e smoke");
+  return pathToFileURL(file);
+};
+
+/** Exactly the versions the registry serves, or the archives this working tree would publish. */
+const resolveRelease = (manifestPath) => {
+  if (manifestPath === undefined) {
+    const packed = JSON.parse(
+      run(["pack", "--json", "--workspace", "@aexhq/brain", "--pack-destination", workspace]),
+    );
+    assert.equal(packed.length, 1, "npm pack returned an unexpected result for @aexhq/brain");
+    const [item] = packed;
+    return [{
+      name: item.name,
+      version: item.version,
+      integrity: item.integrity,
+      spec: `file:${path.join(workspace, item.filename)}`,
+    }];
+  }
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  assert.equal(manifest.schema, 1, "release manifest has an unsupported shape");
+  return manifest.packages.map(({ name, version, integrity }) => {
+    const published = JSON.parse(run(["view", `${name}@${version}`, "dist.integrity", "--json"]));
+    assert.equal(
+      published,
+      integrity,
+      `${name}@${version} on the registry is not the archive this release staged`,
+    );
+    return { name, version, integrity, spec: `${name}@${version}` };
+  });
+};
+
+/** Import the installed package the way an empty consumer would, through its own resolution. */
+const installRelease = async (release) => {
+  mkdirSync(consumer, { recursive: true });
+  writeFileSync(
+    path.join(consumer, "package.json"),
+    `${JSON.stringify({ private: true, type: "module" }, null, 2)}\n`,
+  );
+  run(["install", "--no-audit", "--no-fund", ...release.map(({ spec }) => spec)], consumer);
+  const entry = path.join(consumer, "entry.mjs");
+  writeFileSync(
+    entry,
+    `export * as brain from "@aexhq/brain";\n` +
+      `export { officialTool } from "@aexhq/brain/internal";\n` +
+      `export { z } from "zod";\n`,
+  );
+  return await import(pathToFileURL(entry));
+};
+
+const freePort = async () =>
+  await new Promise((resolve, reject) => {
+    const probe = createSocketServer();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+
+/**
+ * The composition-owned same-host executor. Hosted Brain reaches Control exactly this way, so the
+ * sidecar needs no model, cloud or outbound dependency of its own.
+ */
+const startCapabilitySidecar = async (calls) => {
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      const call = JSON.parse(body);
+      calls.push({
+        authorized: request.headers.authorization === `Bearer ${EXECUTOR_TOKEN}`,
+        capability: call.context["brain.capability"],
+        name: call.name,
+        input: call.input,
+      });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        outcome: "completed",
+        content: JSON.stringify(call.input),
+        is_error: false,
+        disposition: "continue",
+        result: call.input,
+      }));
+    });
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return { server, url: `http://127.0.0.1:${server.address().port}/` };
+};
+
+const startBrain = async (executorUrl) => {
+  const port = await freePort();
+  const server = spawn(binary("brain"), {
+    cwd: root,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      BRAIN_MODE: "local",
+      BRAIN_DATA_DIR: path.join(workspace, "data"),
+      BRAIN_LISTEN: `127.0.0.1:${port}`,
+      BRAIN_API_TOKEN: OPERATOR_TOKEN,
+      BRAIN_COMPONENT_HOST_BIN: binary("brain-component-host"),
+      BRAIN_COMPONENT_WORKERS: "2",
+      BRAIN_EXTERNAL_TOOL_EXECUTOR_URL: executorUrl,
+      BRAIN_EXTERNAL_TOOL_EXECUTOR_TOKEN: EXECUTOR_TOKEN,
+      BRAIN_EXTERNAL_TOOL_POLICIES_JSON: JSON.stringify([{
+        capability: HOSTED_CAPABILITY,
+        scope: "root",
+        completion: "continue",
+        effect: "opaque",
+        max_input_bytes: 65_536,
+      }]),
+    },
+  });
+  let log = "";
+  const record = (chunk) => { log = `${log}${chunk}`.slice(-16_384); };
+  server.stdout.on("data", record);
+  server.stderr.on("data", record);
+  let exited;
+  server.on("exit", (code, signal) => { exited = `brain exited with ${code ?? signal}`; });
+
+  const base = `http://127.0.0.1:${port}`;
+  const deadline = Date.now() + 120_000;
+  for (;;) {
+    if (exited !== undefined) throw new Error(`${exited}\n${log}`);
+    const ready = await fetch(`${base}/v1/sessions`, {
+      headers: { authorization: `Bearer ${OPERATOR_TOKEN}` },
+    }).then((response) => response.ok, () => false);
+    if (ready) return { server, base, log: () => log };
+    assert.ok(Date.now() < deadline, `brain did not accept requests in time\n${log}`);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+};
+
+const composition = ({ brain, officialTool, z }, capability, modelConfig) => ({
+  model: {
+    component: brain.component("model", component("model"), modelConfig, {
+      metadata: { name: "smoke" },
+    }),
+    name: "smoke-model",
+    apiKey: "sk-brain-e2e-smoke",
+  },
+  agentloop: brain.component("agentloop", component("agentloop"), { fixture: "sequential" }),
+  tools: [officialTool({
+    name: "output",
+    description: "Submit the structured answer.",
+    input: z.object({ text: z.string() }),
+    output: z.object({ text: z.string() }),
+    capability,
+  })],
+});
+
+let sidecar;
+let brainServer;
+try {
+  const release = resolveRelease(process.argv[2]);
+  const installed = await installRelease(release);
+  const { brain } = installed;
+
+  const calls = [];
+  sidecar = await startCapabilitySidecar(calls);
+  brainServer = await startBrain(sidecar.url);
+  const client = new brain.Brain({ token: OPERATOR_TOKEN, baseUrl: brainServer.base });
+  try {
+    const session = await client.sessions.create(composition(installed, HOSTED_CAPABILITY, {
+      toolName: "output",
+      toolInput: { text: ANSWER },
+      finalText: ANSWER,
+    }));
+    assert.equal(await session.send("submit the answer"), ANSWER);
+    assert.deepEqual(calls, [{
+      authorized: true,
+      capability: HOSTED_CAPABILITY,
+      name: "output",
+      input: { text: ANSWER },
+    }]);
+
+    const events = [];
+    for await (const event of session.events({ after: 0, follow: false })) events.push(event);
+    const result = events.find((event) => event.type === "tool.result");
+    assert.equal(result?.name, "output");
+    assert.equal(result?.outcome, "completed");
+    const completed = events.find((event) => event.type === "turn.completed");
+    assert.equal(completed?.stop_reason, "end_turn");
+    assert.equal(completed?.tool_calls, 1);
+
+    // Admitting composition-owned capability names must leave sealed deployment policy the only
+    // authority: an unsealed name is a structured refusal, never the raw HTTP 422 that a
+    // request-schema rejection produces before Brain can compare it with policy.
+    const refused = await client.sessions
+      .create(composition(installed, UNSEALED_CAPABILITY, { finalText: ANSWER }))
+      .then(() => undefined, (error) => error);
+    assert.ok(refused instanceof brain.BrainError, `an unsealed capability was admitted`);
+    assert.equal(refused.status, 400);
+    assert.equal(refused.code, "invalid_request");
+  } finally {
+    client.close();
+  }
+
+  const evidence = process.argv[3];
+  if (evidence !== undefined) {
+    mkdirSync(path.dirname(path.resolve(evidence)), { recursive: true });
+    writeFileSync(
+      path.resolve(evidence),
+      `${JSON.stringify({
+        schema: 1,
+        source: process.env.EXPECTED_COMMIT ?? process.env.GITHUB_SHA ?? "local",
+        packages: release.map(({ name, version, integrity }) => ({ name, version, integrity })),
+      }, null, 2)}\n`,
+    );
+  }
+  process.stdout.write(
+    `Brain e2e smoke passed against ${release.map(({ spec }) => spec).join(", ")}\n`,
+  );
+} catch (error) {
+  if (brainServer !== undefined) process.stderr.write(`${brainServer.log()}\n`);
+  throw error;
+} finally {
+  brainServer?.server.kill();
+  sidecar?.server.close();
+  rmSync(workspace, { recursive: true, force: true });
+}

--- a/tools/e2e-smoke.mjs
+++ b/tools/e2e-smoke.mjs
@@ -1,12 +1,13 @@
 // usage: e2e-smoke.mjs [<release manifest.json> [<smoke evidence path>]]
 //
-// Drives one composed session end to end through an installed @aexhq/brain archive and the
-// binaries this tree builds. With a release manifest it installs exactly those registry versions
-// and records the evidence promotion requires; without one it installs what this tree would
-// publish. Nothing here reaches a model provider, a cloud service or any host but loopback.
+// Drives the composition the product ships end to end through an installed @aexhq/brain archive
+// and the binaries this tree builds. With a release manifest it installs exactly those registry
+// versions and records the evidence promotion requires; without one it installs what this tree
+// would publish. Nothing here reaches a model provider, a cloud service or any host but loopback.
 
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import { createServer as createSocketServer } from "node:net";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -28,8 +29,16 @@ if (npmCli === undefined) throw new Error("could not locate npm-cli.js for the a
 const HOSTED_CAPABILITY = "aex.output";
 const UNSEALED_CAPABILITY = "aex.smoke.unsealed";
 const ANSWER = "brain-e2e-smoke-answer";
+const ENVIRONMENT_ANSWER = "brain-e2e-smoke-environment-answer";
+const REFUSAL = "the relay refused this release";
 const OPERATOR_TOKEN = "brain-e2e-smoke-operator";
 const EXECUTOR_TOKEN = "brain-e2e-smoke-executor";
+const DISPATCH_TOKEN = "brain-e2e-smoke-dispatch";
+// The immutable ESM the bound Environment executes. Its byte count reaches the Environment only if
+// the sealed bundle travelled by content-addressed reference and its layer resolved.
+const BUNDLE = new TextEncoder().encode(
+  "export default async function invoke(input) { return input; }\n",
+);
 
 const workspace = mkdtempSync(path.join(os.tmpdir(), "brain-e2e-smoke-"));
 const consumer = path.join(workspace, "consumer");
@@ -112,37 +121,44 @@ const freePort = async () =>
     });
   });
 
-/**
- * The composition-owned same-host executor. Hosted Brain reaches Control exactly this way, so the
- * sidecar needs no model, cloud or outbound dependency of its own.
- */
-const startCapabilitySidecar = async (calls) => {
+const startEndpoint = async (token, calls, respond) => {
   const server = createServer((request, response) => {
     let body = "";
     request.on("data", (chunk) => { body += chunk; });
     request.on("end", () => {
       const call = JSON.parse(body);
       calls.push({
-        authorized: request.headers.authorization === `Bearer ${EXECUTOR_TOKEN}`,
-        capability: call.context["brain.capability"],
-        name: call.name,
-        input: call.input,
+        authorized: request.headers.authorization === `Bearer ${token}`,
+        ...call,
       });
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({
-        outcome: "completed",
-        content: JSON.stringify(call.input),
-        is_error: false,
-        disposition: "continue",
-        result: call.input,
-      }));
+      const [status, payload] = respond(call);
+      response.writeHead(status, { "content-type": "application/json" });
+      response.end(JSON.stringify(payload));
     });
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   return { server, url: `http://127.0.0.1:${server.address().port}/` };
 };
 
-const startBrain = async (executorUrl) => {
+/**
+ * The composition-owned same-host sidecars. Hosted Brain reaches Control's engine capabilities and
+ * the Environment driver exactly this way, so neither needs a model, cloud or outbound dependency.
+ */
+const startSidecars = async (capabilityCalls, dispatchCalls) => ({
+  capability: await startEndpoint(EXECUTOR_TOKEN, capabilityCalls, (call) => [200, {
+    outcome: "completed",
+    content: JSON.stringify(call.input),
+    is_error: false,
+    disposition: "continue",
+    result: call.input,
+  }]),
+  // A release the Environment declares permanently impossible: the refusal shape that kept a live
+  // plane's sessions ending forever, and whose reason three layers used to destroy.
+  dispatch: await startEndpoint(DISPATCH_TOKEN, dispatchCalls, (call) =>
+    call.action === "release" ? [400, { error: REFUSAL }] : [200, { dispatched: "ok" }]),
+});
+
+const startBrain = async (capabilityUrl, dispatchUrl) => {
   const port = await freePort();
   const server = spawn(binary("brain"), {
     cwd: root,
@@ -161,7 +177,7 @@ const startBrain = async (executorUrl) => {
       // first activation carries engine work, which alone exceeds the 30-second default on a
       // two-vCPU runner; the job timeout is what bounds a genuinely wedged turn.
       BRAIN_PROVIDER_HEADER_TIMEOUT_MS: "300000",
-      BRAIN_EXTERNAL_TOOL_EXECUTOR_URL: executorUrl,
+      BRAIN_EXTERNAL_TOOL_EXECUTOR_URL: capabilityUrl,
       BRAIN_EXTERNAL_TOOL_EXECUTOR_TOKEN: EXECUTOR_TOKEN,
       BRAIN_EXTERNAL_TOOL_POLICIES_JSON: JSON.stringify([{
         capability: HOSTED_CAPABILITY,
@@ -170,10 +186,12 @@ const startBrain = async (executorUrl) => {
         effect: "opaque",
         max_input_bytes: 65_536,
       }]),
+      BRAIN_ENVIRONMENT_DISPATCH_URL: dispatchUrl,
+      BRAIN_ENVIRONMENT_DISPATCH_TOKEN: DISPATCH_TOKEN,
     },
   });
   let log = "";
-  const record = (chunk) => { log = `${log}${chunk}`.slice(-16_384); };
+  const record = (chunk) => { log = `${log}${chunk}`.slice(-32_768); };
   server.stdout.on("data", record);
   server.stderr.on("data", record);
   let exited;
@@ -192,7 +210,7 @@ const startBrain = async (executorUrl) => {
   }
 };
 
-const composition = ({ brain, officialTool, z }, capability, modelConfig) => ({
+const kernel = ({ brain }, modelConfig) => ({
   model: {
     component: brain.component("model", component("model"), modelConfig, {
       metadata: { name: "smoke" },
@@ -201,58 +219,147 @@ const composition = ({ brain, officialTool, z }, capability, modelConfig) => ({
     apiKey: "sk-brain-e2e-smoke",
   },
   agentloop: brain.component("agentloop", component("agentloop"), { fixture: "sequential" }),
-  tools: [officialTool({
+});
+
+/** Model, Agentloop and one Brain-owned engine capability, the shape a hosted create carries. */
+const hostedComposition = (installed, capability, modelConfig) => ({
+  ...kernel(installed, modelConfig),
+  tools: [installed.officialTool({
     name: "output",
     description: "Submit the structured answer.",
-    input: z.object({ text: z.string() }),
-    output: z.object({ text: z.string() }),
+    input: installed.z.object({ text: installed.z.string() }),
+    output: installed.z.object({ text: installed.z.string() }),
     capability,
   })],
 });
 
-let sidecar;
+/** All four component worlds: the Tool runs its sealed bundle inside the bound Environment. */
+const shippedComposition = (installed) => {
+  const definition = {
+    name: "environment_echo",
+    description: "Run the sealed bundle in the bound Environment.",
+    input_schema: { type: "object" },
+    output_schema: { type: "object", required: ["providerOperationId", "value"] },
+  };
+  return {
+    ...kernel(installed, {
+      toolName: definition.name,
+      toolInput: { message: "run the bundle" },
+      finalText: ENVIRONMENT_ANSWER,
+    }),
+    tools: [installed.brain.component(
+      "tool",
+      component("tool"),
+      {
+        definition: {
+          ...definition,
+          contract_digest: createHash("sha256").update(JSON.stringify(definition)).digest("hex"),
+        },
+        useEnvironment: true,
+      },
+      { grants: ["environment"], bundle: BUNDLE },
+    )],
+    environments: {
+      workspace: installed.brain.component("environment", component("environment"), {
+        dispatch: true,
+      }),
+    },
+  };
+};
+
+const replay = async (session) => {
+  const events = [];
+  for await (const event of session.events({ after: 0, follow: false })) events.push(event);
+  return events;
+};
+
+const settle = async (session, state, log) => {
+  const deadline = Date.now() + 60_000;
+  for (;;) {
+    if ((await session.refresh()).state === state) return;
+    assert.ok(Date.now() < deadline, `the session never reached ${state}\n${log()}`);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+};
+
+let sidecars;
 let brainServer;
 try {
   const release = resolveRelease(process.argv[2]);
   const installed = await installRelease(release);
   const { brain } = installed;
 
-  const calls = [];
-  sidecar = await startCapabilitySidecar(calls);
-  brainServer = await startBrain(sidecar.url);
+  const capabilityCalls = [];
+  const dispatchCalls = [];
+  sidecars = await startSidecars(capabilityCalls, dispatchCalls);
+  brainServer = await startBrain(sidecars.capability.url, sidecars.dispatch.url);
   const client = new brain.Brain({ token: OPERATOR_TOKEN, baseUrl: brainServer.base });
   try {
-    const session = await client.sessions.create(composition(installed, HOSTED_CAPABILITY, {
+    const hosted = await client.sessions.create(hostedComposition(installed, HOSTED_CAPABILITY, {
       toolName: "output",
       toolInput: { text: ANSWER },
       finalText: ANSWER,
     }));
-    assert.equal(await session.send("submit the answer"), ANSWER);
-    assert.deepEqual(calls, [{
-      authorized: true,
-      capability: HOSTED_CAPABILITY,
-      name: "output",
-      input: { text: ANSWER },
-    }]);
-
-    const events = [];
-    for await (const event of session.events({ after: 0, follow: false })) events.push(event);
-    const result = events.find((event) => event.type === "tool.result");
-    assert.equal(result?.name, "output");
-    assert.equal(result?.outcome, "completed");
-    const completed = events.find((event) => event.type === "turn.completed");
-    assert.equal(completed?.stop_reason, "end_turn");
-    assert.equal(completed?.tool_calls, 1);
+    assert.equal(await hosted.send("submit the answer"), ANSWER);
+    assert.deepEqual(capabilityCalls.map(({ authorized, name, input, context }) => ({
+      authorized,
+      capability: context["brain.capability"],
+      name,
+      input,
+    })), [{ authorized: true, capability: HOSTED_CAPABILITY, name: "output", input: { text: ANSWER } }]);
+    const hostedEvents = await replay(hosted);
+    const hostedResult = hostedEvents.find((event) => event.type === "tool.result");
+    assert.equal(hostedResult?.name, "output");
+    assert.equal(hostedResult?.outcome, "completed");
+    const hostedCompleted = hostedEvents.find((event) => event.type === "turn.completed");
+    assert.equal(hostedCompleted?.stop_reason, "end_turn");
+    assert.equal(hostedCompleted?.tool_calls, 1);
 
     // Admitting composition-owned capability names must leave sealed deployment policy the only
     // authority: an unsealed name is a structured refusal, never the raw HTTP 422 that a
     // request-schema rejection produces before Brain can compare it with policy.
     const refused = await client.sessions
-      .create(composition(installed, UNSEALED_CAPABILITY, { finalText: ANSWER }))
+      .create(hostedComposition(installed, UNSEALED_CAPABILITY, { finalText: ANSWER }))
       .then(() => undefined, (error) => error);
     assert.ok(refused instanceof brain.BrainError, "an unsealed capability was admitted");
     assert.equal(refused.status, 400);
     assert.equal(refused.code, "invalid_request");
+
+    // The composition the product actually ships. Only the legacy Environment declaration was
+    // driven end to end before, so route, world-identity and release handling drift reached a
+    // deployment instead of this gate.
+    const shipped = await client.sessions.create(shippedComposition(installed));
+    assert.equal(await shipped.send("run the environment Tool"), ENVIRONMENT_ANSWER);
+    const shippedEvents = await replay(shipped);
+    const shippedResult = shippedEvents.find((event) => event.type === "tool.result");
+    assert.equal(shippedResult?.name, "environment_echo");
+    assert.equal(shippedResult?.outcome, "completed");
+    const value = JSON.parse(shippedResult.output_preview);
+    assert.equal(value.value, "environment-ok");
+    assert.match(value.providerOperationId, new RegExp(`^ok:.+:${BUNDLE.byteLength}$`));
+    assert.equal(
+      shippedEvents.find((event) => event.type === "turn.completed")?.stop_reason,
+      "end_turn",
+    );
+    const submits = dispatchCalls.filter((call) => call.action === "submit");
+    assert.equal(submits.length, 1);
+    assert.equal(submits[0].authorized, true);
+
+    // The resource route the SDK addresses a bound Environment by. Drift here is a 404 that only
+    // a client meets, and every in-repo test builds its own request instead. A component
+    // Environment is bound by its Tool rather than materialized, which is the state it reports.
+    assert.equal((await shipped.environment("workspace").status()).state, "never_materialized");
+
+    // A release the Environment declares permanent cannot be cleared by repeating it, and an end
+    // that waits on one is never retired. The end must finish, the release must be attempted, and
+    // the endpoint's own reason must survive every layer that used to drop it.
+    await shipped.end();
+    await settle(shipped, "ended", brainServer.log);
+    const releases = dispatchCalls.filter((call) => call.action === "release");
+    assert.equal(releases.length, 1, "a refused release must be recorded once, never repeated");
+    assert.equal(releases[0].authorized, true);
+    assert.equal(releases[0].request.released, true);
+    assert.match(brainServer.log(), new RegExp(REFUSAL));
   } finally {
     client.close();
   }
@@ -277,6 +384,7 @@ try {
   throw error;
 } finally {
   brainServer?.server.kill();
-  sidecar?.server.close();
+  sidecars?.capability.server.close();
+  sidecars?.dispatch.server.close();
   rmSync(workspace, { recursive: true, force: true });
 }

--- a/tools/e2e-smoke.mjs
+++ b/tools/e2e-smoke.mjs
@@ -154,7 +154,13 @@ const startBrain = async (executorUrl) => {
       BRAIN_LISTEN: `127.0.0.1:${port}`,
       BRAIN_API_TOKEN: OPERATOR_TOKEN,
       BRAIN_COMPONENT_HOST_BIN: binary("brain-component-host"),
-      BRAIN_COMPONENT_WORKERS: "2",
+      // One worker per host: a single sequential session never needs two, and a second worker
+      // would compile and instantiate the same component again on a small CI runner.
+      BRAIN_COMPONENT_WORKERS: "1",
+      // The deadline exists for a network provider. Here the model is a Wasm component whose
+      // first activation carries engine work, which alone exceeds the 30-second default on a
+      // two-vCPU runner; the job timeout is what bounds a genuinely wedged turn.
+      BRAIN_PROVIDER_HEADER_TIMEOUT_MS: "300000",
       BRAIN_EXTERNAL_TOOL_EXECUTOR_URL: executorUrl,
       BRAIN_EXTERNAL_TOOL_EXECUTOR_TOKEN: EXECUTOR_TOKEN,
       BRAIN_EXTERNAL_TOOL_POLICIES_JSON: JSON.stringify([{
@@ -244,7 +250,7 @@ try {
     const refused = await client.sessions
       .create(composition(installed, UNSEALED_CAPABILITY, { finalText: ANSWER }))
       .then(() => undefined, (error) => error);
-    assert.ok(refused instanceof brain.BrainError, `an unsealed capability was admitted`);
+    assert.ok(refused instanceof brain.BrainError, "an unsealed capability was admitted");
     assert.equal(refused.status, 400);
     assert.equal(refused.code, "invalid_request");
   } finally {

--- a/tools/publish.mjs
+++ b/tools/publish.mjs
@@ -125,6 +125,27 @@ const verifyRegistrySignatures = () => {
   }
 };
 
+/**
+ * Promotion may only move `latest` onto versions the stage run already exercised end to end.
+ * Missing or mismatched evidence means the exact archives being promoted were never smoked.
+ */
+const assertStagedSmoke = () => {
+  const file = path.join(directory, "smoke.json");
+  if (!existsSync(file)) {
+    throw new Error("the stage run published no e2e smoke evidence for these versions");
+  }
+  const smoke = JSON.parse(readFileSync(file, "utf8"));
+  const identity = (item) => `${item?.name}@${item?.version} ${item?.integrity}`;
+  if (
+    smoke.schema !== 1 ||
+    smoke.source !== expectedCommit ||
+    smoke.packages?.length !== manifest.packages.length ||
+    !manifest.packages.every((item, index) => identity(smoke.packages[index]) === identity(item))
+  ) {
+    throw new Error("the staged e2e smoke did not cover exactly these release versions");
+  }
+};
+
 const verifyPublishedRelease = async () => {
   for (const item of manifest.packages) {
     assertRegistryObject(item);
@@ -179,6 +200,7 @@ if (operation === "stage") {
   if (!process.env.NODE_AUTH_TOKEN) {
     throw new Error("the protected npm-production environment has no NPM_DIST_TAG_TOKEN");
   }
+  assertStagedSmoke();
   // Validate every immutable object and its original OIDC provenance before moving any tag.
   for (const item of manifest.packages) {
     const staged = registryValue(`${item.name}@next`, "version");


### PR DESCRIPTION
## Why

Almost every defect this release has been a Brain defect, and every one was first seen only in a
full tagged platform deployment whose canary signs up a customer, tops up credit and mints an API
key — none of which any of them needed. Nothing in Brain drove the composition the product ships
against the artifact the product installs.

`standalone_e2e` declares an Environment only in the legacy shape (`extension: "brain.local"`,
`protocol`, `profile`, `configuration`) and never the component shape (`component_digest`, `world`,
`config`) the SDK actually sends. `package-smoke` proves an empty consumer can import the packed
archive; it never creates a session.

## What the smoke drives

`tools/e2e-smoke.mjs` installs an `@aexhq/brain` archive into an empty consumer directory and drives
three sessions against the binaries this tree builds, over real HTTP and finite SSE:

**1. The hosted engine capability.** Model and agentloop components plus an `officialTool` bound to
`aex.output`, the shape a hosted create carries. Asserts the answer, one authorized executor call
carrying `brain.capability`, `tool.result` `completed`, and `turn.completed` with
`stop_reason: end_turn` and `tool_calls: 1`.

**2. A capability outside sealed policy.** The same shape with a schema-valid name the deployment
never sealed must be refused with a structured HTTP 400 `invalid_request` — never the raw 422 a
request-schema rejection produces before Brain can compare the name with policy.

**3. The shipped four-component composition.** A component Model, a component Agentloop, and a
component Tool with the `environment` grant and a sealed ESM bundle, bound to a component
Environment. The turn runs the Tool inside the Environment, whose `submit` dispatches to a loopback
driver. Asserts:
- the Tool result carries the Environment's own terminal (`value: "environment-ok"`) and a
  `providerOperationId` of `ok:<operation>:<bundle bytes>` — the bundle's byte count reaches the
  Environment only if it travelled by content-addressed reference and its layer resolved;
- exactly one authorized `submit` reached the driver;
- `session.environment("workspace").status()` resolves through the SDK's own resource route and
  reports `never_materialized`, the state a bound-but-not-materialized component Environment has;
- then the unhappy half: the driver refuses the release with 400 and a named reason.
  `session.end()` must complete and the session must reach `ended`; the release must be attempted
  exactly once, never repeated; and the driver's own reason must appear in Brain's record, having
  survived `HttpEnvironmentCapabilities`, the component worker boundary and `environment_transport`.

Hermetic: the model is the scripted guest component, both sidecars are loopback Node servers,
storage is local SQLite. The only network is the npm registry.

Each new assertion is mutation-tested: accepting the release instead of refusing it fails the
reason assertion; dropping the sealed bundle fails the `providerOperationId` assertion; pointing
case 2 at the sealed name fails the refusal assertion.

## Gate

Unchanged: `stage` → `smoke` → `promote`. The `smoke` job reads the stage run's `manifest.json`,
asserts each `name@version`'s registry `dist.integrity` equals the staged archive's, installs those
exact versions, and uploads `brain-e2e-smoke-<commit>`. `promote` downloads that artifact from the
same `stage_run_id`; a missing artifact fails the step, and `publish.mjs` re-checks that the
evidence names the same commit and exactly the same `name@version` and integrity set as the
manifest before any dist-tag moves. Keyed on exact versions, never on the `next` dist-tag.

## Cost

The smoke runs inside `test-component-host`, after the steps that already warmed the component
compilation cache — componentize-js emits different bytes on every build, so that cache can only
ever hit within a job that warmed it. Measured on this run: `cargo build` of the two binaries 1s,
`npm run e2e-smoke` 40s. The publish workflow pays the warm itself with the same command.

## What this still does not catch

- **A customer-app Tool.** Trying to cover it found a live defect instead: `tool(...).client()`
  emits `{kind: "customer_app"}`, which the request schema does not admit, so every such create
  fails with `HTTP 422 ... tools.items[0].executor.kind: unknown variant `customer_app`, expected
  one of `component`, `environment`, `engine`` — the same raw-422 signature as the `aex.output`
  defect. Covering it needs a contract change, out of scope while a release is in flight.
- **Subagents / child capabilities.** The fixture agentloop never spawns a child, so the
  `id` vs `child_id` handle contract is untouched.
- **The customer WebSocket frame proof.** Blocked by the same `customer_app` gap.
- **Anything needing hosted infrastructure**: API Gateway's `$connect` envelope, MicroVM
  environments, AWS durability, real providers.

