### PR TITLE
environment: reach the Environment host, its routes and its proof

### DIFF
--- a/contracts/examples/session/Session.idle.json
+++ b/contracts/examples/session/Session.idle.json
@@ -29,5 +29,8 @@
   "agentloop": {
     "component_digest": "a1fce4363854ff888cff4b8e7875d600c2682390412a8cf79b37d0b11148b0fa",
     "world": "aex:agentloop/agentloop@1.0.0"
-  }
+  },
+  "environments": [
+    "workspace"
+  ]
 }

--- a/contracts/examples/session/SessionList.example.json
+++ b/contracts/examples/session/SessionList.example.json
@@ -28,7 +28,8 @@
       "turns": 4,
       "metadata": {
         "customer_ref": "job-77"
-      }
+      },
+      "environments": []
     }
   ],
   "has_more": false

--- a/contracts/session/v1/customer-frame-proof.json
+++ b/contracts/session/v1/customer-frame-proof.json
@@ -1,0 +1,5 @@
+{
+  "description": "Domain-separated customer-Environment frame proof. Brain's coordinator and every client runner must derive the same value from one consumed connect grant.",
+  "protocol": "environment-grant.g_conformance",
+  "proof": "d9dbb717ef1147776c3320e38c49eafabce423e870e72836ce40e88480550718"
+}

--- a/contracts/session/v1/schemas.json
+++ b/contracts/session/v1/schemas.json
@@ -675,7 +675,8 @@
         "retain_until",
         "updated_at",
         "turns",
