### PR TITLE
release: gate promotion on image e2e

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: publish npm packages
+name: release Brain
 
 on:
   workflow_dispatch:
@@ -27,6 +27,11 @@ on:
         type: string
         required: false
         default: ''
+      image_run_id:
+        description: Successful candidate-image workflow run for this commit (stage only)
+        type: string
+        required: false
+        default: ''
 
 concurrency:
   group: brain-npm-publish
@@ -52,6 +57,7 @@ jobs:
           SELECTED_COMMIT: ${{ github.sha }}
           SELECTED_REF: ${{ github.ref }}
           STAGE_RUN_ID: ${{ inputs.stage_run_id }}
+          IMAGE_RUN_ID: ${{ inputs.image_run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
@@ -63,6 +69,7 @@ jobs:
           git merge-base --is-ancestor "$EXPECTED_COMMIT" origin/main
           if [[ "$OPERATION" == promote ]]; then
             [[ "$STAGE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+            test -z "$IMAGE_RUN_ID"
             stage_run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$STAGE_RUN_ID")
             test "$(jq -r .head_sha <<<"$stage_run")" = "$EXPECTED_COMMIT"
             test "$(jq -r .event <<<"$stage_run")" = workflow_dispatch
@@ -73,6 +80,15 @@ jobs:
               "$stage_path" == .github/workflows/npm-publish.yml@* ]]
           else
             test -z "$STAGE_RUN_ID"
+            [[ "$IMAGE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+            image_run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$IMAGE_RUN_ID")
+            test "$(jq -r .head_sha <<<$image_run)" = "$EXPECTED_COMMIT"
+            test "$(jq -r .event <<<$image_run)" = workflow_run
+            test "$(jq -r .status <<<$image_run)" = completed
+            test "$(jq -r .conclusion <<<$image_run)" = success
+            image_path=$(jq -r .path <<<$image_run)
+            [[ "$image_path" == .github/workflows/image.yml || \
+              "$image_path" == .github/workflows/image.yml@* ]]
           fi
 
   prepare:
@@ -81,6 +97,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
+      actions: read
       contents: read
     outputs:
       versions: ${{ steps.pack.outputs.versions }}
@@ -120,6 +137,22 @@ jobs:
             echo
             node tools/npm-release.mjs markdown "$release_dir/manifest.json"
           } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/download-artifact@v7
+        with:
+          name: brain-image-${{ inputs.expected_commit }}
+          path: ${{ runner.temp }}/brain-npm-release
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.image_run_id }}
+      - name: Bind the candidate image to this release
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+        run: |
+          jq -e --arg source "$EXPECTED_COMMIT" '
+            .schema == 1 and .source_sha == $source and
+            (.image | test("^ghcr\\.io/aexhq/brain$")) and
+            (.manifest_digest | test("^sha256:[0-9a-f]{64}$"))
+          ' "$RUNNER_TEMP/brain-npm-release/brain-image.json" >/dev/null
       - uses: actions/upload-artifact@v6
         with:
           name: brain-npm-release-${{ inputs.expected_commit }}
@@ -159,6 +192,136 @@ jobs:
         run: |
           echo "Staged exact versions under npm dist-tag \`next\`: \`$VERSIONS\`" >> "$GITHUB_STEP_SUMMARY"
 
