### PR TITLE
environment: keep a refused dispatch's reason and stop ending on it forever

### DIFF
--- a/crates/brain-component-host/guest/fixtures/environment.mjs
+++ b/crates/brain-component-host/guest/fixtures/environment.mjs
@@ -35,4 +35,7 @@ export function cancel() {}
 
 export function acknowledge() {}
 
-export function release() {}
+export function release(bindingJson) {
+  if (JSON.parse(bindingJson).dispatch !== true) return;
+  dispatch("release", "release", JSON.stringify({ released: true }), 18446744073709551615n);
+}

--- a/crates/brain-component-host/src/runtime.rs
+++ b/crates/brain-component-host/src/runtime.rs
@@ -40,6 +40,34 @@ pub struct CapabilityCall {
     pub request: Value,
 }
 
+/// A component export's declared `extension-error`. `retryable: false` is the component's own
+/// judgement that repeating the call cannot succeed; discarding it turned a permanent Environment
+/// refusal into a session end that retried for as long as the plane was up.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentFailure {
+    pub code: String,
+    pub message: String,
+    pub retryable: bool,
+}
+
+impl ComponentFailure {
+    pub fn error(code: String, message: String, retryable: bool) -> anyhow::Error {
+        anyhow::Error::new(Self {
+            code,
+            message,
+            retryable,
+        })
+    }
+}
+
+impl std::fmt::Display for ComponentFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ComponentFailure {}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CapabilityFailure {
     pub code: String,
@@ -840,7 +868,7 @@ impl ModelInstance {
             .bindings
             .call_start(armed(&mut self.store), request)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn observe(
@@ -852,7 +880,7 @@ impl ModelInstance {
             .bindings
             .call_observe(armed(&mut self.store), provider_operation_id, cursor)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn cancel(&mut self, provider_operation_id: &str) -> anyhow::Result<()> {
@@ -860,7 +888,7 @@ impl ModelInstance {
             .bindings
             .call_cancel(armed(&mut self.store), provider_operation_id)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn acknowledge(
@@ -872,7 +900,7 @@ impl ModelInstance {
             .bindings
             .call_acknowledge(armed(&mut self.store), provider_operation_id, terminal_json)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 }
 
@@ -885,7 +913,7 @@ impl EnvironmentInstance {
             .bindings
             .call_resolve(armed(&mut self.store), request)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn submit(
@@ -897,7 +925,7 @@ impl EnvironmentInstance {
             .bindings
             .call_submit(armed(&mut self.store), binding_json, operation)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn observe(
@@ -915,7 +943,7 @@ impl EnvironmentInstance {
                 cursor,
             )
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn cancel(
@@ -927,7 +955,7 @@ impl EnvironmentInstance {
             .bindings
             .call_cancel(armed(&mut self.store), binding_json, provider_operation_id)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn acknowledge(
@@ -945,7 +973,7 @@ impl EnvironmentInstance {
                 terminal_json,
             )
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn release(&mut self, binding_json: &str) -> anyhow::Result<()> {
@@ -953,7 +981,7 @@ impl EnvironmentInstance {
             .bindings
             .call_release(armed(&mut self.store), binding_json)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 }
 
@@ -966,7 +994,7 @@ impl AgentloopInstance {
             .bindings
             .call_activate(armed(&mut self.store), request)
             .await)?
-        .map_err(|error| anyhow::anyhow!(error.message))
+        .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 }
 
@@ -1100,7 +1128,7 @@ impl ComponentRuntime {
         ));
         let bindings = wt(tool::Tool::instantiate_async(&mut store, &component, &linker).await)?;
         wt(bindings.call_invoke(&mut store, &request).await)?
-            .map_err(|error| anyhow::anyhow!(error.message))
+            .map_err(|error| ComponentFailure::error(error.code, error.message, error.retryable))
     }
 
     pub async fn resolve_environment(

--- a/crates/brain-component-host/src/worker.rs
+++ b/crates/brain-component-host/src/worker.rs
@@ -14,9 +14,9 @@ use tokio::sync::Mutex;
 use tracing::Instrument as _;
 
 use crate::{
-    AgentloopInstance, CapabilityCall, CapabilityFailure, CapabilityHandler, ComponentRuntime,
-    DenyCapabilities, EnvironmentInstance, ModelInstance, agentloop, component_digest, environment,
-    model, tool,
+    AgentloopInstance, CapabilityCall, CapabilityFailure, CapabilityHandler, ComponentFailure,
+    ComponentRuntime, DenyCapabilities, EnvironmentInstance, ModelInstance, agentloop,
+    component_digest, environment, model, tool,
 };
 
 const MAX_COMPONENT_BYTES: u64 = 32 << 20;
@@ -296,12 +296,57 @@ enum ParentFrame {
     },
 }
 
+/// One worker failure as it crosses the process boundary. A component's declared `extension-error`
+/// keeps its code and its own retryability; anything else is an internal failure a retry may clear.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerFailure {
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(default = "retryable_by_default")]
+    pub retryable: bool,
+}
+
+fn retryable_by_default() -> bool {
+    true
+}
+
+impl WorkerFailure {
+    fn of(error: &anyhow::Error) -> Self {
+        match error.downcast_ref::<ComponentFailure>() {
+            Some(failure) => Self {
+                message: failure.message.clone(),
+                code: Some(failure.code.clone()),
+                retryable: failure.retryable,
+            },
+            None => Self {
+                message: error.to_string(),
+                code: None,
+                retryable: true,
+            },
+        }
+    }
+
+    fn into_error(self) -> anyhow::Error {
+        match self.code {
+            Some(code) => ComponentFailure::error(code, self.message, self.retryable),
+            None => anyhow::Error::msg(self.message),
+        }
+    }
+}
+
+impl std::fmt::Display for WorkerFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "frame", rename_all = "snake_case")]
 enum WorkerFrame {
     Response {
         id: u64,
-        result: Result<Value, String>,
+        result: Result<Value, WorkerFailure>,
     },
     Capability {
         id: u64,
@@ -727,13 +772,17 @@ pub async fn run_worker() -> anyhow::Result<()> {
             )
             .instrument(span)
             .await
-            .map_err(|error| error.to_string()),
+            .map_err(|error| WorkerFailure::of(&error)),
         };
         let mut encoded = serde_json::to_vec(&response)?;
         if encoded.len() + 1 > MAX_FRAME_BYTES {
             encoded = serde_json::to_vec(&WorkerFrame::Response {
                 id,
-                result: Err("worker response exceeds the frame bound".into()),
+                result: Err(WorkerFailure {
+                    message: "worker response exceeds the frame bound".into(),
+                    code: None,
+                    retryable: true,
+                }),
             })?;
         }
         encoded.push(b'\n');
@@ -873,7 +922,7 @@ impl WorkerPool {
             .call(id, request, self.capabilities.as_ref(), self.frame_timeout)
             .await
         {
-            Ok(result) => result.map_err(anyhow::Error::msg),
+            Ok(result) => result.map_err(|failure| failure.into_error()),
             Err(error) => {
                 // A worker that stopped speaking the frame protocol is replaced; its resident
                 // instances rehydrate on the next activation.
@@ -926,7 +975,7 @@ impl Worker {
         request: WorkerRequest,
         capabilities: &dyn CapabilityHandler,
         frame_timeout: Duration,
-    ) -> anyhow::Result<Result<Value, String>> {
+    ) -> anyhow::Result<Result<Value, WorkerFailure>> {
         if self.child.try_wait()?.is_some() {
             anyhow::bail!("component worker exited before request {id}");
         }

--- a/crates/brain-environment-host/src/lib.rs
+++ b/crates/brain-environment-host/src/lib.rs
@@ -18,6 +18,8 @@ use serde_json::Value;
 
 const MAX_DISPATCH_REQUEST_BYTES: usize = 8 * 1024 * 1024;
 const MAX_DISPATCH_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+/// Enough of a refused dispatch's body to name the reason without pasting a payload into a log.
+const MAX_DISPATCH_DETAIL_CHARS: usize = 512;
 
 static STAGING_NONCE: AtomicU64 = AtomicU64::new(1);
 
@@ -259,7 +261,15 @@ fn required_string<'a>(value: &'a Value, field: &str) -> Result<&'a str> {
 }
 
 fn environment_transport(error: anyhow::Error) -> BrainError {
-    BrainError::Transport(format!("Environment component: {error}"))
+    // An Environment that declares a failure unretryable has judged that repeating the call cannot
+    // succeed. Reporting it as transport makes every caller wait on a retry that never lands.
+    match error.downcast_ref::<brain_component_host::ComponentFailure>() {
+        Some(failure) if !failure.retryable => BrainError::EnvironmentRefused(format!(
+            "Environment component: {} ({})",
+            failure.message, failure.code
+        )),
+        _ => BrainError::Transport(format!("Environment component: {error}")),
+    }
 }
 
 pub async fn registry_with_component_store(
@@ -502,9 +512,23 @@ impl CapabilityHandler for HttpEnvironmentCapabilities {
             body.extend_from_slice(&chunk);
         }
         if !status.is_success() {
+            // The endpoint names the refusal in its body. Dropping it leaves only a status, which
+            // is how a release refusal reached a live plane as an unexplained "400 Bad Request".
+            let detail = String::from_utf8_lossy(&body);
+            let detail = detail.trim();
             return Err(capability_failure(
                 "dispatch_failed",
-                &format!("Environment dispatch returned {status}"),
+                &if detail.is_empty() {
+                    format!("Environment dispatch returned {status}")
+                } else {
+                    format!(
+                        "Environment dispatch returned {status}: {}",
+                        detail
+                            .chars()
+                            .take(MAX_DISPATCH_DETAIL_CHARS)
+                            .collect::<String>()
+                    )
+                },
                 status.is_server_error(),
             ));
         }
@@ -550,6 +574,60 @@ mod tests {
                 Duration::from_secs(1)
             )
             .is_ok()
+        );
+    }
+
+    /// A refused dispatch reached a live plane as "400 Bad Request" and nothing else, three times
+    /// in one release. The endpoint names the reason in its body; the failure must carry it.
+    #[tokio::test]
+    async fn a_refused_dispatch_carries_the_endpoint_reason_and_is_not_retryable() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut chunk = [0_u8; 4096];
+            let _ = socket.read(&mut chunk).await.unwrap();
+            let body = br#"{"error":"the relay refused this release"}"#;
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            socket.write_all(body).await.unwrap();
+        });
+        let handler = HttpEnvironmentCapabilities::new(
+            format!("http://{address}/environment"),
+            None,
+            Duration::from_secs(2),
+        )
+        .unwrap();
+        let failure = handler
+            .call(CapabilityCall {
+                world: ENVIRONMENT_COMPONENT.into(),
+                instance_id: Some("instance".into()),
+                capability: "environment.dispatch".into(),
+                operation_id: "workspace".into(),
+                request: serde_json::json!({
+                    "action": "release",
+                    "request": {"binding": {"driver": "customer"}},
+                    "deadline_at_ms": (brain::wall_ms() + 2_000).to_string(),
+                }),
+            })
+            .await
+            .expect_err("a refused dispatch fails");
+        assert!(
+            failure.message.contains("the relay refused this release"),
+            "the refusal must name its reason: {}",
+            failure.message
+        );
+        assert!(
+            !failure.retryable,
+            "a client refusal cannot be cleared by repeating it"
         );
     }
 

--- a/crates/brain-server/src/api/error.rs
+++ b/crates/brain-server/src/api/error.rs
@@ -188,6 +188,12 @@ pub(super) fn map_err(e: BrainError) -> Failure {
             "the upstream provider request failed",
             false,
         ),
+        BrainError::EnvironmentRefused(_) => (
+            S::CONFLICT,
+            "environment_refused",
+            "the execution runtime refused the operation",
+            false,
+        ),
         BrainError::EnvironmentUnavailable(_) | BrainError::Environment(_) => (
             S::SERVICE_UNAVAILABLE,
             "environment_unavailable",

--- a/crates/brain-server/tests/component_tool_environment.rs
+++ b/crates/brain-server/tests/component_tool_environment.rs
@@ -58,8 +58,20 @@ async fn dispatch_endpoint() -> (String, Arc<Mutex<Vec<Value>>>) {
         axum::routing::post(move |axum::Json(body): axum::Json<Value>| {
             let recorder = recorder.clone();
             async move {
+                let refuse = body["action"] == "release";
                 recorder.lock().expect("recorded dispatches").push(body);
-                axum::Json(json!({"dispatched": "ok"}))
+                if refuse {
+                    // A permanent content refusal, the shape that kept a live plane's sessions in
+                    // ending forever.
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        axum::Json(json!({"error": "the relay refused this release"})),
+                    );
+                }
+                (
+                    axum::http::StatusCode::OK,
+                    axum::Json(json!({"dispatched": "ok"})),
+                )
             }
         }),
     );
@@ -214,6 +226,40 @@ async fn component_tool_calls_component_environment_through_the_session_kernel()
         assert_eq!(call["action"], "submit");
         assert!(call["request"]["operation_id"].is_string());
     }
+
+    // A release the Environment declares permanently impossible cannot be cleared by repeating it.
+    // An end that waits on one is never retired: the session is swept forever, which holds the
+    // control plane's write lock and fails unrelated routes. The end must finish, and the refusal
+    // must arrive with the endpoint's own reason rather than a bare status.
+    brain
+        .end(&session_id)
+        .await
+        .expect("end past a refused release");
+    let mut ended = false;
+    for _ in 0..3_000 {
+        if brain.journal.get_head(&session_id).await.unwrap().doc.state
+            == brain::journal::SessionLifecycle::Ended
+        {
+            ended = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    {
+        let recorded = dispatched.lock().expect("recorded dispatches");
+        let release = recorded
+            .iter()
+            .find(|call| call["action"] == "release")
+            .unwrap_or_else(|| {
+                let actions: Vec<_> = recorded.iter().map(|call| call["action"].clone()).collect();
+                panic!("the end never released the Environment; ended={ended} actions={actions:?}")
+            });
+        assert_eq!(release["request"]["released"], true);
+    }
+    assert!(
+        ended,
+        "a refused release must not leave the session ending forever"
+    );
 
     // The immutable bundle is the largest Tool payload; sealing it inline would put megabytes in
     // every session's CONFIG record, which is what the journal ceiling exists to refuse.

--- a/crates/brain/src/lib.rs
+++ b/crates/brain/src/lib.rs
@@ -178,6 +178,11 @@ pub enum BrainError {
     #[error("environment operation error: {0}")]
     Environment(String),
 
+    /// The Environment itself declared the operation permanently impossible. Retrying it cannot
+    /// succeed, so nothing may wait on a retry.
+    #[error("environment refused the operation: {0}")]
+    EnvironmentRefused(String),
+
     #[error("journal: {0}")]
     Journal(String),
 

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -7419,7 +7419,7 @@ async fn release_component_environments(
             )
         })?;
     for (environment_id, declaration) in declarations {
-        registry
+        let released = registry
             .release(
                 &declaration,
                 crate::environment::ComponentEnvironmentRelease {
@@ -7427,11 +7427,24 @@ async fn release_component_environments(
                     session_id: session_id.to_owned(),
                     root_id: head.root_id.clone(),
                     parent_id: head.parent_id.clone(),
-                    environment_id,
+                    environment_id: environment_id.clone(),
                     policy: serde_json::json!({ "network": head.prefix.network }),
                 },
             )
-            .await?;
+            .await;
+        // A refusal the Environment declares permanent cannot be cleared by repeating it, and an
+        // end that waits on it is never retired: the session is swept forever, which holds the
+        // control plane's write lock and fails unrelated routes. Record it and finish the end.
+        match released {
+            Ok(()) => {}
+            Err(BrainError::EnvironmentRefused(reason)) => tracing::warn!(
+                session = session_id,
+                environment = environment_id,
+                reason,
+                "Environment refused its release; ending without it"
+            ),
+            Err(error) => return Err(error),
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
Development run `32944099176`. Takes the release-dispatch half of the two defects; the agentloop bind is diagnosed but not fixed here (below).

## What the 400 actually is, and is not

I ran the deployed composition locally — Brain `286014c8`, the **real** `environment-driver` binary in front of it, its `customer` relay pointed back at Brain's `/internal/v1/customer-environment/dispatch` — against the exact release body Brain sends:

```json
{"operation_id":"application","action":"release",
 "request":{"binding":{"configuration":{"registration":"probe-app"},"driver":"customer",
   "environment_id":"application","policy":{"network":{"outbound":"none"}},
   "root_id":"ses_…","session_id":"ses_…","tenant_id":"local"}},
 "deadline_at_ms":"18446744073709551615"}
```

Every layer accepts it. `submit → observe → acknowledge → release` all return 200 and `session.end()` completes. So the release is **not** being sent in a shape the relay or driver rejects, and `kind == "invoke"` does not apply — that constraint is on `submit`, and `release` is its own action which both drivers implement.

The 400 on dev is therefore a deployment-specific refusal that the system throws away before anyone can read it. Three layers each drop what the next one needs, and that is what this PR fixes.

## The reason survives

`HttpEnvironmentCapabilities` reported only its own status and never read the endpoint's body — where the refusal names itself. It now carries it, bounded. `HttpRelayDriver` additionally collapsed every client error into a bare 400 and dropped the relayed text; aexhq/extensions#53 fixes that half and logs refusals, so `401`, `404` and a rejected payload stop looking identical.

New unit test: a refused dispatch's failure must contain the endpoint's reason and must be non-retryable.

## The amplifier

The component runtime turned an export's declared `extension-error` into `anyhow!(error.message)` — discarding `code` and `retryable` — and the worker then crossed its process boundary as a bare `String`. `HttpEnvironmentCapabilities` already marks a client refusal `retryable: false`; that judgement was destroyed two frames later, so `environment_transport` reported everything as transport and `release_component_environments` propagated it, and the end retried about once a second forever. A session that never ends is never retired, so Control's sweeper keeps it and holds the write lock — the 500s on unrelated routes.

Both boundaries now carry the component's own judgement, and a refusal the Environment declares permanent is recorded and the end completes. Repeating it cannot release anything; waiting on it costs the whole plane.

`component_tool_environment` now refuses the release with a 400 and a reason and asserts the session still reaches `Ended`. With that one branch reverted the test hangs in `Ending` until its own bound expires and fails with "a refused release must not leave the session ending forever".

## The agentloop bind — diagnosed, not fixed

`capabilities are already bound for agentloop instance ses_f505e2849e41bc013deab391` is a *symptom*: the router keys an agentloop binding by session id because that is also the resident instance id a capability call carries, so two concurrent activations of one session genuinely cannot both be routed. Refusing is correct; the defect is upstream, in whatever drove a second activation.

What I established: it was that session's **first** turn (`trn_Y5aqA3gEHSWYb06xvje6vVq6`, diagnostic `session.updated, turn.started, replay.complete`), on a fresh session, and Brain logged nothing else for it. `ComponentAgentloop::drive_turn` binds once and drops on every path, so two `drive_turn` calls overlapped. There are exactly two callers of the turn driver: the live path (`run.run`, `session/mod.rs:4748`) and the recovery path (`run.resume`, `session/mod.rs:5666`), and only recovery can re-enter a session that already has a live turn. I could not reproduce that race locally and did not want to change lease or recovery semantics on a guess, so I have left it.

It is not the same defect as `subagent`'s `component worker closed before response`, but it may share that one's cause: `brain-component-host`'s `vertical_slice` tests `a_worker_that_stops_answering_is_stopped_with_a_named_reason` and `a_request_waiting_on_the_kernel_outlives_the_worker_frame_bound` **already fail on unmodified `main`** with `component worker sent no frame for request 1 within 5s`. Whoever owns the worker defect should start there — it is reproducible without a deployment today.

## Gates

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude brain-loophost --exclude brain-component-host --exclude brain-server`, `cargo test -p brain-server --test component_tool_environment`, `--test standalone_e2e`, `--lib --bins`, `npm test` all pass. `cargo test -p brain-component-host` fails only on the two pre-existing worker-frame tests named above, identically with these changes stashed.

No package version changes: this round touches only Rust.