-        "metadata"
+        "metadata",
+        "environments"
       ],
       "properties": {
         "id": {
@@ -734,6 +735,15 @@
         },
         "storage": {
           "$ref": "#/$defs/StorageInfo"
+        },
+        "environments": {
+          "type": "array",
+          "maxItems": 32,
+          "uniqueItems": true,
+          "description": "Sorted names of the Environments sealed into this session's prefix. Each names one addressable /v1/sessions/{session_id}/environments/{environment} resource; a session that declared none has an empty array.",
+          "items": {
+            "$ref": "#/$defs/EnvironmentName"
+          }
         },
         "created_at": {
           "$ref": "#/$defs/Timestamp"

--- a/crates/brain-component-host/guest/fixtures/environment.mjs
+++ b/crates/brain-component-host/guest/fixtures/environment.mjs
@@ -1,9 +1,25 @@
+import { dispatch } from "aex:environment/host@1.0.0";
+
 export function resolve(request) {
-  return { bindingJson: JSON.stringify({ environmentId: request.environmentId }) };
+  const config = JSON.parse(request.configJson);
+  return {
+    bindingJson: JSON.stringify({
+      environmentId: request.environmentId,
+      dispatch: config.dispatch === true,
+    }),
+  };
 }
 
-export function submit(_bindingJson, operation) {
-  return { providerOperationId: `${operation.operationId}:${operation.bundle?.length ?? 0}` };
+export function submit(bindingJson, operation) {
+  const suffix = `${operation.operationId}:${operation.bundle?.length ?? 0}`;
+  if (JSON.parse(bindingJson).dispatch !== true) return { providerOperationId: suffix };
+  const response = dispatch(
+    operation.operationId,
+    "submit",
+    JSON.stringify({ operation_id: operation.operationId }),
+    operation.deadlineAtMs,
+  );
+  return { providerOperationId: `${JSON.parse(response).dispatched}:${suffix}` };
 }
 
 export function observe(_bindingJson, providerOperationId, cursor) {

--- a/crates/brain-component-host/src/runtime.rs
+++ b/crates/brain-component-host/src/runtime.rs
@@ -23,6 +23,14 @@ const EPOCH_TICK: Duration = Duration::from_millis(10);
 const EPOCH_DEADLINE_TICKS: u64 = 3_000;
 const MEMORY_LIMIT_BYTES: usize = 256 << 20;
 
+/// The WIT world *name* a running component was instantiated for. It is what `CapabilityCall::world`
+/// carries and what keys a capability route or a resident instance; it is not the versioned world
+/// id in `generated.rs`. Every crate that binds, routes or guards a capability uses these.
+pub const AGENTLOOP_COMPONENT: &str = "agentloop";
+pub const TOOL_COMPONENT: &str = "tool";
+pub const ENVIRONMENT_COMPONENT: &str = "environment";
+pub const MODEL_COMPONENT: &str = "model";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CapabilityCall {
     pub world: String,
@@ -197,7 +205,7 @@ impl State {
         metadata: tool::aex::tool::types::CallMetadata,
         grants: &[String],
     ) -> Self {
-        let mut state = Self::new(capabilities, "tool", Some(metadata.call_id.clone()));
+        let mut state = Self::new(capabilities, TOOL_COMPONENT, Some(metadata.call_id.clone()));
         state.tool_metadata = Some(metadata);
         state.tool_grants.extend(grants.iter().cloned());
         state
@@ -1056,7 +1064,7 @@ impl ComponentRuntime {
         )?;
         let mut store = self.store_with(State::new(
             self.capabilities.clone(),
-            "agentloop",
+            AGENTLOOP_COMPONENT,
             instance_id,
         ));
         let bindings =
@@ -1127,7 +1135,7 @@ impl ComponentRuntime {
         >(&mut linker, |state| state))?;
         let mut store = self.store_with(State::new(
             self.capabilities.clone(),
-            "environment",
+            ENVIRONMENT_COMPONENT,
             instance_id,
         ));
         let bindings =
@@ -1190,8 +1198,11 @@ impl ComponentRuntime {
             &mut linker,
             |state| state,
         ))?;
-        let mut store =
-            self.store_with(State::new(self.capabilities.clone(), "model", instance_id));
+        let mut store = self.store_with(State::new(
+            self.capabilities.clone(),
+            MODEL_COMPONENT,
+            instance_id,
+        ));
         let bindings = wt(model::Model::instantiate_async(&mut store, &component, &linker).await)?;
         Ok(ModelInstance { store, bindings })
     }

--- a/crates/brain-component-host/src/worker.rs
+++ b/crates/brain-component-host/src/worker.rs
@@ -639,13 +639,13 @@ async fn execute(
         }
         WorkerRequest::Release { world, instance_id } => {
             match world.as_str() {
-                "agentloop" => {
+                crate::AGENTLOOP_COMPONENT => {
                     agentloops.remove(&instance_id);
                 }
-                "environment" => {
+                crate::ENVIRONMENT_COMPONENT => {
                     environments.remove(&instance_id);
                 }
-                "model" => {
+                crate::MODEL_COMPONENT => {
                     models.remove(&instance_id);
                 }
                 _ => anyhow::bail!("unknown resident component world {world}"),

--- a/crates/brain-environment-host/src/lib.rs
+++ b/crates/brain-environment-host/src/lib.rs
@@ -5,13 +5,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use brain::environment::{
-    COMPONENT_ENVIRONMENT_WORLD, ComponentEnvironmentInvocation, ComponentEnvironmentRegistry,
-};
+use brain::environment::{ComponentEnvironmentInvocation, ComponentEnvironmentRegistry};
 use brain::{BrainError, Result};
 use brain_component_host::{
     CapabilityCall, CapabilityFailure, CapabilityHandler, CapabilityRouter, ComponentSource,
-    ENVIRONMENT_WORLD, WorkerPool, WorkerRequest, component_digest, environment,
+    ENVIRONMENT_COMPONENT, ENVIRONMENT_WORLD, WorkerPool, WorkerRequest, component_digest,
+    environment,
 };
 use futures_util::StreamExt;
 use serde::Serialize;
@@ -65,7 +64,7 @@ impl WasmEnvironmentRegistry {
 #[async_trait]
 impl ComponentEnvironmentRegistry for WasmEnvironmentRegistry {
     fn admit(&self, digest: &str, world: &str, component: &[u8]) -> Result<()> {
-        if world != COMPONENT_ENVIRONMENT_WORLD || world != ENVIRONMENT_WORLD {
+        if world != ENVIRONMENT_WORLD {
             return Err(BrainError::Invalid(format!(
                 "Environment world {world:?} is not supported; expected {ENVIRONMENT_WORLD:?}"
             )));
@@ -378,7 +377,7 @@ impl std::fmt::Debug for HttpEnvironmentCapabilities {
 #[async_trait]
 impl CapabilityHandler for HttpEnvironmentCapabilities {
     async fn call(&self, call: CapabilityCall) -> std::result::Result<Value, CapabilityFailure> {
-        if call.capability != "environment.dispatch" || call.world != ENVIRONMENT_WORLD {
+        if call.capability != "environment.dispatch" || call.world != ENVIRONMENT_COMPONENT {
             return Err(CapabilityFailure {
                 code: "capability_unbound".into(),
                 message: format!(
@@ -605,7 +604,7 @@ mod tests {
         .unwrap();
         let response = handler
             .call(CapabilityCall {
-                world: ENVIRONMENT_WORLD.into(),
+                world: ENVIRONMENT_COMPONENT.into(),
                 instance_id: Some("instance".into()),
                 capability: "environment.dispatch".into(),
                 operation_id: "op-1".into(),

--- a/crates/brain-loophost/src/component.rs
+++ b/crates/brain-loophost/src/component.rs
@@ -99,7 +99,7 @@ impl Agentloop for ComponentAgentloop {
         let binding = self
             .router
             .bind(
-                "agentloop",
+                brain_component_host::AGENTLOOP_COMPONENT,
                 session_id.clone(),
                 Arc::new(ChannelCapabilities { sender }),
             )

--- a/crates/brain-protocol/src/session.rs
+++ b/crates/brain-protocol/src/session.rs
@@ -5248,6 +5248,7 @@ pub struct RetentionUpdate {
 #[doc = "  \"required\": ["]
 #[doc = "    \"created_at\","]
 #[doc = "    \"depth\","]
+#[doc = "    \"environments\","]
 #[doc = "    \"id\","]
 #[doc = "    \"last_seq\","]
 #[doc = "    \"metadata\","]
@@ -5279,6 +5280,15 @@ pub struct RetentionUpdate {
 #[doc = "      \"type\": \"integer\","]
 #[doc = "      \"maximum\": 8.0,"]
 #[doc = "      \"minimum\": 0.0"]
+#[doc = "    },"]
+#[doc = "    \"environments\": {"]
+#[doc = "      \"description\": \"Sorted names of the Environments sealed into this session's prefix. Each names one addressable /v1/sessions/{session_id}/environments/{environment} resource; a session that declared none has an empty array.\","]
+#[doc = "      \"type\": \"array\","]
+#[doc = "      \"items\": {"]
+#[doc = "        \"$ref\": \"#/$defs/EnvironmentName\""]
+#[doc = "      },"]
+#[doc = "      \"maxItems\": 32,"]
+#[doc = "      \"uniqueItems\": true"]
 #[doc = "    },"]
 #[doc = "    \"failure\": {"]
 #[doc = "      \"$ref\": \"#/$defs/SessionFailure\""]
@@ -5374,6 +5384,8 @@ pub struct Session {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub current_turn: ::std::option::Option<TurnId>,
     pub depth: i64,
+    #[doc = "Sorted names of the Environments sealed into this session's prefix. Each names one addressable /v1/sessions/{session_id}/environments/{environment} resource; a session that declared none has an empty array."]
+    pub environments: Vec<EnvironmentName>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub failure: ::std::option::Option<SessionFailure>,
     pub id: SessionId,

--- a/crates/brain-providers/src/component.rs
+++ b/crates/brain-providers/src/component.rs
@@ -282,7 +282,11 @@ impl Provider for ComponentProvider {
         );
         let binding = self
             .router
-            .bind("model", instance_id.clone(), self.http.clone())
+            .bind(
+                brain_component_host::MODEL_COMPONENT,
+                instance_id.clone(),
+                self.http.clone(),
+            )
             .map_err(|error| BrainError::Transport(error.to_string()))?;
         let started = self
             .pool

--- a/crates/brain-server/tests/component_tool_environment.rs
+++ b/crates/brain-server/tests/component_tool_environment.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use base64::Engine as _;
 use brain::journal::Record;
 use brain::session::BrainConfig;
+use brain_environment_host::HttpEnvironmentCapabilities;
 use brain_protocol::session::CreateSessionRequest;
-use serde_json::json;
+use serde_json::{Value, json};
 use sha2::{Digest as _, Sha256};
 
 struct TempDir(PathBuf);
@@ -44,6 +46,33 @@ fn artifact(bytes: &[u8]) -> serde_json::Value {
     })
 }
 
+/// Serves the Environment dispatch endpoint the way a deployment does, so the identity a real
+/// component run stamps is judged by the real `HttpEnvironmentCapabilities` guard rather than by a
+/// hand-built call. A refused dispatch is invisible to a turn: it surfaces only as a session end
+/// that retries forever, which is why only a live plane ever saw it.
+async fn dispatch_endpoint() -> (String, Arc<Mutex<Vec<Value>>>) {
+    let seen: Arc<Mutex<Vec<Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let recorder = seen.clone();
+    let app = axum::Router::new().route(
+        "/environment",
+        axum::routing::post(move |axum::Json(body): axum::Json<Value>| {
+            let recorder = recorder.clone();
+            async move {
+                recorder.lock().expect("recorded dispatches").push(body);
+                axum::Json(json!({"dispatched": "ok"}))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind dispatch endpoint");
+    let address = listener.local_addr().expect("dispatch endpoint address");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{address}/environment"), seen)
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn component_tool_calls_component_environment_through_the_session_kernel() {
     let temp = TempDir::new();
@@ -57,6 +86,11 @@ async fn component_tool_calls_component_environment_through_the_session_kernel()
     let environment_digest = hex::encode(Sha256::digest(&environment_component));
     let bundle = b"export default async function invoke(input) { return input; }";
     let bundle_digest = hex::encode(Sha256::digest(bundle));
+    let (endpoint, dispatched) = dispatch_endpoint().await;
+    let dispatch = Arc::new(
+        HttpEnvironmentCapabilities::new(endpoint, Some("token".into()), Duration::from_secs(30))
+            .expect("Environment dispatch capabilities"),
+    );
 
     let brain = brain_server::compose_local(brain_server::LocalOptions {
         data_dir: temp.0.clone(),
@@ -67,7 +101,7 @@ async fn component_tool_calls_component_environment_through_the_session_kernel()
         advertised_address: "127.0.0.1:1".into(),
         transport_urls: None,
         provider_factory: None,
-        environment_capabilities: None,
+        environment_capabilities: Some(dispatch.clone()),
         loophost: Some(brain_server::LoophostOptions {
             component_host: PathBuf::from(env!("CARGO_BIN_EXE_brain-component-host")),
             workers: 2,
@@ -130,7 +164,7 @@ async fn component_tool_calls_component_environment_through_the_session_kernel()
             "workspace": {
                 "component_digest": environment_digest,
                 "world": "aex:environment/environment@1.0.0",
-                "config": {}
+                "config": {"dispatch": true}
             }
         }
     }))
@@ -163,14 +197,23 @@ async fn component_tool_calls_component_environment_through_the_session_kernel()
                 ..
             } => serde_json::from_str::<serde_json::Value>(content).is_ok_and(|value| {
                 value["value"] == "environment-ok"
-                    && value["providerOperationId"]
-                        .as_str()
-                        .is_some_and(|id| id.ends_with(&format!(":{}", bundle.len())))
+                    && value["providerOperationId"].as_str().is_some_and(|id| {
+                        id.starts_with("ok:") && id.ends_with(&format!(":{}", bundle.len()))
+                    })
             }),
             _ => false,
         }),
-        "the sealed bundle must reach the Environment: {records:#?}"
+        "the sealed bundle and the dispatch response must reach the Environment: {records:#?}"
     );
+
+    {
+        let recorded = dispatched.lock().expect("recorded dispatches");
+        let call = recorded
+            .first()
+            .unwrap_or_else(|| panic!("the Environment never reached its dispatch: {records:#?}"));
+        assert_eq!(call["action"], "submit");
+        assert!(call["request"]["operation_id"].is_string());
+    }
 
     // The immutable bundle is the largest Tool payload; sealing it inline would put megabytes in
     // every session's CONFIG record, which is what the journal ceiling exists to refuse.

--- a/crates/brain-toolhost/src/lib.rs
+++ b/crates/brain-toolhost/src/lib.rs
@@ -160,7 +160,7 @@ impl ToolRegistry for ComponentToolRegistry {
         let binding = self
             .router
             .bind(
-                "tool",
+                brain_component_host::TOOL_COMPONENT,
                 request.call_id.clone(),
                 Arc::new(ComponentCapabilities {
                     handler: capabilities,

--- a/crates/brain/src/customer_tests.rs
+++ b/crates/brain/src/customer_tests.rs
@@ -886,3 +886,18 @@ async fn direct_observations_cannot_exceed_the_reserved_envelope() {
         })
     ));
 }
+
+/// The frame proof crosses a language boundary: Brain's coordinator derives it in Rust and every
+/// client runner derives it again in TypeScript. Both derive the contract vector, so a one-sided
+/// change to the domain separator fails here instead of silently refusing every registration.
+#[test]
+fn frame_proof_matches_the_contract_vector() {
+    let vector: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../contracts/session/v1/customer-frame-proof.json"
+    ))
+    .expect("customer frame proof vector");
+    assert_eq!(
+        frame_proof(vector["protocol"].as_str().expect("vector protocol")),
+        vector["proof"].as_str().expect("vector proof")
+    );
+}

--- a/crates/brain/src/journal/docs.rs
+++ b/crates/brain/src/journal/docs.rs
@@ -1182,9 +1182,23 @@ pub struct SessionSummary {
     pub context_window_tokens: u32,
     pub shape: String,
     pub base_url: Option<String>,
+    /// Sorted sealed Environment names, so a listing can address the same resources as the full
+    /// session projection.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub environments: Vec<String>,
     pub metadata: HashMap<String, String>,
     pub session_storage_bytes: u64,
     pub storage_reserved_bytes: u64,
+}
+
+/// The sealed Environment names in one stable order, so listings, full projections and clients
+/// agree on what a session can address.
+pub fn sorted_environment_names(
+    environments: &HashMap<String, brain_protocol::session::EnvironmentConfig>,
+) -> Vec<String> {
+    let mut names = environments.keys().cloned().collect::<Vec<_>>();
+    names.sort();
+    names
 }
 
 impl SessionSummary {
@@ -1222,6 +1236,7 @@ impl SessionSummary {
             context_window_tokens: doc.prefix.context_window_tokens,
             shape: doc.prefix.shape.clone(),
             base_url: doc.prefix.base_url.clone(),
+            environments: sorted_environment_names(&doc.prefix.environments),
             metadata: doc.prefix.metadata.clone(),
             session_storage_bytes: doc.session_storage_bytes,
             storage_reserved_bytes: doc.storage_reserved_bytes,

--- a/crates/brain/src/session/view.rs
+++ b/crates/brain/src/session/view.rs
@@ -170,6 +170,9 @@ pub fn session_doc(session_id: &str, doc: &HeadDoc) -> Result<session::Session> 
             .parse()
             .map_err(|_| corrupt("root session id"))?,
         depth: i64::from(doc.depth),
+        environments: environment_names(crate::journal::sorted_environment_names(
+            &doc.prefix.environments,
+        ))?,
         last_seq: doc.last_seq,
         last_message_at: doc.last_message_ms.map(crate::events::ts),
         metadata: doc
@@ -269,6 +272,7 @@ pub(super) fn session_doc_summary(
         retain_until: crate::events::ts(summary.retain_until_ms),
         root_id: summary.root_id.parse().map_err(|_| corrupt("root id"))?,
         depth: i64::from(summary.depth),
+        environments: environment_names(summary.environments.clone())?,
         last_seq: summary.last_seq,
         last_message_at: summary.last_message_ms.map(crate::events::ts),
         metadata: summary
@@ -323,6 +327,17 @@ pub(super) fn session_doc_summary(
         turns: summary.turns,
         updated_at: crate::events::ts(summary.updated_ms),
     })
+}
+
+fn environment_names(names: Vec<String>) -> Result<Vec<session::EnvironmentName>> {
+    names
+        .into_iter()
+        .map(|name| {
+            name.parse().map_err(|_| {
+                BrainError::Journal("stored session has a corrupt Environment name".into())
+            })
+        })
+        .collect()
 }
 
 pub(super) fn public_context_fork(fork: &ContextForkDoc) -> session::ContextFork {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,7 +1080,7 @@
     },
     "packages/brain": {
       "name": "@aexhq/brain",
-      "version": "0.3.3",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.25.9"

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Client, tool authoring API, and local builder for the independent Brain session server",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/brain/schemas/session.v1.json
+++ b/packages/brain/schemas/session.v1.json
@@ -675,7 +675,8 @@
         "retain_until",
         "updated_at",
         "turns",
-        "metadata"
+        "metadata",
+        "environments"
       ],
       "properties": {
         "id": {
@@ -734,6 +735,15 @@
         },
         "storage": {
           "$ref": "#/$defs/StorageInfo"
+        },
+        "environments": {
+          "type": "array",
+          "maxItems": 32,
+          "uniqueItems": true,
+          "description": "Sorted names of the Environments sealed into this session's prefix. Each names one addressable /v1/sessions/{session_id}/environments/{environment} resource; a session that declared none has an empty array.",
+          "items": {
+            "$ref": "#/$defs/EnvironmentName"
+          }
         },
         "created_at": {
           "$ref": "#/$defs/Timestamp"

--- a/packages/brain/src/customer.ts
+++ b/packages/brain/src/customer.ts
@@ -792,7 +792,7 @@ function registrationDescriptorBytes(registration: ClientRegistration): number {
 /** Domain-separated proof bound to one consumed connect grant. */
 export function deriveFrameProof(protocol: string): string {
   return createHash("sha256")
-    .update("aex.customer-environment.frame-proof\0", "utf8")
+    .update("brain.customer-environment.frame-proof\0", "utf8")
     .update(protocol, "utf8")
     .digest("hex");
 }

--- a/packages/brain/src/generated/paths.ts
+++ b/packages/brain/src/generated/paths.ts
@@ -1036,6 +1036,7 @@ export type components = {
             /** @description Outstanding staged upload bytes held against the sealed session quota until staging cleanup completes. These bytes are not yet published session objects. */
             upload_reserved_bytes: number;
         };
+        EnvironmentName: string;
         /**
          * Format: date-time
          * @description RFC 3339, UTC.
@@ -1081,6 +1082,8 @@ export type components = {
             shape: "1gb";
             model: components["schemas"]["ModelInfo"];
             storage: components["schemas"]["StorageInfo"];
+            /** @description Sorted names of the Environments sealed into this session's prefix. Each names one addressable /v1/sessions/{session_id}/environments/{environment} resource; a session that declared none has an empty array. */
+            environments: components["schemas"]["EnvironmentName"][];
             created_at: components["schemas"]["Timestamp"];
             /** @description Finite renewable durable-retention deadline. Environment capacity has an independent shorter lifetime. */
             retain_until: components["schemas"]["Timestamp"];
@@ -1152,7 +1155,6 @@ export type components = {
             };
             contract_digest: components["schemas"]["Sha256Hex"];
         };
-        EnvironmentName: string;
         NetworkDestination: {
             host: string;
             ports: [

--- a/packages/brain/src/generated/session.ts
+++ b/packages/brain/src/generated/session.ts
@@ -894,6 +894,12 @@ export interface Session {
   shape: "1gb";
   model: ModelInfo;
   storage: StorageInfo;
+  /**
+   * Sorted names of the Environments sealed into this session's prefix. Each names one addressable /v1/sessions/{session_id}/environments/{environment} resource; a session that declared none has an empty array.
+   *
+   * @maxItems 32
+   */
+  environments: EnvironmentName[];
   created_at: Timestamp;
   /**
    * RFC 3339, UTC.

--- a/packages/brain/src/resources.ts
+++ b/packages/brain/src/resources.ts
@@ -8,16 +8,21 @@ import type {
   FileEntry as CanonicalSandboxFileEntry,
   SandboxStatus as CanonicalSandboxStatus,
 } from "./generated/environment.js";
-import type { components as ApiComponents } from "./generated/paths.js";
+import type { components as ApiComponents, paths as ApiPaths } from "./generated/paths.js";
 import { randomIdempotencyKey } from "./json.js";
 import type { EventOptions, JsonRequestOptions, SessionTransport } from "./transport.js";
 
-function sid(sessionId: string): string {
-  return encodeURIComponent(sessionId);
-}
-
-function childPath(sessionId: string, childId: string): string {
-  return `/v1/sessions/${sid(sessionId)}/children/${encodeURIComponent(childId)}`;
+/** Builds one request URL from a path the Brain-owned OpenAPI declares. A literal that is not a
+ *  declared path, or a missing parameter, fails to compile rather than reaching Brain as a 404. */
+function path<P extends keyof ApiPaths & string>(
+  template: P,
+  params: Readonly<Record<string, string>>,
+): string {
+  return template.replace(/\{(\w+)\}/gu, (_match, name: string) => {
+    const value = params[name];
+    if (value === undefined) throw new TypeError(`${template} is missing ${name}`);
+    return encodeURIComponent(value);
+  });
 }
 
 export const MAX_INLINE_FILE_BYTES = 1024 * 1024;
@@ -40,62 +45,78 @@ export type SandboxFileEntry = CanonicalSandboxFileEntry;
 export type SandboxFileList = ApiSchemas["SandboxFileList"];
 
 export class SandboxFiles {
-  constructor(readonly transport: SessionTransport, readonly sessionId: string) {}
+  readonly #route: Readonly<Record<string, string>>;
+
+  constructor(
+    readonly transport: SessionTransport,
+    readonly sessionId: string,
+    readonly environment: string,
+  ) {
+    this.#route = { session_id: sessionId, environment };
+  }
 
   list(input: ApiSchemas["SandboxFileListRequest"], options: JsonRequestOptions = {}): Promise<SandboxFileList> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/list`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/list", this.#route), { ...options, body: input });
   }
 
   stat(input: ApiSchemas["SandboxFilePathRequest"], options: JsonRequestOptions = {}): Promise<SandboxFileEntry> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/stat`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/stat", this.#route), { ...options, body: input });
   }
 
   readInline(input: ApiSchemas["SandboxFilePathRequest"], options: JsonRequestOptions = {}): Promise<ApiSchemas["SandboxFileContent"]> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/read-inline`, { ...options, body: { ...input, max_bytes: MAX_INLINE_FILE_BYTES } });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/read-inline", this.#route), { ...options, body: { ...input, max_bytes: MAX_INLINE_FILE_BYTES } });
   }
 
   writeInline(input: ApiSchemas["SandboxFileWriteRequest"], options: JsonRequestOptions = {}): Promise<SandboxFileEntry> {
     assertInlineBase64(input.content_base64);
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/write-inline`, { ...idempotent(options), body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/write-inline", this.#route), { ...idempotent(options), body: input });
   }
 
   /** Happy-path convenience only; restart/expiry requires inspection and a fresh prepare. */
   prepareDownload(input: ApiSchemas["SandboxFilePathRequest"], options: JsonRequestOptions = {}): Promise<TransferTicket> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/downloads`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/downloads", this.#route), { ...options, body: input });
   }
 
   /** Happy-path convenience only; restart/expiry/ambiguity requires inspection and a fresh prepare. */
   prepareUpload(input: ApiSchemas["SandboxFileUploadRequest"], options: JsonRequestOptions = {}): Promise<TransferTicket> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/uploads`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/uploads", this.#route), { ...options, body: input });
   }
 
   /** Not auto-retried. Use storage plus copy when the transfer itself must be recovery-safe. */
   completeUpload(transferId: string, options: JsonRequestOptions = {}): Promise<SandboxFileEntry> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/uploads/${encodeURIComponent(transferId)}/complete`, options);
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/uploads/{transfer_id}/complete", { ...this.#route, transfer_id: transferId }), options);
   }
 
   find(input: ApiSchemas["SandboxFileFindRequest"], options: JsonRequestOptions = {}): Promise<SandboxFileList> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/find`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/find", this.#route), { ...options, body: input });
   }
 
   grep(input: ApiSchemas["SandboxFileGrepRequest"], options: JsonRequestOptions = {}): Promise<SandboxFileList> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox/files/grep`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}/files/grep", this.#route), { ...options, body: input });
   }
 }
 
+/** One Environment the session declared, addressed by its declared name. Brain has no unnamed
+ *  default: `Session.environments` lists the names this session can address. */
 export class SessionSandbox {
   readonly files: SandboxFiles;
+  readonly #route: Readonly<Record<string, string>>;
 
-  constructor(readonly transport: SessionTransport, readonly sessionId: string) {
-    this.files = new SandboxFiles(transport, sessionId);
+  constructor(
+    readonly transport: SessionTransport,
+    readonly sessionId: string,
+    readonly environment: string,
+  ) {
+    this.files = new SandboxFiles(transport, sessionId, environment);
+    this.#route = { session_id: sessionId, environment };
   }
 
   status(options: JsonRequestOptions = {}): Promise<SandboxStatus> {
-    return this.transport.json("GET", `/v1/sessions/${sid(this.sessionId)}/sandbox`, options);
+    return this.transport.json("GET", path("/v1/sessions/{session_id}/environments/{environment}", this.#route), options);
   }
 
   create(options: JsonRequestOptions = {}): Promise<SandboxStatus> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/sandbox`, options);
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/environments/{environment}", this.#route), options);
   }
 }
 
@@ -103,47 +124,51 @@ export type StorageObject = ApiSchemas["StorageObject"];
 export type StorageList = ApiSchemas["StorageList"];
 
 export class SessionStorage {
-  constructor(readonly transport: SessionTransport, readonly sessionId: string) {}
+  readonly #route: Readonly<Record<string, string>>;
+
+  constructor(readonly transport: SessionTransport, readonly sessionId: string) {
+    this.#route = { session_id: sessionId };
+  }
 
   list(input: ApiSchemas["StorageListRequest"] = {}, options: JsonRequestOptions = {}): Promise<StorageList> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/list`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/list", this.#route), { ...options, body: input });
   }
 
   stat(key: string, options: JsonRequestOptions = {}): Promise<StorageObject> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/stat`, { ...options, body: { key } });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/stat", this.#route), { ...options, body: { key } });
   }
 
   readInline(key: string, options: JsonRequestOptions = {}): Promise<ApiSchemas["StorageContent"]> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/read-inline`, { ...options, body: { key, max_bytes: MAX_INLINE_FILE_BYTES } });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/read-inline", this.#route), { ...options, body: { key, max_bytes: MAX_INLINE_FILE_BYTES } });
   }
 
   writeInline(input: ApiSchemas["StorageWriteRequest"], options: JsonRequestOptions = {}): Promise<StorageObject> {
     assertInlineBase64(input.content_base64);
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/write-inline`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/write-inline", this.#route), { ...options, body: input });
   }
 
   prepareDownload(key: string, options: JsonRequestOptions = {}): Promise<TransferTicket> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/downloads`, { ...options, body: { key } });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/downloads", this.#route), { ...options, body: { key } });
   }
 
   prepareUpload(input: ApiSchemas["StorageUploadRequest"], options: JsonRequestOptions = {}): Promise<TransferTicket> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/uploads`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/uploads", this.#route), { ...options, body: input });
   }
 
   completeUpload(transferId: string, options: JsonRequestOptions = {}): Promise<StorageObject> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/uploads/${encodeURIComponent(transferId)}/complete`, options);
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/uploads/{transfer_id}/complete", { ...this.#route, transfer_id: transferId }), options);
   }
 
   delete(key: string, options: JsonRequestOptions = {}): Promise<void> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/delete`, { ...options, body: { key } });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/delete", this.#route), { ...options, body: { key } });
   }
 
   copyFromEnvironment(environment: string, input: ApiSchemas["StorageEnvironmentCopyRequest"], options: JsonRequestOptions = {}): Promise<StorageObject> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/copy-from-environment/${encodeURIComponent(environment)}`, { ...idempotent(options), body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/copy-from-environment/{environment}", { ...this.#route, environment }), { ...idempotent(options), body: input });
   }
 
   copyToEnvironment(environment: string, input: ApiSchemas["StorageEnvironmentCopyRequest"], options: JsonRequestOptions = {}): Promise<SandboxFileEntry> {
-    return this.transport.json("POST", `/v1/sessions/${sid(this.sessionId)}/storage/copy-to-environment/${encodeURIComponent(environment)}`, { ...idempotent(options), body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/storage/copy-to-environment/{environment}", { ...this.#route, environment }), { ...idempotent(options), body: input });
   }
 }
 
@@ -159,36 +184,40 @@ function idempotent(options: JsonRequestOptions): JsonRequestOptions {
 }
 
 export class SessionChild {
-  constructor(readonly transport: SessionTransport, readonly sessionId: string, readonly id: string) {}
+  readonly #route: Readonly<Record<string, string>>;
+
+  constructor(readonly transport: SessionTransport, readonly sessionId: string, readonly id: string) {
+    this.#route = { session_id: sessionId, child_id: id };
+  }
 
   get(options: JsonRequestOptions = {}): Promise<SessionData> {
-    return this.transport.json("GET", childPath(this.sessionId, this.id), options);
+    return this.transport.json("GET", path("/v1/sessions/{session_id}/children/{child_id}", this.#route), options);
   }
 
   send(message: string, options: JsonRequestOptions = {}): Promise<MessageAccepted> {
-    return this.transport.json("POST", `${childPath(this.sessionId, this.id)}/messages`, {
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/children/{child_id}/messages", this.#route), {
       ...idempotent(options),
       body: { message },
     });
   }
 
   followUp(message: string, options: JsonRequestOptions = {}): Promise<SessionData> {
-    return this.transport.json("POST", `${childPath(this.sessionId, this.id)}/follow-up`, {
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/children/{child_id}/follow-up", this.#route), {
       ...idempotent(options),
       body: { message },
     });
   }
 
   wait(input: ApiSchemas["WaitChildRequest"] = {}, options: JsonRequestOptions = {}): Promise<SessionData> {
-    return this.transport.json("POST", `${childPath(this.sessionId, this.id)}/wait`, { ...options, body: input });
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/children/{child_id}/wait", this.#route), { ...options, body: input });
   }
 
   interrupt(options: JsonRequestOptions = {}): Promise<SessionData> {
-    return this.transport.json("POST", `${childPath(this.sessionId, this.id)}/interrupt`, options);
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/children/{child_id}/interrupt", this.#route), options);
   }
 
   end(options: JsonRequestOptions = {}): Promise<SessionData> {
-    return this.transport.json("POST", `${childPath(this.sessionId, this.id)}/end`, options);
+    return this.transport.json("POST", path("/v1/sessions/{session_id}/children/{child_id}/end", this.#route), options);
   }
 
   events(options: EventOptions = {}): AsyncGenerator<Event> {
@@ -197,11 +226,15 @@ export class SessionChild {
 }
 
 export class SessionChildren {
-  constructor(readonly transport: SessionTransport, readonly sessionId: string) {}
+  readonly #route: Readonly<Record<string, string>>;
+
+  constructor(readonly transport: SessionTransport, readonly sessionId: string) {
+    this.#route = { session_id: sessionId };
+  }
 
   create(input: { prompt: string; name?: string; fork_turns?: "all" | "none" | `${number}` }, options: JsonRequestOptions = {}): Promise<SessionChild> {
     return this.transport
-      .json<SessionData>("POST", `/v1/sessions/${sid(this.sessionId)}/children`, {
+      .json<SessionData>("POST", path("/v1/sessions/{session_id}/children", this.#route), {
         ...idempotent(options),
         body: input,
       })
@@ -213,7 +246,7 @@ export class SessionChildren {
     if (input.cursor !== undefined) query.set("cursor", input.cursor);
     if (input.limit !== undefined) query.set("limit", String(input.limit));
     const suffix = query.size === 0 ? "" : `?${query}`;
-    return this.transport.json("GET", `/v1/sessions/${sid(this.sessionId)}/children${suffix}`, options);
+    return this.transport.json("GET", path("/v1/sessions/{session_id}/children", this.#route) + suffix, options);
   }
 
   get(childId: string): SessionChild {

--- a/packages/brain/src/session.ts
+++ b/packages/brain/src/session.ts
@@ -369,15 +369,26 @@ function waitWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T
 export class Session implements SessionSummary {
   readonly #transport: Transport;
   #data: SessionData;
-  readonly sandbox: SessionSandbox;
   readonly storage: SessionStorage;
   readonly children: SessionChildren;
   constructor(transport: Transport, data: SessionData) {
     this.#transport = transport;
     this.#data = data;
-    this.sandbox = new SessionSandbox(transport, data.id);
     this.storage = new SessionStorage(transport, data.id);
     this.children = new SessionChildren(transport, data.id);
+  }
+
+  /** The Environment names this session sealed. Only these can be addressed. */
+  get environments(): readonly string[] {
+    return this.#data.environments;
+  }
+
+  /** Addresses one sealed Environment by its declared name. */
+  environment(name: string): SessionSandbox {
+    if (!this.#data.environments.includes(name)) {
+      throw new TypeError(`Session ${this.#data.id} did not declare Environment ${JSON.stringify(name)}`);
+    }
+    return new SessionSandbox(this.#transport, this.#data.id, name);
   }
 
   get id(): string {

--- a/packages/brain/test/customer.test.mjs
+++ b/packages/brain/test/customer.test.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { z } from "zod";
 
 import { CustomerEnvironment, compileTools, customerTerminalDigest, tool } from "../dist/index.js";
+import { deriveFrameProof } from "../dist/customer.js";
 
 class FakeSocket {
   listeners = new Map();
@@ -571,4 +573,15 @@ test("initial readiness keeps Node alive while the gateway is retrying", async (
     if (child.exitCode === null && child.signalCode === null) child.kill();
     await closed;
   }
+});
+
+// The frame proof crosses a language boundary: this runner derives it and Brain's coordinator
+// derives it again in Rust. Both derive the contract vector, so a one-sided change to the domain
+// separator fails here instead of silently refusing every registration.
+test("the customer frame proof matches the Brain-owned contract vector", () => {
+  const vector = JSON.parse(readFileSync(
+    new URL("../../../contracts/session/v1/customer-frame-proof.json", import.meta.url),
+    "utf8",
+  ));
+  assert.equal(deriveFrameProof(vector.protocol), vector.proof);
 });


### PR DESCRIPTION
Three boundaries between Brain and its own clients disagreed. Each is invisible to a test that builds one side of the boundary by hand, so only a live plane ever saw them; development run `32926477468` failed `computer-tools`, `cancellation` and `callback-tool` on all three.

## The Environment host capability was refused, always

`brain-component-host` stamps a capability call with the WIT world *name* — `"tool"`, `"environment"` — which is also what keys a capability route and a resident instance. `HttpEnvironmentCapabilities` compared it against the versioned world id `aex:environment/environment@1.0.0` and refused every call as `capability_unbound`:

```
WARN brain::session: session end will retry session=ses_321d448c07bc16a2da9a571e
  error=provider transport: Environment component: Environment host capability
         environment.dispatch is not configured
```

379 of those in seven minutes on dev, across the two sessions that declared an Environment. No component Environment could resolve, submit or release, so ending one retried forever and `session.delete()` timed out — the `Customer canary cleanup failed; The operation was cancelled` half of `computer-tools` and all of `cancellation`.

The existing unit test built its own `CapabilityCall` with the long id, which is why it passed. Name the four component worlds once in the host that mints them, and have every crate that binds, routes or guards a capability use those constants. `component_tool_environment` now runs a guest that actually dispatches, through the real `HttpEnvironmentCapabilities` and a loopback endpoint, so the identity a real component run mints is judged by the guard a real composition installs. Reverting the guard alone fails it with the exact production message.

## The client asked for a path the contract never declared

`packages/brain` addressed environments at `/v1/sessions/{id}/sandbox…`; the contract has only ever declared `/v1/sessions/{session_id}/environments/{environment}…`. Probing a local Brain separates the two 404s exactly:

```
POST /v1/sessions/ses_fake/sandbox                  -> 404, empty body   (no route)
POST /v1/sessions/ses_fake/environments/workspace   -> 404 {"error":{"code":"not_found",…}}
```

An empty body is why the canary could only say `Aex API request failed with HTTP 404 (status=404)`.

Every client URL is now built from a path the Brain-owned OpenAPI declares, so an undeclared literal fails `tsc` instead of Brain. An Environment is addressed by the name the session sealed, and `Session` carries those names, so a session from create, get or list addresses the same resources.

## The frame proof crossed a language boundary under two names

The client derived the customer-Environment frame proof under `aex.customer-environment.frame-proof\0`; the coordinator derives it under `brain.…`. Every registration was refused and the runner reconnected until its caller timed out — `callback-tool`, at 372 s against a 360 s create deadline. Against a local Brain the socket now reaches `ready` and `registered`. Both sides derive one contract vector, checked from Rust and from Node.

## Still open, deliberately not in this PR

`session.sandbox.create()` and `session.sandbox.files.*` reach Brain now but are refused with `400 invalid_request`: `materialize_environment_resident` and `environment_adapter` call `legacy_environment(...)`, and the deployed AWS driver's component `dispatch` accepts only `submit`/`observe`/`cancel`/`acknowledge`/`release` with `kind == "invoke"`. The Environment *resource* family has no component implementation in Brain, in the component world's operation kinds, or in the driver. `computer-tools` cannot pass until that is designed and a new driver image ships; it is a feature across three repos, not a defect fix.

## Gates

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude brain-loophost --exclude brain-component-host --exclude brain-server`, `cargo test -p brain-component-host`, `cargo test -p brain-server --test component_tool_environment`, `npm test`, `npm run package-smoke` all pass locally.

`@aexhq/brain` goes to `0.5.0`: `Session.sandbox` is replaced by `Session.environment(name)` and `Session` gains `environments`.