+  e2e-sdk:
+    if: inputs.operation == 'stage'
+    needs: stage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v7
+        with:
+          name: brain-npm-release-${{ inputs.expected_commit }}
+          path: ${{ runner.temp }}/brain-release
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Install the staged public SDK
+        shell: bash
+        run: |
+          set -euo pipefail
+          sdk=$(jq -er '.packages[] | select(.name == "@aexhq/brain") | "\(.name)@\(.version)"' "$RUNNER_TEMP/brain-release/manifest.json")
+          test "$(npm view "$sdk" version)" = "${sdk##*@}"
+          mkdir "$RUNNER_TEMP/sdk-e2e"
+          cp tests/release/sdk.mjs "$RUNNER_TEMP/sdk-e2e/sdk.mjs"
+          cd "$RUNNER_TEMP/sdk-e2e"
+          npm init --yes >/dev/null
+          npm install --ignore-scripts --save-exact "$sdk" @aexhq/loop-pi@0.89.0
+          npm audit --audit-level=high
+      - name: Run the candidate image through the staged SDK
+        shell: bash
+        env:
+          BRAIN_API_TOKEN: release-sdk-token
+        run: |
+          set -euo pipefail
+          image=$(jq -er '"\(.image)@\(.manifest_digest)"' "$RUNNER_TEMP/brain-release/brain-image.json")
+          docker pull "$image" >/dev/null
+          docker run -d --name brain-sdk-e2e -p 18080:8080 -e BRAIN_API_TOKEN "$image"
+          trap 'docker logs brain-sdk-e2e; docker rm -f brain-sdk-e2e >/dev/null' EXIT
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent http://127.0.0.1:18080/health/ready >/dev/null; then break; fi
+            test "$attempt" -lt 60
+            sleep 1
+          done
+          BRAIN_BASE_URL=http://127.0.0.1:18080 node "$RUNNER_TEMP/sdk-e2e/sdk.mjs"
+
+  e2e-http:
+    if: inputs.operation == 'stage'
+    needs: stage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v7
+        with:
+          name: brain-npm-release-${{ inputs.expected_commit }}
+          path: ${{ runner.temp }}/brain-release
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          package-manager-cache: false
+      - name: Prepare the raw HTTP client and deployed journal shape
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir "$RUNNER_TEMP/http-e2e" "$RUNNER_TEMP/http-data"
+          cp tests/release/http.mjs "$RUNNER_TEMP/http-e2e/http.mjs"
+          cd "$RUNNER_TEMP/http-e2e"
+          npm init --yes >/dev/null
+          npm install --ignore-scripts --save-exact @aexhq/loop-pi@0.89.0
+          npm audit --audit-level=high
+          python3 - "$RUNNER_TEMP/http-data/brain.sqlite3" <<'PY'
+          import sqlite3
+          import sys
+          connection = sqlite3.connect(sys.argv[1])
+          connection.execute("""CREATE TABLE sessions (
+            session_id TEXT PRIMARY KEY,
+            journal_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            through_sequence INTEGER NOT NULL,
+            configuration_json TEXT NOT NULL,
+            context_json TEXT NOT NULL,
+            presentation_digest TEXT NOT NULL,
+            metadata_json TEXT NOT NULL
+          )""")
+          connection.close()
+          PY
+          sudo chown -R 10001:10001 "$RUNNER_TEMP/http-data"
+      - name: Run the candidate image through raw HTTP after an in-place upgrade
+        shell: bash
+        env:
+          BRAIN_API_TOKEN: release-http-token
+        run: |
+          set -euo pipefail
+          image=$(jq -er '"\(.image)@\(.manifest_digest)"' "$RUNNER_TEMP/brain-release/brain-image.json")
+          docker pull "$image" >/dev/null
+          docker run -d --name brain-http-e2e -p 18081:8080 -e BRAIN_API_TOKEN \
+            -v "$RUNNER_TEMP/http-data:/var/lib/brain" "$image"
+          trap 'docker logs brain-http-e2e; docker rm -f brain-http-e2e >/dev/null' EXIT
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent http://127.0.0.1:18081/health/ready >/dev/null; then break; fi
+            test "$attempt" -lt 60
+            sleep 1
+          done
+          BRAIN_BASE_URL=http://127.0.0.1:18081 node "$RUNNER_TEMP/http-e2e/http.mjs"
+
+  stage-gate:
+    if: always() && inputs.operation == 'stage'
+    needs: [stage, e2e-sdk, e2e-http]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require both candidate interfaces
+        env:
+          STAGE: ${{ needs.stage.result }}
+          SDK: ${{ needs.e2e-sdk.result }}
+          HTTP: ${{ needs.e2e-http.result }}
+        run: |
+          test "$STAGE" = success
+          test "$SDK" = success
+          test "$HTTP" = success
+
   promote:
     if: inputs.operation == 'promote'
     needs: validate
