### PR TITLE
session: answer a child capability with the handle it takes

### DIFF
--- a/crates/brain/src/session/engine/subagents.rs
+++ b/crates/brain/src/session/engine/subagents.rs
@@ -38,7 +38,7 @@ impl Brain {
                         Some(operation_id),
                     )
                     .await?;
-                    Ok(serde_json::to_value(child)?)
+                    child_doc(&child)
                 }
                 Some("send_message" | "follow_up") => {
                     let child_id = required_child_string(&input, "child_id")?;
@@ -64,9 +64,7 @@ impl Brain {
                 }
                 Some("peek") => {
                     let child_id = required_child_string(&input, "child_id")?;
-                    Ok(serde_json::to_value(
-                        self.get_child(parent_id, &child_id).await?,
-                    )?)
+                    child_doc(&self.get_child(parent_id, &child_id).await?)
                 }
                 Some("wait") => {
                     let child_id = required_child_string(&input, "child_id")?;
@@ -81,7 +79,7 @@ impl Brain {
                         result = wait => result?,
                         _ = cancel.cancelled() => return Err(BrainError::Cancelled),
                     };
-                    Ok(serde_json::to_value(child)?)
+                    child_doc(&child)
                 }
                 Some("list_children") => {
                     let cursor = input.get("cursor").and_then(serde_json::Value::as_str);
@@ -94,18 +92,18 @@ impl Brain {
                     Ok(serde_json::json!({
                         "has_more": next_cursor.is_some(),
                         "next_cursor": next_cursor,
-                        "data": data,
+                        "data": child_docs(&data)?,
                     }))
                 }
                 Some("interrupt_agent") => {
                     let child_id = required_child_string(&input, "child_id")?;
                     self.get_child(parent_id, &child_id).await?;
-                    Ok(serde_json::to_value(self.cancel(&child_id).await?)?)
+                    child_doc(&self.cancel(&child_id).await?)
                 }
                 Some("end_agent") => {
                     let child_id = required_child_string(&input, "child_id")?;
                     self.get_child(parent_id, &child_id).await?;
-                    Ok(serde_json::to_value(self.end(&child_id).await?)?)
+                    child_doc(&self.end(&child_id).await?)
                 }
                 Some(other) => Err(BrainError::Invalid(format!(
                     "unknown subagents action {other:?}"

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -3878,7 +3878,9 @@ impl Brain {
                         Some(operation_id),
                     )
                     .await?;
-                Ok(serde_json::Value::String(serde_json::to_string(&child)?))
+                Ok(serde_json::Value::String(serde_json::to_string(
+                    &child_doc(&child)?,
+                )?))
             }
             "tool.children.send" => {
                 let child_id = required_tool_capability_string(&request, "child_id")?;
@@ -3900,7 +3902,7 @@ impl Brain {
             "tool.children.inspect" => {
                 let child_id = required_tool_capability_string(&request, "child_id")?;
                 Ok(serde_json::Value::String(serde_json::to_string(
-                    &self.get_child(parent_id, child_id).await?,
+                    &child_doc(&self.get_child(parent_id, child_id).await?)?,
                 )?))
             }
             "tool.children.wait" => {
@@ -3912,9 +3914,11 @@ impl Brain {
                     .unwrap_or(30_000)
                     .min(300_000);
                 Ok(serde_json::Value::String(serde_json::to_string(
-                    &self
-                        .wait_child(parent_id, child_id, Duration::from_millis(timeout_ms))
-                        .await?,
+                    &child_doc(
+                        &self
+                            .wait_child(parent_id, child_id, Duration::from_millis(timeout_ms))
+                            .await?,
+                    )?,
                 )?))
             }
             "tool.children.events" => {
@@ -3934,7 +3938,9 @@ impl Brain {
                         )));
                     }
                 };
-                Ok(serde_json::Value::String(serde_json::to_string(&child)?))
+                Ok(serde_json::Value::String(serde_json::to_string(
+                    &child_doc(&child)?,
+                )?))
             }
             "tool.children.list" => {
                 let cursor = request.get("cursor").and_then(serde_json::Value::as_str);
@@ -3944,7 +3950,7 @@ impl Brain {
                     .unwrap_or(32) as usize;
                 let (items, next_cursor) = self.list_children(parent_id, cursor, limit).await?;
                 Ok(serde_json::json!({
-                    "items_json": serde_json::to_string(&items)?,
+                    "items_json": serde_json::to_string(&child_docs(&items)?)?,
                     "next_cursor": next_cursor,
                 }))
             }

--- a/crates/brain/src/session/view.rs
+++ b/crates/brain/src/session/view.rs
@@ -112,6 +112,27 @@ pub fn build_prefix(
     Ok((sealed, dialect))
 }
 
+/// A child session as the `children` capability addresses it. Five of that contract's seven
+/// functions take a `child-id`, but the session projection names the identity `id`, beside the
+/// caller's own `name` — so the handle a caller must supply was never a key it was given.
+pub fn child_doc(child: &session::Session) -> Result<serde_json::Value> {
+    let mut value = serde_json::to_value(child)?;
+    let object = value.as_object_mut().ok_or_else(|| {
+        BrainError::Journal("a child session did not project as an object".into())
+    })?;
+    let id = object
+        .get("id")
+        .cloned()
+        .ok_or_else(|| BrainError::Journal("a child session projection has no id".into()))?;
+    object.insert("child_id".into(), id);
+    Ok(value)
+}
+
+/// The same handle, for a page of children.
+pub fn child_docs(children: &[session::Session]) -> Result<Vec<serde_json::Value>> {
+    children.iter().map(child_doc).collect()
+}
+
 /// Builds the contract Session document from the head. A sealed value that no longer parses
 /// as its contract type is journal corruption and errors loudly, naming the field — the REST
 /// read never substitutes placeholders or omits sealed identity.

--- a/crates/brain/tests/task_e2e.rs
+++ b/crates/brain/tests/task_e2e.rs
@@ -413,3 +413,262 @@ async fn end_fences_a_root_while_its_post_spawn_provider_call_is_stalled() {
 
     provider.root_continuation_release.notify_waiters();
 }
+
+/// A caller can only address a child by a key it was handed. Five of the seven `children`
+/// contract functions take a `child-id`, so `spawn_agent` must answer with one under that name:
+/// while its result carried only `id` beside the caller's own `name`, the canary's second
+/// `subagents` call kept passing back the label the model had chosen, and failed on it.
+#[derive(Debug, Default)]
+struct TwoCallProvider;
+
+impl TwoCallProvider {
+    fn response(request: &Value) -> Result<BoxStream<'static, Result<ProviderEvent>>> {
+        let messages = request["messages"]
+            .as_array()
+            .ok_or_else(|| BrainError::Protocol("scripted request has no messages".into()))?;
+        let text = messages
+            .iter()
+            .filter_map(|message| message["content"].as_array())
+            .flatten()
+            .filter(|block| block["type"] == "text")
+            .filter_map(|block| block["text"].as_str())
+            .next_back()
+            .unwrap_or_default();
+        let calls = messages
+            .iter()
+            .filter_map(|message| message["content"].as_array())
+            .flatten()
+            .filter(|block| block["type"] == "tool_use" && block["name"] == "subagents")
+            .count();
+        // Exactly what a model does: take the handle out of the previous result, under the name
+        // of the parameter it feeds.
+        let handle = messages
+            .iter()
+            .filter_map(|message| message["content"].as_array())
+            .flatten()
+            .filter(|block| block["type"] == "tool_result")
+            .filter_map(|block| block["content"].as_str())
+            .filter_map(|content| serde_json::from_str::<Value>(content).ok())
+            .filter_map(|value| value["child_id"].as_str().map(str::to_owned))
+            .next_back();
+
+        let events = if text == "child prompt" {
+            vec![
+                ProviderEvent::TextDelta {
+                    index: 0,
+                    text: "child answer".into(),
+                },
+                ProviderEvent::MessageDone {
+                    stop_reason: StopReason::EndTurn,
+                    usage: zero_usage(),
+                },
+            ]
+        } else if calls == 0 {
+            subagents_call(
+                "provider-spawn",
+                json!({
+                    "action": "spawn_agent",
+                    "task_name": "child1",
+                    "message": "child prompt",
+                    "fork_turns": "all"
+                }),
+            )?
+        } else if calls == 2 {
+            // The other way a caller recovers a handle it no longer has in context.
+            subagents_call("provider-list", json!({"action": "list_children"}))?
+        } else if calls == 1 {
+            subagents_call(
+                "provider-peek",
+                json!({
+                    "action": "peek",
+                    "child_id": handle.ok_or_else(|| BrainError::Protocol(
+                        "spawn_agent returned no child_id for the next call to use".into()
+                    ))?
+                }),
+            )?
+        } else {
+            vec![
+                ProviderEvent::TextDelta {
+                    index: 0,
+                    text: "root answer".into(),
+                },
+                ProviderEvent::MessageDone {
+                    stop_reason: StopReason::EndTurn,
+                    usage: zero_usage(),
+                },
+            ]
+        };
+        Ok(Box::pin(futures_util::stream::iter(
+            events.into_iter().map(Ok),
+        )))
+    }
+}
+
+fn subagents_call(id: &str, input: Value) -> Result<Vec<ProviderEvent>> {
+    Ok(vec![
+        ProviderEvent::ToolUseStart {
+            index: 0,
+            id: id.into(),
+            name: "subagents".into(),
+        },
+        ProviderEvent::ToolInputDelta {
+            index: 0,
+            partial_json: serde_json::to_string(&input)?,
+        },
+        ProviderEvent::BlockDone { index: 0 },
+        ProviderEvent::MessageDone {
+            stop_reason: StopReason::ToolUse,
+            usage: zero_usage(),
+        },
+    ])
+}
+
+#[async_trait::async_trait]
+impl Provider for TwoCallProvider {
+    fn dialect(&self) -> Dialect {
+        Dialect::AnthropicMessages
+    }
+
+    fn build_request(
+        &self,
+        prefix: &SealedPrefix,
+        history: &[Message],
+        key: &ProviderKey,
+        base_url: &str,
+    ) -> Result<ModelRequest> {
+        brain::provider::anthropic::Anthropic::build_request(prefix, history, key, base_url)
+    }
+
+    async fn stream(
+        &self,
+        request: ModelRequest,
+    ) -> Result<BoxStream<'static, Result<ProviderEvent>>> {
+        Self::response(&serde_json::from_slice(&request.body)?)
+    }
+}
+
+/// The full action surface, so the second call is not rejected before it reaches the capability.
+fn every_action_request() -> CreateSessionRequest {
+    serde_json::from_value(json!({
+        "model": support::model_config(),
+        "component_artifacts": support::component_artifacts(),
+        "agentloop": support::loop_config(),
+        "tools": {"items": [{
+            "definition": {
+                "name": "subagents",
+                "description": "Create and interact with durable direct child sessions.",
+                "contract_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "input_schema": {"type": "object", "additionalProperties": true},
+                "output_schema": {}
+            },
+            "executor": {"kind": "engine", "capability": "brain.subagents"}
+        }]}
+    }))
+    .expect("typed create request")
+}
+
+fn brain_with(provider: Arc<TwoCallProvider>, journal: Journal) -> Arc<Brain> {
+    Brain::with_parts_and_services(
+        BrainConfig {
+            max_concurrent_model_rounds: 1,
+            max_concurrent_turns: 1,
+            idle_discard: Duration::from_secs(60),
+            ..BrainConfig::default()
+        },
+        journal,
+        Arc::new(brain::keys::PlainCustody),
+        Arc::new(DisabledToolExecutor),
+        support::services(),
+        Arc::new(move |_| provider.clone() as Arc<dyn Provider>),
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_second_subagents_call_addresses_the_child_the_first_returned() {
+    let _tmp = TempDir::new();
+    let journal = Journal::new_memory("child-handle-e2e");
+    let brain = brain_with(Arc::new(TwoCallProvider), journal.clone());
+    let root = brain
+        .create_session(every_action_request(), Some("child-handle-root"))
+        .await
+        .expect("create root");
+    let root_id = root.id.to_string();
+    brain
+        .message(
+            &root_id,
+            MessageRequestContent::String("root prompt".parse().expect("message")),
+        )
+        .await
+        .expect("start root turn");
+    wait_turn_finished(&brain, &root_id).await;
+
+    let records = journal
+        .read_records(&root_id, 0)
+        .await
+        .expect("root journal");
+    let results = records
+        .iter()
+        .filter_map(|entry| match &entry.record {
+            Record::ToolResult {
+                name,
+                is_error,
+                content,
+                ..
+            } if name == "subagents" => Some((*is_error, content.clone())),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(results.len(), 3, "spawn_agent, peek, list_children");
+    for (is_error, content) in &results {
+        assert!(!is_error, "subagents failed: {content}");
+    }
+    let (children, _) = brain
+        .list_children(&root_id, None, 100)
+        .await
+        .expect("list direct children");
+    let child_id = serde_json::to_value(&children[0]).expect("child JSON")["id"]
+        .as_str()
+        .expect("child id")
+        .to_owned();
+    for (_, content) in &results[..2] {
+        let value: Value = serde_json::from_str(content).expect("subagents result JSON");
+        assert_eq!(value["child_id"], child_id);
+        assert_eq!(
+            value["name"], "child1",
+            "the caller's label is kept beside the handle, not in place of it"
+        );
+    }
+    let listed: Value = serde_json::from_str(&results[2].1).expect("list_children JSON");
+    assert_eq!(listed["data"][0]["child_id"], child_id);
+}
+
+/// Why the label cannot be the handle: two children may carry the same `task_name`, so only the
+/// minted id resolves one of them.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn two_children_may_share_one_task_name() {
+    let _tmp = TempDir::new();
+    let brain = brain_with(
+        Arc::new(TwoCallProvider),
+        Journal::new_memory("child-name-collision"),
+    );
+    let root = brain
+        .create_session(every_action_request(), Some("child-name-collision-root"))
+        .await
+        .expect("create root");
+    let root_id = root.id.to_string();
+    let mut ids = Vec::new();
+    for key in ["op-one", "op-two"] {
+        let child = brain
+            .create_child(
+                &root_id,
+                "child prompt".into(),
+                Some("child1".into()),
+                Some("none".into()),
+                Some(key),
+            )
+            .await
+            .expect("create child");
+        ids.push(child.id.to_string());
+    }
+    assert_ne!(ids[0], ids[1], "one label, two children");
+}


### PR DESCRIPTION
## The defect

Development run 32929864396, `subagent` case: the first `subagents` call succeeds, the
second fails.

```
tool.call    subagents
tool.result  subagents  outcome=completed
tool.call    subagents
tool.result  subagents  outcome=failed
             error="provider transport: Tool component: session child1 not found"
```

An earlier run showed the same shape with `session smoke not found`. Both names were
chosen by the model.

## Cause

`contracts/tool/v1/tool.wit`, `interface children`, takes a `child-id` in five of its
seven functions:

```wit
spawn:  func(request-json: string)                 -> result<string, extension-error>;
send:   func(child-id: string, request-json: string) -> ...
inspect: func(child-id: string)                      -> ...
wait:   func(child-id: string, timeout-ms: u64)      -> ...
events: func(child-id: string, ...)                  -> ...
manage: func(child-id: string, action: string)       -> ...
```

The one function that *mints* a child answered with Brain's session projection, in which
that parameter does not appear under that name. This is the whole result a caller got back
from `spawn_agent`:

```json
{"agentloop":{…},"context_fork":{…},"created_at":"…","current_turn":"trn_…","depth":1,
 "id":"ses_68b585926a60458456b6a2ef","last_message_at":"…","last_seq":1,"metadata":{},
 "model":{…},"name":"child1","object":"session","parent_id":"ses_…","retain_until":"…",
 "root_id":"ses_…","shape":"1gb","state":"open","storage":{…},"turn_phase":"…",
 "turn_state":"running","turns":1,"updated_at":"…"}
```

No key called `child_id`. The identity is `id` — session vocabulary — and sitting next to
it is `name`, the label the caller itself just supplied. Asked for a `child_id`, a caller
returns the only handle in the result it recognises as its own. `get_child` then resolves
it as a session id and reports `session child1 not found`.

The mismatch is inside Brain's own contract, so the official `subagents` tool is not at
fault: `children-dispatcher.mjs` passes `child_id` through and relays the result verbatim,
with no way to know that `id` is the `child-id`. Brain's own `task_e2e.rs` had to encode
that same out-of-band knowledge as `child_json["id"]`. The engine path already agreed with
the contract in one place — `send_message` returns `child_id` — which is what the
child-returning results were missing.

### Evidence

Two `subagents` calls in one turn against a local Brain with a scripted provider, the
second addressing the child the way the model did:

```
TOOL RESULT name=subagents is_error=false content={…,"id":"ses_68b5…","name":"child1",…}
TOOL RESULT name=subagents is_error=true  content=session child1 not found
```

The canary's message verbatim. With this change the same run yields
`"child_id":"ses_4a40…"` in the first result, and the second call resolves it.

## The change

`child_doc` in `crates/brain/src/session/view.rs` restates a child's identity under the
name this contract addresses it by, and every child-returning capability result goes
through it — `spawn`/`inspect`/`wait`/`manage`/`list` on the component path
(`tool.children.*`) and `spawn_agent`/`peek`/`wait`/`interrupt_agent`/`end_agent`/
`list_children` on the engine path (`brain.subagents`). One helper, both paths.

The session projection itself is untouched: `id` is the session vocabulary and the REST
read keeps it. `name` stays beside the handle rather than becoming one — two children may
carry the same `task_name`, so only the minted id resolves one of them, which is why
teaching `get_child` to accept a name would have been the wrong fix.

These results are opaque JSON strings in the WIT (`-> result<string, extension-error>`),
not typed contract views, so no generated artifact changes and `protocol-gen` is unaffected.
No change is needed in the extensions repo — the dispatcher relays whatever the capability
returns, so `@aexhq/tools` picks this up without a republish.

## Regression

Two tests in `crates/brain/tests/task_e2e.rs`, on the existing `test` CI leg, no deployment:

- `a_second_subagents_call_addresses_the_child_the_first_returned` — the defect. The
  scripted provider does exactly what a model does: reads the handle out of the previous
  tool result *under the name of the parameter it feeds*, then spawns, peeks and lists.
  On `main` it fails — there is no such key, so the second call never happens
  (`spawn_agent then peek: left: 1, right: 2`).
- `two_children_may_share_one_task_name` — why the label cannot be the handle. Passes
  either way; it guards the design against a later "fix" that resolves names.

## Ruled out

The child's environment and its release are **not** implicated, which matters because the
same run has the two Environment cases and `callback-tool` failing separately on a 404
after create. In my reproduction the child session is created, journaled and addressable
by its minted id throughout: `list_children` finds it, `peek` by id succeeds, and the
failure is only `get_head("child1")` returning `NoSuchSession`. Nothing here touches the
Environment path, and this fix does not depend on that one.

Also unchanged: `get_child` still reports a miss as `NoSuchSession` whether the session is
absent or simply is not this parent's child. That is deliberate — it refuses to confirm the
existence of somebody else's session — and it is not what broke here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTKXL4hmbssi59fhiaf72c
