### PR TITLE
worker: bound worker liveness, not the kernel work a request waits on

### DIFF
--- a/crates/brain-component-host/src/worker.rs
+++ b/crates/brain-component-host/src/worker.rs
@@ -946,7 +946,7 @@ impl Worker {
             let bytes = bounded(
                 id,
                 frame_timeout,
-                "answer",
+                "sent no frame",
                 self.output.read_line(&mut line),
             )
             .await?;
@@ -984,8 +984,14 @@ impl Worker {
     }
 
     async fn send(&mut self, id: u64, frame: &[u8], frame_timeout: Duration) -> anyhow::Result<()> {
-        bounded(id, frame_timeout, "take", self.input.write_all(frame)).await?;
-        bounded(id, frame_timeout, "take", self.input.flush()).await
+        bounded(
+            id,
+            frame_timeout,
+            "accepted no frame",
+            self.input.write_all(frame),
+        )
+        .await?;
+        bounded(id, frame_timeout, "accepted no frame", self.input.flush()).await
     }
 }
 
@@ -994,13 +1000,13 @@ impl Worker {
 async fn bounded<T>(
     id: u64,
     frame_timeout: Duration,
-    verb: &str,
+    silence: &str,
     io: impl Future<Output = std::io::Result<T>>,
 ) -> anyhow::Result<T> {
     match tokio::time::timeout(frame_timeout, io).await {
         Ok(result) => Ok(result?),
         Err(_) => anyhow::bail!(
-            "component worker did not {verb} a frame for request {id} within {}s",
+            "component worker {silence} for request {id} within {}s",
             frame_timeout.as_secs()
         ),
     }

--- a/crates/brain-component-host/src/worker.rs
+++ b/crates/brain-component-host/src/worker.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -20,7 +21,12 @@ use crate::{
 
 const MAX_COMPONENT_BYTES: u64 = 32 << 20;
 const MAX_FRAME_BYTES: usize = 16 << 20;
-const WORKER_REQUEST_TIMEOUT: Duration = Duration::from_secs(90);
+/// How long the parent waits for one worker to make progress on a request: to take a frame,
+/// and to answer with its next one. It is a liveness check on the worker process, the only
+/// thing the parent cannot otherwise observe. Work the parent performs on the request's behalf
+/// (a model round, a Tool dispatch, a child session's turn) happens between frames and is
+/// bounded by the kernel that owns it, so it must not be measured here.
+const WORKER_FRAME_TIMEOUT: Duration = Duration::from_secs(90);
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ComponentSource {
@@ -811,6 +817,7 @@ pub struct WorkerPool {
     next_worker: AtomicUsize,
     next_request: AtomicU64,
     capabilities: Arc<dyn CapabilityHandler>,
+    frame_timeout: Duration,
 }
 
 impl WorkerPool {
@@ -822,6 +829,16 @@ impl WorkerPool {
         program: impl AsRef<Path>,
         size: usize,
         capabilities: Arc<dyn CapabilityHandler>,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::with_frame_timeout(program, size, capabilities, WORKER_FRAME_TIMEOUT).await
+    }
+
+    /// The pool with an explicit worker-liveness bound; tests drive a short one.
+    pub async fn with_frame_timeout(
+        program: impl AsRef<Path>,
+        size: usize,
+        capabilities: Arc<dyn CapabilityHandler>,
+        frame_timeout: Duration,
     ) -> anyhow::Result<Arc<Self>> {
         if !(1..=64).contains(&size) {
             anyhow::bail!("component worker pool size must be between 1 and 64");
@@ -837,6 +854,7 @@ impl WorkerPool {
             next_worker: AtomicUsize::new(0),
             next_request: AtomicU64::new(1),
             capabilities,
+            frame_timeout,
         }))
     }
 
@@ -851,20 +869,16 @@ impl WorkerPool {
         );
         let id = self.next_request.fetch_add(1, Ordering::Relaxed);
         let mut worker = self.workers[index].lock().await;
-        let result = tokio::time::timeout(
-            WORKER_REQUEST_TIMEOUT,
-            worker.call(id, request, self.capabilities.as_ref()),
-        )
-        .await;
-        match result {
-            Ok(Ok(result)) => result.map_err(anyhow::Error::msg),
-            Ok(Err(error)) => {
+        match worker
+            .call(id, request, self.capabilities.as_ref(), self.frame_timeout)
+            .await
+        {
+            Ok(result) => result.map_err(anyhow::Error::msg),
+            Err(error) => {
+                // A worker that stopped speaking the frame protocol is replaced; its resident
+                // instances rehydrate on the next activation.
                 *worker = Worker::spawn(&self.program)?;
                 Err(error)
-            }
-            Err(_) => {
-                *worker = Worker::spawn(&self.program)?;
-                anyhow::bail!("component worker request {id} exceeded the wall-time bound")
             }
         }
     }
@@ -911,6 +925,7 @@ impl Worker {
         id: u64,
         request: WorkerRequest,
         capabilities: &dyn CapabilityHandler,
+        frame_timeout: Duration,
     ) -> anyhow::Result<Result<Value, String>> {
         if self.child.try_wait()?.is_some() {
             anyhow::bail!("component worker exited before request {id}");
@@ -924,12 +939,17 @@ impl Worker {
             anyhow::bail!("component worker request exceeds the frame bound");
         }
         encoded.push(b'\n');
-        self.input.write_all(&encoded).await?;
-        self.input.flush().await?;
+        self.send(id, &encoded, frame_timeout).await?;
 
         loop {
             let mut line = String::new();
-            let bytes = self.output.read_line(&mut line).await?;
+            let bytes = bounded(
+                id,
+                frame_timeout,
+                "answer",
+                self.output.read_line(&mut line),
+            )
+            .await?;
             if bytes == 0 {
                 anyhow::bail!("component worker closed before response {id}");
             }
@@ -945,6 +965,8 @@ impl Worker {
                     id: capability_id,
                     call,
                 } => {
+                    // The kernel owns how long this takes and bounds it itself. The worker is
+                    // parked on stdin meanwhile, so none of it is the worker falling silent.
                     let result = capabilities.call(call).await;
                     let mut encoded = serde_json::to_vec(&ParentFrame::CapabilityResult {
                         id: capability_id,
@@ -954,12 +976,33 @@ impl Worker {
                         anyhow::bail!("component capability response exceeds the frame bound");
                     }
                     encoded.push(b'\n');
-                    self.input.write_all(&encoded).await?;
-                    self.input.flush().await?;
+                    self.send(id, &encoded, frame_timeout).await?;
                 }
                 _ => anyhow::bail!("component worker response id does not match request {id}"),
             }
         }
+    }
+
+    async fn send(&mut self, id: u64, frame: &[u8], frame_timeout: Duration) -> anyhow::Result<()> {
+        bounded(id, frame_timeout, "take", self.input.write_all(frame)).await?;
+        bounded(id, frame_timeout, "take", self.input.flush()).await
+    }
+}
+
+/// One wait on the worker itself. Exceeding it means the worker stopped speaking the frame
+/// protocol, which is the condition [`WORKER_FRAME_TIMEOUT`] exists to catch.
+async fn bounded<T>(
+    id: u64,
+    frame_timeout: Duration,
+    verb: &str,
+    io: impl Future<Output = std::io::Result<T>>,
+) -> anyhow::Result<T> {
+    match tokio::time::timeout(frame_timeout, io).await {
+        Ok(result) => Ok(result?),
+        Err(_) => anyhow::bail!(
+            "component worker did not {verb} a frame for request {id} within {}s",
+            frame_timeout.as_secs()
+        ),
     }
 }
 

--- a/crates/brain-component-host/tests/vertical_slice.rs
+++ b/crates/brain-component-host/tests/vertical_slice.rs
@@ -369,3 +369,171 @@ async fn worker_keeps_environment_and_model_lifecycles_resident() {
     .await
     .unwrap();
 }
+
+/// The bound is a liveness check on the worker, so it must not be spent on work the parent does
+/// on the request's behalf. `subagents.wait` blocks one ctx op on a child session's turn for up
+/// to its own 300 s kernel bound; before this was scoped to frames, the 90 s request bound killed
+/// the worker mid-wait and failed the whole turn.
+const TEST_FRAME_BOUND: std::time::Duration = std::time::Duration::from_secs(5);
+
+struct SlowKernel;
+
+#[async_trait::async_trait]
+impl CapabilityHandler for SlowKernel {
+    async fn call(&self, _call: CapabilityCall) -> Result<Value, CapabilityFailure> {
+        tokio::time::sleep(TEST_FRAME_BOUND * 3).await;
+        Ok(Value::String(r#"{"child":"done"}"#.into()))
+    }
+}
+
+fn agentloop_activation(instance: &str, config: &str) -> WorkerRequest {
+    let path = component_path("agentloop");
+    let bytes = std::fs::read(&path).unwrap();
+    WorkerRequest::Agentloop {
+        instance_id: instance.into(),
+        component: ComponentSource {
+            path,
+            sha256: component_digest(&bytes),
+        },
+        request: agentloop::aex::agentloop::types::Activation {
+            operation_id: format!("activation_{instance}"),
+            session_id: instance.into(),
+            kind: "message".into(),
+            payload_json: r#"{"activation_id":"act_1","message":{"content":[]}}"#.into(),
+            config_json: config.into(),
+            deadline_at_ms: u64::MAX,
+        },
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_request_waiting_on_the_kernel_outlives_the_worker_frame_bound() {
+    let pool = WorkerPool::with_frame_timeout(
+        env!("CARGO_BIN_EXE_component-host"),
+        1,
+        Arc::new(SlowKernel),
+        TEST_FRAME_BOUND,
+    )
+    .await
+    .unwrap();
+    let path = component_path("tool");
+    let bytes = std::fs::read(&path).unwrap();
+    let response = pool
+        .call(WorkerRequest::Tool {
+            component: ComponentSource {
+                path,
+                sha256: component_digest(&bytes),
+            },
+            request: tool::aex::tool::types::Invocation {
+                metadata: tool::aex::tool::types::CallMetadata {
+                    tenant_id: "tenant_1".into(),
+                    session_id: "ses_1".into(),
+                    turn_id: "turn_1".into(),
+                    call_id: "call_subagents".into(),
+                    tool_name: "subagents".into(),
+                },
+                input_json: r#"{"action":"wait"}"#.into(),
+                config_json: r#"{"useEnvironment":true}"#.into(),
+                deadline_at_ms: u64::MAX,
+            },
+            grants: vec!["environment".into()],
+        })
+        .await
+        .unwrap();
+    assert_eq!(response["value_json"], r#"{"child":"done"}"#);
+}
+
+/// The bound still stops a worker that genuinely goes silent, and names why. The instance is
+/// resident first, so the only thing between the request and the missing frame is the guest.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_worker_that_stops_answering_is_stopped_with_a_named_reason() {
+    let pool = WorkerPool::with_frame_timeout(
+        env!("CARGO_BIN_EXE_component-host"),
+        1,
+        Arc::new(DenyEverything),
+        TEST_FRAME_BOUND,
+    )
+    .await
+    .unwrap();
+    pool.call(agentloop_activation("ses_spin", r#"{"track":true}"#))
+        .await
+        .unwrap();
+    let error = pool
+        .call(agentloop_activation("ses_spin", r#"{"fixture":"spin"}"#))
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .starts_with("component worker did not answer a frame for request"),
+        "{error}"
+    );
+}
+
+struct DenyEverything;
+
+#[async_trait::async_trait]
+impl CapabilityHandler for DenyEverything {
+    async fn call(&self, _call: CapabilityCall) -> Result<Value, CapabilityFailure> {
+        Err(CapabilityFailure {
+            code: "capability_denied".into(),
+            message: "no capability is bound".into(),
+            retryable: false,
+        })
+    }
+}
+
+/// A ctx op that needs the same pool (a subagent's child turn) waits for a free worker. It is
+/// the kernel's own bound that releases it, so the parent always finishes: head-of-line blocking
+/// degrades the child, it never wedges the caller.
+struct NestedChild {
+    pool: std::sync::OnceLock<Arc<WorkerPool>>,
+}
+
+#[async_trait::async_trait]
+impl CapabilityHandler for NestedChild {
+    async fn call(&self, call: CapabilityCall) -> Result<Value, CapabilityFailure> {
+        if call.request["op"]["op"].as_str() == Some("model_stream") {
+            let pool = self.pool.get().expect("pool").clone();
+            let child = tokio::time::timeout(
+                TEST_FRAME_BOUND,
+                pool.call(agentloop_activation("ses_child", r#"{"track":true}"#)),
+            )
+            .await;
+            assert!(child.is_err(), "the only worker is held by the parent");
+            return Ok(Value::String(
+                serde_json::json!({"result":{"message":{"content":[],"stop_reason":"end_turn"}}})
+                    .to_string(),
+            ));
+        }
+        Ok(Value::String(
+            serde_json::json!({ "result": Value::Null }).to_string(),
+        ))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_nested_request_is_delayed_but_the_parent_still_completes() {
+    let capabilities = Arc::new(NestedChild {
+        pool: std::sync::OnceLock::new(),
+    });
+    let pool = WorkerPool::with_capabilities(
+        env!("CARGO_BIN_EXE_component-host"),
+        1,
+        capabilities.clone(),
+    )
+    .await
+    .unwrap();
+    capabilities.pool.set(pool.clone()).ok();
+    let returned = pool
+        .call(agentloop_activation(
+            "ses_parent",
+            r#"{"fixture":"sequential"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        returned["payload_json"],
+        r#"{"activation_id":"act_1","outcome":"completed"}"#
+    );
+}

--- a/crates/brain-component-host/tests/vertical_slice.rs
+++ b/crates/brain-component-host/tests/vertical_slice.rs
@@ -465,7 +465,7 @@ async fn a_worker_that_stops_answering_is_stopped_with_a_named_reason() {
     assert!(
         error
             .to_string()
-            .starts_with("component worker did not answer a frame for request"),
+            .starts_with("component worker sent no frame for request"),
         "{error}"
     );
 }


### PR DESCRIPTION
## The defect

The canary's `subagent` case fails with the epoch trap now gone:

```
tool.result subagents outcome=failed
  error="provider transport: Tool component: component worker request 2 exceeded the wall-time bound"
turn.failed code=agentloop_error
  "agentloop: component worker request 9 exceeded the wall-time bound"
```

## Cause

`WorkerPool::call` wrapped the *whole* pool call in `tokio::time::timeout(WORKER_REQUEST_TIMEOUT, …)`.
That future includes `Worker::call`'s frame loop, and the frame loop awaits
`capabilities.call(call)` — the parent doing kernel work on the request's behalf. So the
90 s bound measured the kernel, not the worker.

The subagents Tool reaches `execute_child_capability`'s `wait` action
(`crates/brain/src/session/engine/subagents.rs`), which blocks on `wait_child` for up to
its own `timeout_ms`, defaulted to 30 000 and **capped at 300 000**. One capability call
is therefore allowed by the kernel to take five minutes. At 90 s the parent gave up on a
worker that was idle and healthy — parked on stdin waiting for the capability result it
had asked for — killed it, respawned it (destroying every resident instance on it), and
failed both the Tool and the activation that dispatched it.

Same distinction as the epoch slice, one level out: the seam is `Worker::call`'s read
loop, where `read_line` is the only place the parent waits on the worker and
`capabilities.call` is the only place it waits on itself.

### Evidence

At the worker layer, with a capability handler standing in for a child session's turn
(100 s, inside the kernel's own 300 s allowance):

```
TOOL      after  90.17s: Err(component worker request 1 exceeded the wall-time bound)
AGENTLOOP after  91.10s: Err(component worker request 1 exceeded the wall-time bound)
```

`brain-toolhost` wraps the first as `Tool component: {error}`, which is the canary's line
verbatim. With this change:

```
TOOL      after 100.87s: Ok({"value_json":"{\"child\":\"done\"}"})
AGENTLOOP after 200.85s: Ok({"payload_json":"{…,\"outcome\":\"completed\"}"})
```

## The change

`crates/brain-component-host/src/worker.rs`:

- `WORKER_REQUEST_TIMEOUT` → `WORKER_FRAME_TIMEOUT`, still 90 s, now applied to each
  individual wait on the worker: `read_line` for its next frame, and `write_all`/`flush`
  handing it one. A `bounded()` helper names which side went quiet.
- `WorkerPool::call` no longer wraps the request; a frame-bound expiry returns `Err`,
  which already lands in the respawn arm, so a wedged worker is still replaced.
- The bound is a `WorkerPool` field with `with_frame_timeout`; `with_capabilities` keeps
  the 90 s default. Production behaviour for a healthy worker is unchanged.

**The bound is not raised and nothing it protected is now unprotected.** It exists so the
parent can detect a worker child process that has stopped answering — the one thing it
cannot otherwise observe — and it still does, in 90 s. Everything it *used* to cover
incidentally is owned and bounded elsewhere, by the layer that knows what the work is:

| work | its real bound |
| --- | --- |
| a managed Tool call | sealed `deadline_at_ms` from `managed_environment_resources().timeout_ms` (`turn.rs`) |
| a model round | `provider_header_timeout` / `idle_timeout` / `total_timeout` |
| a subagent wait | `subagents.wait` `timeout_ms`, capped at 300 s |
| contiguous guest execution | the 30 s epoch slice, re-armed only on host progress (#68) |
| rounds in a turn | `Limits::max_rounds` |

Component instantiation still counts against the frame bound, and correctly so: that is
the worker's own work, which is why `BRAIN_COMPONENT_CACHE_DIR` on a durable volume is a
deployment requirement rather than an optimisation.

## Regression

Three tests in `crates/brain-component-host/tests/vertical_slice.rs`, on the existing
`test-component-host` CI leg, no deployment. The first two fail with the pre-change
scoping, reporting exactly `component worker request N exceeded the wall-time bound`:

- `a_request_waiting_on_the_kernel_outlives_the_worker_frame_bound` — the defect: a Tool
  whose capability is serviced for 3× the bound completes.
- `a_worker_that_stops_answering_is_stopped_with_a_named_reason` — a resident instance is
  warmed first, then spins; the bound still fires, and names why.
- `a_nested_request_is_delayed_but_the_parent_still_completes` — see below.

## What I checked before shipping this

Removing a timeout can turn a failure into a hang, so I looked for one. There is a real
re-entrancy path: `create_child_session` spawns the child's actor, and the child's own
activation goes back to the *same* loop pool while the parent's activation still holds a
worker. Affinity is `hash(instance_id) % workers`, so with the default 4 workers a
parent/child collision is 1-in-4, and the colliding child cannot start until the parent's
worker frees. I reproduced this (pool size 1): today the parent's 90 s bound is the only
thing that unwedges it.

It does not become a hang, because every kernel capability is itself bounded — the table
above is exhaustive for this seam. The parent's capability always returns, always releases
the worker, and the child is merely delayed. `a_nested_request_is_delayed_but_the_parent_still_completes`
pins that property: pool size 1, the nested child call cannot get a worker, the kernel's
bound releases it, and the parent activation still completes.

## Named, not fixed here

**Head-of-line blocking.** `WorkerPool::call` holds a worker exclusively for the whole
request including capability servicing, so a `subagents.wait` occupies a worker for the
whole wait while the worker process sits idle. A colliding subagent is therefore degraded
(its child does not run until the parent's turn ends) even though it is no longer fatal.
The real fix is to stop making exclusivity a property of the request: demultiplex frames
by id in the parent and let the worker execute concurrently, which also makes per-request
liveness natural. That is a worker-protocol change, not a bound change, and it should not
ride a release-blocker fix. Raising `BRAIN_COMPONENT_WORKERS` (default 4) lowers the
collision odds meanwhile.

Per your note, `ComponentAgentloop`'s `started` set diverging from worker-side residency
is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTKXL4hmbssi59fhiaf72c