@@ -195,3 +358,41 @@ jobs:
         run: |
           versions=$(node "$RUNNER_TEMP/brain-npm-release/npm-release.mjs" versions "$RUNNER_TEMP/brain-npm-release/manifest.json")
           echo "Promoted the same registry objects to npm dist-tag \`latest\`: \`$versions\`" >> "$GITHUB_STEP_SUMMARY"
+
+  promote-image:
+    if: inputs.operation == 'promote'
+    needs: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    environment: npm-production
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: brain-npm-release-${{ inputs.expected_commit }}
+          path: ${{ runner.temp }}/brain-release
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.stage_run_id }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Promote the tested manifest
+        shell: bash
+        env:
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+        run: |
+          set -euo pipefail
+          manifest="$RUNNER_TEMP/brain-release/brain-image.json"
+          test "$(jq -er .source_sha "$manifest")" = "$EXPECTED_COMMIT"
+          image=$(jq -er .image "$manifest")
+          digest=$(jq -er .manifest_digest "$manifest")
+          docker buildx imagetools inspect "$image@$digest" >/dev/null
+          docker buildx imagetools create -t "$image:latest" "$image@$digest"
+          promoted=$(docker buildx imagetools inspect "$image:latest" --format '{{json .Manifest}}' | jq -er .digest)
+          test "$promoted" = "$digest"
+          echo "Promoted the tested image to \`$image:latest\` at \`$image@$digest\`." >> "$GITHUB_STEP_SUMMARY"

--- a/crates/brain/src/journal/sqlite.rs
+++ b/crates/brain/src/journal/sqlite.rs
@@ -43,8 +43,7 @@ impl SqliteJournal {
                through_sequence INTEGER NOT NULL,
                configuration_json TEXT NOT NULL,
                context_json TEXT NOT NULL,
-               presentation_digest TEXT NOT NULL,
-               metadata_json TEXT NOT NULL DEFAULT 'null'
+               presentation_digest TEXT NOT NULL
              );
              CREATE TABLE IF NOT EXISTS records (
                session_id TEXT NOT NULL,
@@ -66,6 +65,22 @@ impl SqliteJournal {
              );",
             )
             .map_err(journal_error)?;
