### PR TITLE
worker: report what a component worker is holding

### DIFF
--- a/crates/brain-component-host/src/worker.rs
+++ b/crates/brain-component-host/src/worker.rs
@@ -431,6 +431,7 @@ struct Residents {
     agentloops: Table<ResidentAgentloop>,
     environments: Table<ResidentEnvironment>,
     models: Table<ResidentModel>,
+    reported: AtomicUsize,
 }
 
 impl Residents {
@@ -472,6 +473,28 @@ impl Residents {
         sweep_table(&self.agentloops, policy);
         sweep_table(&self.environments, policy);
         sweep_table(&self.models, policy);
+        self.report();
+    }
+
+    /// A resident instance is a whole JavaScript runtime, and residency is bounded by count and
+    /// idle time but never by bytes, so the only way to know what a worker is holding is to say
+    /// so. The hosted task publishes no per-process memory metric, which is what left a stalled
+    /// plane undiagnosable; this is the number that settles it.
+    fn report(&self) {
+        let agentloops = resident_count(&self.agentloops);
+        let environments = resident_count(&self.environments);
+        let models = resident_count(&self.models);
+        let resident = agentloops + environments + models;
+        if self.reported.swap(resident, Ordering::Relaxed) == resident {
+            return;
+        }
+        tracing::info!(
+            component.agentloops = agentloops,
+            component.environments = environments,
+            component.models = models,
+            component.resident_bytes = resident_bytes(),
+            "component worker residency"
+        );
     }
 }
 
@@ -487,6 +510,18 @@ fn live<'a, T: Resident>(
             resident.instance()
         })
         .ok_or_else(|| anyhow::anyhow!("{world} instance is not resident"))
+}
+
+fn resident_count<T>(table: &Table<T>) -> usize {
+    table.lock().expect("resident instances").len()
+}
+
+/// This process's resident set, as the kernel reports it. Linux only, which is where the
+/// hosted plane runs; elsewhere the field is absent rather than wrong.
+fn resident_bytes() -> Option<u64> {
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+    Some(pages * 4096)
 }
 
 /// Evict idle instances and hold the table to its cap. A slot that is locked is serving a request

--- a/crates/brain-component-host/tests/vertical_slice.rs
+++ b/crates/brain-component-host/tests/vertical_slice.rs
@@ -530,6 +530,11 @@ async fn a_nested_request_runs_while_the_parent_is_parked_in_its_own_ctx_op() {
     .await
     .unwrap();
     capabilities.pool.set(Arc::downgrade(&pool)).ok();
+    // Compile the component before the nested call is timed: this test is about the parent not
+    // blocking its child, not about how long a cold cranelift compile takes.
+    pool.call(agentloop_activation("ses_warm", r#"{"track":true}"#))
+        .await
+        .expect("warm the component");
     let returned = pool
         .call(agentloop_activation(
             "ses_parent",


### PR DESCRIPTION
This does **not** fix the `subagent` wedge. It ships the measurement that would settle what
the wedge is, plus a fix to a test of mine that was failing for the wrong reason. What I
found and what I ruled out is below, so the next person picking this up does not repeat it.

## The child-session path reproduces clean

The stated shape — one turn, two `subagents` calls, the second addressing the child the
first created — served over a **real listener**, with a probe polling `/v1/sessions` every
200 ms throughout so the accept path is observable, and 4 workers as deployed. All three
things the second call can be:

| second call | turn finished | tool.call / tool.result | worst probe |
| --- | --- | --- | --- |
| `wait` on the child | yes | 2 / 2 | 2 ms |
| `send_message` to the child | yes | 2 / 2 | 2 ms |
| `peek` at the child | yes | 2 / 2 | 2 ms |

The child really runs — it takes its own turn and its own tool call against the same
component pools, so the re-entrancy is present. Nothing hangs and the listener never
misses a beat. Whatever the plane is doing, it is not the two-call child path on its own.

## Ruled out, with the check that ruled it out

- **A lock held across an await, anywhere.** `cargo clippy --workspace --all-targets
  -W clippy::await_holding_lock` — no findings.
- **`sessions` against `root_secret_cells` inversion.** These are the two `std::sync::Mutex`
  maps a child session makes non-trivial, and they are the natural candidate for "a lock the
  accept path and the actor supervisor both need". The actor-exit path takes
  `sessions → root_secret_cells`; `root_execution_secrets` takes `root_secret_cells` alone
  in a block and drops it before awaiting. No cycle.
- **`/end` waiting on a stuck turn.** `Command::End` fences durably, cancels, and replies
  *before* the running task is awaited, so a stuck turn cannot hold the reply. (`Command::Delete`
  does await the task — but End is what Control calls.)
- **The actor loop serialising against its own turn.** It `select!`s the running turn against
  the mailbox, so a self-delivered `CreateChild` from inside that turn is serviced concurrently.
  `capture_context_fork` only reads the journal; it takes no session lock.

## What I measured instead

Residency is bounded by instance **count** and idle time, never by bytes — on every build,
multiplexed or not. Each resident instance is a whole JavaScript runtime. Sessions arriving
**strictly one at a time**, no concurrency involved:

```
idle worker                    25 MiB
64 resident sessions          597 MiB      (~8.9 MiB each)
```

`BRAIN_COMPONENT_INSTANCE_CAP` defaults to **256**, which permits roughly **2.3 GiB in one
worker process**. A deployment runs four pools of four, against a **3072 MiB task shared
with Control and the Environment driver**.

`subagent` is the only case that *creates sessions*, so it is the only case that multiplies
residency — which fits a wedge that follows the case rather than the build.

I am **not** shipping an eviction-by-bytes policy on that inference. That is exactly the
move that cost a cycle last time: a well-reasoned change to an unreproduced fault. The
sizing wants the real number first.

## What this ships

- The worker logs its instance counts per world and its own resident set from
  `/proc/self/statm` whenever residency changes. That is the per-process number the hosted
  task does not publish, available from the next deployment regardless of Container Insights,
  and it is what distinguishes exhaustion from deadlock at the moment of a stall.
- `a_nested_request_runs_while_the_parent_is_parked_in_its_own_ctx_op` now compiles the
  component before the nested call is timed. It asserted a five-second bound that a cold
  cranelift compile cannot meet, so it failed on an empty cache while testing compile speed
  rather than head-of-line blocking. The whole crate now passes on an empty
  `BRAIN_COMPONENT_CACHE_DIR` again (16 tests).

No behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTKXL4hmbssi59fhiaf72c
