### PR TITLE
api: let the Environment dispatch relay in without a tenant header

### DIFF
--- a/crates/brain-server/src/api/mod.rs
+++ b/crates/brain-server/src/api/mod.rs
@@ -222,22 +222,25 @@ pub fn router(state: AppState) -> Router {
             post(customer_environment_grant)
                 .layer(DefaultBodyLimit::max(SMALL_JSON_BODY_LIMIT_BYTES)),
         )
-        .route(
-            "/internal/v1/customer-environment/dispatch",
-            post(customer_environment_dispatch)
-                .layer(DefaultBodyLimit::max(INLINE_FILE_BODY_LIMIT_BYTES)),
-        )
         .merge(create)
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             operator_auth_before_body,
         ));
-    let customer_gateway = Router::new()
+    // Global internal ingress. The operator bearer authenticates the caller and the scoped payload
+    // — a consumed connect grant, an Environment binding — names the tenant. A tenant header does
+    // not belong on a route the gateway or an Environment driver reaches on the plane's behalf.
+    let internal_ingress = Router::new()
         .route(
             "/internal/v1/customer-environment/gateway",
             post(customer_environment_gateway).layer(DefaultBodyLimit::max(
                 brain_protocol::MAX_CUSTOMER_WS_FRAME_BYTES,
             )),
+        )
+        .route(
+            "/internal/v1/customer-environment/dispatch",
+            post(customer_environment_dispatch)
+                .layer(DefaultBodyLimit::max(INLINE_FILE_BODY_LIMIT_BYTES)),
         )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
@@ -274,7 +277,7 @@ pub fn router(state: AppState) -> Router {
             get(customer_environment_socket),
         )
         .merge(operator)