+        let has_retired_metadata = {
+            let mut statement = transaction
+                .prepare("PRAGMA table_info(sessions)")
+                .map_err(journal_error)?;
+            let columns = statement
+                .query_map([], |row| row.get::<_, String>(1))
+                .map_err(journal_error)?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(journal_error)?;
+            columns.iter().any(|column| column == "metadata_json")
+        };
+        if has_retired_metadata {
+            transaction
+                .execute("ALTER TABLE sessions DROP COLUMN metadata_json", [])
+                .map_err(journal_error)?;
+        }
         let existing: Option<String> = transaction
             .query_row(
                 "SELECT value FROM metadata WHERE key = 'journal_id'",

--- a/crates/brain/tests/kernel.rs
+++ b/crates/brain/tests/kernel.rs
@@ -311,6 +311,62 @@ async fn restart_marks_an_inflight_turn_ambiguous_instead_of_guessing() {
 }
 
 #[tokio::test]
+async fn opens_a_legacy_journal_after_removing_session_metadata() {
+    let data_dir = temporary_directory();
+    let database = data_dir.join("brain.sqlite3");
+    let connection = rusqlite::Connection::open(&database).unwrap();
+    connection
+        .execute_batch(
+            "CREATE TABLE sessions (
+               session_id TEXT PRIMARY KEY,
+               journal_id TEXT NOT NULL,
+               status TEXT NOT NULL,
+               through_sequence INTEGER NOT NULL,
+               configuration_json TEXT NOT NULL,
+               context_json TEXT NOT NULL,
+               presentation_digest TEXT NOT NULL,
+               metadata_json TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+    drop(connection);
+
+    let (publisher, _worker) = telemetry_channel();
+    let kernel = Kernel::open(
+        KernelConfig {
+            data_dir: data_dir.clone(),
+            max_decisions_per_turn: 8,
+            loop_executor: Arc::new(ScriptedLoop {
+                calls: AtomicUsize::new(0),
+            }),
+            model_executor: Arc::new(ScriptedModel),
+            tool_executor: Arc::new(NoTools),
+        },
+        publisher,
+    )
+    .unwrap();
+    kernel.create_session(request()).await.unwrap();
+    drop(kernel);
+
+    let connection = rusqlite::Connection::open(database).unwrap();
+    let metadata_columns = connection
+        .prepare("PRAGMA table_info(sessions)")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert!(
+        !metadata_columns
+            .iter()
+            .any(|column| column == "metadata_json")
+    );
+    drop(connection);
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    fs::remove_dir_all(data_dir).unwrap();
+}
+
+#[tokio::test]
 async fn cancel_interrupts_an_inflight_model_request() {
     let data_dir = temporary_directory();
     let (publisher, _worker) = telemetry_channel();

--- a/package-lock.json
+++ b/package-lock.json
@@ -619,7 +619,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^24.3.0",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "Apache-2.0",
   "repository": {

--- a/tests/release/http.mjs
+++ b/tests/release/http.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+import { pi } from "@aexhq/loop-pi";
+
+const baseUrl = process.env.BRAIN_BASE_URL;
+const token = process.env.BRAIN_API_TOKEN;
+assert.ok(baseUrl);
+assert.ok(token);
+
+let operation = 0;
+const request = async (method, path, body, contentType = "application/json") => {
+  operation += 1;
+  const headers = {
+    accept: "application/json",
+    authorization: `Bearer ${token}`,
+    "idempotency-key": `release-http-${operation}`,
+  };
+  if (body !== undefined) headers["content-type"] = contentType;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body === undefined
+      ? undefined
+      : contentType === "application/json"
+        ? JSON.stringify(body)
+        : body,
+  });
+  const result = response.status === 204 ? undefined : await response.json();
+  assert.ok(response.ok, `${method} ${path} returned ${response.status}: ${JSON.stringify(result)}`);
+  return result;
+};
+
+const admission = await request(
+  "POST",
+  "/v1/agentloops",
+  await readFile(pi().package),
+  "application/octet-stream",
+);
+assert.equal(admission.status, "admitted");
+const session = await request("POST", "/v1/sessions", {
+  agentloop_digest: admission.digest,
+  model: {
+    provider: "vercel-ai-gateway",
+    name: "openai/gpt-5-mini",
+    api_key: "release-smoke-key",
+  },
+  presentation: { system: "", tools: [] },
+  environments: [],
+  tool_bindings: [],
+});
+assert.equal(session.status, "idle");
+assert.equal((await request("GET", `/v1/sessions/${session.session_id}`)).session_id, session.session_id);
+assert.ok((await request("GET", "/v1/sessions")).sessions.some(({ session_id }) => session_id === session.session_id));
+assert.equal((await request("POST", `/v1/sessions/${session.session_id}/end`)).status, "ended");
+await request("DELETE", `/v1/sessions/${session.session_id}`);
+assert.deepEqual((await request("GET", "/v1/sessions")).sessions, []);

--- a/tests/release/sdk.mjs
+++ b/tests/release/sdk.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+
+import { Brain } from "@aexhq/brain";
+import { pi } from "@aexhq/loop-pi";
+
+const baseUrl = process.env.BRAIN_BASE_URL;
+const token = process.env.BRAIN_API_TOKEN;
+assert.ok(baseUrl);
+assert.ok(token);
+
+const brain = new Brain({ baseUrl, token });
+const session = await brain.createSession({
+  model: {
+    provider: "vercel-ai-gateway",
+    name: "openai/gpt-5-mini",
+    apiKey: "release-smoke-key",
+  },
+  agentLoop: pi(),
+});
+assert.equal(session.state.status, "idle");
+assert.equal((await brain.getSession(session.id)).id, session.id);
+assert.ok((await brain.listSessions()).some((candidate) => candidate.id === session.id));
+assert.equal((await session.end()).status, "ended");
+await session.delete();
+assert.deepEqual(await brain.listSessions(), []);


### PR DESCRIPTION
## Summary
- migrate deployed journals away from the retired session metadata column
- stage the immutable image and npm archive as one Brain candidate
- gate promotion on parallel published-SDK and raw-HTTP image E2Es
- promote only the tested npm object and image manifest

## Local verification
- workflow lint
- Brain Rust tests and regression test
- Clippy with warnings denied
- SDK tests, package smoke, and npm audit