-        .merge(customer_gateway)
+        .merge(internal_ingress)
         .merge(public_observation)
         .merge(internal_observation)
         .layer(middleware::from_fn_with_state(

--- a/crates/brain-server/tests/api_admission.rs
+++ b/crates/brain-server/tests/api_admission.rs
@@ -90,8 +90,16 @@ async fn a_tenanted_composition_refuses_requests_without_the_tenant_header() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
+/// Global internal ingress: the API Gateway, an Environment driver's relay and the observation
+/// hop all reach Brain on the plane's behalf, never on one tenant's. The operator bearer
+/// authenticates the caller and the scoped payload — a consumed connect grant, an observation
+/// grant, an Environment binding — names the tenant, so requiring `x-brain-tenant-id` refuses a
+/// caller that has no tenant to give. That mistake reached a deployment three times in one
+/// release: the connect gateway, the observation hop and finally the release dispatch, which held
+/// every `app()` session in ending. Judge the whole family here so a fourth cannot be added
+/// quietly.
 #[tokio::test]
-async fn scoped_customer_ingress_does_not_require_a_tenant_header() {
+async fn global_internal_ingress_does_not_require_a_tenant_header() {
     let temp = TempDir::new("scoped-customer-ingress");
     let brain = Brain::in_memory_test(
         temp.0.clone(),
@@ -105,35 +113,75 @@ async fn scoped_customer_ingress_does_not_require_a_tenant_header() {
         tenancy: brain_server::api::Tenancy::Required,
     });
 
-    let gateway = Request::builder()
-        .method("POST")
-        .uri("/internal/v1/customer-environment/gateway")
-        .header(header::AUTHORIZATION, "Bearer operator-token")
-        .header("x-brain-connection-id", "connection-1")
-        .header("x-brain-request-id", "request-1")
-        .header("x-brain-route-key", "$connect")
-        .header("x-brain-source-ip", "192.0.2.10")
-        .header(
-            header::SEC_WEBSOCKET_PROTOCOL,
-            "environment-grant.valid-token",
-        )
-        .body(Body::empty())
-        .unwrap();
-    let gateway_response = app.clone().oneshot(gateway).await.unwrap();
-    assert_eq!(gateway_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let ingress = [
+        (
+            "connect gateway",
+            Request::builder()
+                .method("POST")
+                .uri("/internal/v1/customer-environment/gateway")
+                .header(header::AUTHORIZATION, "Bearer operator-token")
+                .header("x-brain-connection-id", "connection-1")
+                .header("x-brain-request-id", "request-1")
+                .header("x-brain-route-key", "$connect")
+                .header("x-brain-source-ip", "192.0.2.10")
+                .header(
+                    header::SEC_WEBSOCKET_PROTOCOL,
+                    "environment-grant.valid-token",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        ),
+        (
+            "observation hop",
+            Request::builder()
+                .method("POST")
+                .uri("/internal/v1/customer-environment/observations/grant-1")
+                .header(header::AUTHORIZATION, "Bearer operator-token")
+                .header("x-brain-observation-grant", "observation-token")
+                .body(Body::from("{}"))
+                .unwrap(),
+        ),
+        (
+            "Environment dispatch relay",
+            Request::builder()
+                .method("POST")
+                .uri("/internal/v1/customer-environment/dispatch")
+                .header(header::AUTHORIZATION, "Bearer operator-token")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "operation_id": "application",
+                        "action": "release",
+                        "request": {"binding": {"driver": "customer"}},
+                        "deadline_at_ms": (brain::wall_ms() + 60_000).to_string(),
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        ),
+    ];
+    for (label, request) in ingress {
+        let response = app.clone().oneshot(request).await.unwrap();
+        // This composition has no customer coordinator, so reaching the handler is the proof: a
+        // tenancy refusal is a 400 that never gets there.
+        assert_eq!(
+            response.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "{label} must not be refused for a missing tenant header",
+        );
+    }
 
-    let observation = Request::builder()
+    // The boundary of the rule. Minting a grant takes the tenant as its input — no scoped payload
+    // can resolve it — so Control sends the header and this route is right to demand it.
+    let grants = Request::builder()
         .method("POST")
-        .uri("/internal/v1/customer-environment/observations/grant-1")
+        .uri("/internal/v1/customer-environment/grants")
         .header(header::AUTHORIZATION, "Bearer operator-token")
-        .header("x-brain-observation-grant", "observation-token")
-        .body(Body::from("{}"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"client_id":"app.one"}"#))
         .unwrap();
-    let observation_response = app.oneshot(observation).await.unwrap();
-    assert_eq!(
-        observation_response.status(),
-        StatusCode::SERVICE_UNAVAILABLE
-    );
+    let grants_response = app.oneshot(grants).await.unwrap();
+    assert_eq!(grants_response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Development run `32953775235`, session `ses_610be16ab664c57439dc19b2`. The reason now reads end to end, and this is what it was hiding:

```
x-brain-tenant-id header is required by this composition
```

## Same mistake, third instance, existing fix extended

The relay dispatches back into Brain at `/internal/v1/customer-environment/dispatch`, which still sat in the tenant-scoped operator router. It has no tenant to give: it acts for the plane, not for one customer. The connect gateway and the observation hop already had this and were converted; the resolution recorded then stands, so I extended it rather than inventing a pattern:

> global internal ingress — the operator bearer authenticates the caller and the scoped payload names the tenant

For dispatch, that payload is the Environment binding, whose `tenant_id` `validate_binding` already checks. The route moves to `global_operator_auth_before_body` alongside the gateway. No header was added to the relay or the driver.

## Reproduced first

Extending `scoped_customer_ingress_does_not_require_a_tenant_header` with the dispatch route reproduces it exactly, against `Tenancy::Required`:

```
assertion `left == right` failed: Environment dispatch relay must not be refused for a missing tenant header
  left: 400
 right: 503
```

`503` is the proof of reaching the handler — this composition has no customer coordinator — where a tenancy refusal is a `400` that never gets there.

This also closes the loop on my previous report. I ran the whole deployed composition locally — the real `environment-driver` in front of Brain, relay pointed back at the internal route — and every dispatch returned 200. That was not a false negative in the harness: `BRAIN_MODE=local` composes `Tenancy::Implicit`, so `auth()` never demanded the header and only a hosted composition could refuse it. The regression therefore drives `Tenancy::Required` directly, which is where this class belongs.

## The whole family, and its boundary

I audited every route reachable from a driver, the gateway or a customer-supplied component. A component only reaches Brain through in-process capability calls, so the HTTP family is:

| route | guard | correct? |
| --- | --- | --- |
| `/internal/v1/customer-environment/gateway` | operator bearer, no tenant | already converted |
| `/internal/v1/customer-environment/observations/{grant_id}` | operator bearer + grant | already converted |
| `/internal/v1/customer-environment/dispatch` | tenant-scoped | **the fourth instance — fixed here** |
| `/v1/customer-environment/observations/{grant_id}` | grant | fine |
| `/v1/customer-environment/socket` | connect grant subprotocol | fine |
| `/internal/v1/customer-environment/grants` | tenant-scoped | **correct as it is** |

`grants` is the boundary of the rule, not a fifth instance: minting a grant takes the tenant as its *input* — `customer_environment_grant` calls `auth()` for the principal it mints against — so no scoped payload could resolve it, and Control does send the header (`aex-control/src/brain.rs`). The regression now asserts that too, so a future change cannot "convert" it by pattern-matching, and cannot add a route on the permissive side without covering it.

The test is renamed `global_internal_ingress_does_not_require_a_tenant_header` and judges the three ingress routes in one loop with named failures.

## Gates

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --exclude brain-loophost --exclude brain-component-host --exclude brain-server`, `cargo test -p brain-server --lib --bins`, `--test api_admission --test create_idempotency --test message_idempotency --test discard_race`, and `npm test` all pass. The component-gated suites are unaffected by a routing change and run in CI.

Rust only; no package version changes.