### PR TITLE
chore: relicense to MIT and clear stale build and benchmark claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:18080/v1/sessions)" = 401
           curl --fail --silent -H 'authorization: Bearer test-token' http://127.0.0.1:18080/v1/sessions | jq -e '.sessions == []'
 
-  resource-bounds:
+  benchmark-leakage:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -146,9 +146,9 @@ jobs:
           BRAIN_DATA_DIR="$data_dir" \
           BRAIN_API_TOKEN=test-token \
           BRAIN_LOOP_WORKER=target/release/brain-loop-worker \
-            target/release/brain >"$RUNNER_TEMP/brain-resource-bounds.log" 2>&1 &
+            target/release/brain >"$RUNNER_TEMP/brain-benchmark.log" 2>&1 &
           brain_pid=$!
-          trap 'kill "$brain_pid" 2>/dev/null || true; wait "$brain_pid" 2>/dev/null || true; cat "$RUNNER_TEMP/brain-resource-bounds.log"' EXIT
+          trap 'kill "$brain_pid" 2>/dev/null || true; wait "$brain_pid" 2>/dev/null || true; cat "$RUNNER_TEMP/brain-benchmark.log"' EXIT
           for attempt in $(seq 1 60); do
             if curl --fail --silent http://127.0.0.1:18081/health/ready >/dev/null; then break; fi
             test "$attempt" -lt 60
@@ -168,7 +168,7 @@ jobs:
 
   build-test:
     if: always()
-    needs: [contracts, lint, rust-core, rust-platforms, loophost, image-smoke, resource-bounds]
+    needs: [contracts, lint, rust-core, rust-platforms, loophost, image-smoke, benchmark-leakage]
     runs-on: ubuntu-24.04
     steps:
       - name: Every release gate passed
@@ -179,7 +179,7 @@ jobs:
           PLATFORMS: ${{ needs.rust-platforms.result }}
           LOOPHOST: ${{ needs.loophost.result }}
           IMAGE: ${{ needs.image-smoke.result }}
-          RESOURCE_BOUNDS: ${{ needs.resource-bounds.result }}
+          RESOURCE_BOUNDS: ${{ needs.benchmark-leakage.result }}
         run: |
           test "$CONTRACTS" = success
           test "$LINT" = success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:18080/v1/sessions)" = 401
           curl --fail --silent -H 'authorization: Bearer test-token' http://127.0.0.1:18080/v1/sessions | jq -e '.sessions == []'
 
-  benchmark-leakage:
+  resource-bounds:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -146,9 +146,9 @@ jobs:
           BRAIN_DATA_DIR="$data_dir" \
           BRAIN_API_TOKEN=test-token \
           BRAIN_LOOP_WORKER=target/release/brain-loop-worker \
-            target/release/brain >"$RUNNER_TEMP/brain-benchmark.log" 2>&1 &
+            target/release/brain >"$RUNNER_TEMP/brain-resource-bounds.log" 2>&1 &
           brain_pid=$!
-          trap 'kill "$brain_pid" 2>/dev/null || true; wait "$brain_pid" 2>/dev/null || true; cat "$RUNNER_TEMP/brain-benchmark.log"' EXIT
+          trap 'kill "$brain_pid" 2>/dev/null || true; wait "$brain_pid" 2>/dev/null || true; cat "$RUNNER_TEMP/brain-resource-bounds.log"' EXIT
           for attempt in $(seq 1 60); do
             if curl --fail --silent http://127.0.0.1:18081/health/ready >/dev/null; then break; fi
             test "$attempt" -lt 60
@@ -168,7 +168,7 @@ jobs:
 
   build-test:
     if: always()
-    needs: [contracts, lint, rust-core, rust-platforms, loophost, image-smoke, benchmark-leakage]
+    needs: [contracts, lint, rust-core, rust-platforms, loophost, image-smoke, resource-bounds]
     runs-on: ubuntu-24.04
     steps:
       - name: Every release gate passed
@@ -179,7 +179,7 @@ jobs:
           PLATFORMS: ${{ needs.rust-platforms.result }}
           LOOPHOST: ${{ needs.loophost.result }}
           IMAGE: ${{ needs.image-smoke.result }}
-          BENCHMARK: ${{ needs.benchmark-leakage.result }}
+          RESOURCE_BOUNDS: ${{ needs.resource-bounds.result }}
         run: |
           test "$CONTRACTS" = success
           test "$LINT" = success
@@ -187,4 +187,4 @@ jobs:
           test "$PLATFORMS" = success
           test "$LOOPHOST" = success
           test "$IMAGE" = success
-          test "$BENCHMARK" = success
+          test "$RESOURCE_BOUNDS" = success

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -155,6 +155,10 @@ jobs:
           verify_index "$release" "$amd" "$arm"
           digest=$(digest_of "$release")
 
+          # Moving tag for humans. The immutable sha- tag above stays the deploy identity.
+          docker buildx imagetools create -t "$IMAGE:latest" "$IMAGE@$digest"
+          test "$(digest_of "$IMAGE:latest")" = "$digest"
+
           package_api="/orgs/$PACKAGE_OWNER/packages/container/brain"
           visibility=$(gh api "$package_api" --jq .visibility 2>/dev/null || true)
           if [ "$visibility" != public ]; then
@@ -184,6 +188,8 @@ jobs:
             echo '### Brain image'
             echo
             echo "Immutable source tag: \`$release\`"
+            echo
+            echo "Moving tag: \`$IMAGE:latest\`"
             echo
             echo "Resolved deploy identity: \`$IMAGE@$digest\`"
             echo

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/dist
 .env
 .env.*
+/.worktrees

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,11 +1,33 @@
 # Benchmarks
 
-Brain's benchmark suite measures the engine, not a model. It drives the public HTTP and SSE paths
-with an instant scripted provider, an in-process echo Environment, and an in-memory journal. Reference
-measurements below were recorded on 18 August 2026 using a release build on a c7g.xlarge
-(4-vCPU Graviton3, Ubuntu, glibc).
+> [!NOTE]
+> The benchmark harness is being rebuilt against the current kernel. The figures in the archive
+> below were measured before that rebuild and are **not current**. Do not quote them as present-day
+> numbers.
 
-## Reference results
+## What the benchmark measures
+
+The engine, not a model. It drives the real HTTP and SSE paths with an instant scripted provider and
+an in-process echo environment, so no model latency reaches the numbers. First-byte and turn
+measurements include HTTP, SSE, request construction, writing to the session log, and dispatch.
+
+Density and reclaim measurements need Linux `/proc/*/smaps_rollup`. Other platforms run the portable
+latency and correctness arms only. The harness refuses to substitute RSS for private memory, because
+that would double-count shared pages.
+
+## What CI enforces today
+
+Every push runs a resource bound against a live server: after 10,000 requests, resident memory must
+stay under 256 MiB and must not have grown by more than 16 MiB. See the `resource-bounds` job in
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+
+That is a leak guard, not a benchmark. Latency, throughput, and the cross-session isolation test are
+being rebuilt — see the roadmap in the [README](README.md).
+
+## Pre-rebuild archive (not current)
+
+Measured 2026-08-18 on a c7g.xlarge (4-vCPU Graviton3, Ubuntu, glibc) release build, against the
+kernel as it stood before the architecture reset. Kept for reference only.
 
 | Measurement | Result |
 | --- | ---: |
@@ -15,31 +37,13 @@ measurements below were recorded on 18 August 2026 using a release build on a c7
 | Throughput, 64 sessions | 2,002 turns/s · p99 58 ms |
 | Throughput, 256 sessions | 2,100 turns/s · p99 254 ms |
 | Tool loop, 64 sessions, 2 rounds × 4 calls | 429 turns/s · about 3,430 tool calls/s |
-| Resident session, excluding the in-process journal | 21–31 KiB private memory |
+| Resident session, excluding the in-process log | 21–31 KiB private memory |
 | Memory returned after deleting all sessions | 82–86% in one cycle |
 | Steady-state change across delete cycles | −0.6 MiB per cycle over 6 cycles |
 
-The first-byte and turn measurements include HTTP, SSE, request construction, journaling, and
-dispatch. The provider itself is instant. The resident-session figure is the private-memory delta
-between live actors and the post-discard state; production journals are off-process. An
-in-process journal at four 8-KiB turns uses roughly 450–470 KiB per session.
+The resident-session figure is the private-memory delta between live actors and the post-discard
+state; production logs are off-process. An in-process log at four 8-KiB turns used roughly
+450–470 KiB per session.
 
 The one-cycle reclaim percentage reflects allocator fragmentation. The stronger long-running
-invariant is that the post-delete floor stops rising; the measured floor plateaued. CI thresholds
-are deliberately loose regression guards for shared runners, not replacements for the reference
-record.
-
-## Reproduce
-
-```sh
-cargo run -p brain-bench --release -- ci
-cargo run -p brain-bench --release -- --help
-```
-
-Density and reclaim measurements require Linux `/proc/*/smaps_rollup`; other platforms run the
-portable latency and correctness arms only. The benchmark refuses to substitute RSS because it
-would double-count shared pages.
-
-`crates/brain/tests/leakage.rs` independently checks cross-session isolation on every push: files,
-conversation content, model identity, provider keys, events, and journals must remain scoped to
-their owning session.
+invariant is that the post-delete floor stops rising, and the measured floor plateaued.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -18,10 +18,11 @@ that would double-count shared pages.
 ## What CI enforces today
 
 Every push runs a resource bound against a live server: after 10,000 requests, resident memory must
-stay under 256 MiB and must not have grown by more than 16 MiB. See the `resource-bounds` job in
-[`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+stay under 256 MiB and must not have grown by more than 16 MiB. See the `benchmark-leakage` job
+in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
-That is a leak guard, not a benchmark. Latency, throughput, and the cross-session isolation test are
+That job is a leak guard, not a benchmark, and it no longer checks leakage between sessions either;
+the name is older than what it does. Latency, throughput, and the cross-session isolation test are
 being rebuilt — see the roadmap in the [README](README.md).
 
 ## Pre-rebuild archive (not current)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.97"
-license = "Apache-2.0"
+license = "MIT"
 
 [workspace.dependencies]
 # Brain owns its public session API and the Brain↔Environment wire protocol.

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 Weilue Luo
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2026 aex contributors
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied. See the License for the specific language governing
-   permissions and limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -149,4 +149,4 @@ The schemas, OpenAPI document, protocol semantics, examples, generators, and con
 in this repository are the source of truth. See [BENCHMARKS.md](BENCHMARKS.md) for the methodology
 and reference measurements.
 
-Licensed under [Apache 2.0](LICENSE).
+Licensed under [MIT](LICENSE).

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,14 +7,11 @@ services:
     image: ${BRAIN_SERVER_IMAGE:-brain:local}
     restart: unless-stopped
     environment:
-      # Explicit durable local mode: SQLite WAL journal, persistent local custody and session
-      # object storage under BRAIN_DATA_DIR, Tool execution on this container's node runtime.
-      # Requested network policy is retained but reported not_enforced.
-      BRAIN_MODE: local
-      BRAIN_LISTEN: 0.0.0.0:3210
+      # SQLite log and local session storage under BRAIN_DATA_DIR.
+      BRAIN_LISTEN: 0.0.0.0:8080
       BRAIN_DATA_DIR: /var/lib/brain
     ports:
-      - 127.0.0.1:3210:3210
+      - 127.0.0.1:8080:8080
     volumes:
       - type: bind
         source: ${BRAIN_DATA_DIR:?set BRAIN_DATA_DIR to an absolute host path}

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@aexhq/brain",
   "version": "0.7.2",
   "description": "TypeScript SDK for an independently runnable Brain server",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aexhq/brain.git",


### PR DESCRIPTION
Relicenses the workspace and the TypeScript SDK from Apache 2.0 to MIT (`Copyright (c) 2026 Weilue Luo`). Sole contributor across the full history, so no third-party consent is involved.

Then clears four things that no longer match the tree:

| Stale | Fix |
| --- | --- |
| `BENCHMARKS.md` tells readers to run `cargo run -p brain-bench`, which has not been a workspace member since the architecture reset, and claims an isolation test at `crates/brain/tests/leakage.rs` that no longer exists | Rewritten around what CI actually enforces today; the 2026-08-18 figures move into a marked pre-rebuild archive |
| CI job `benchmark-leakage` does neither benchmarking nor leakage checking | Renamed `resource-bounds` — it bounds RSS after 10,000 requests |
| `compose.yaml` sets `BRAIN_MODE` (nothing reads it) and binds 3210 while the Dockerfile exposes 8080 | Dead var removed, port aligned to 8080 |
| The image workflow publishes only immutable `sha-` tags, so nothing can point a reader at a runnable image | Publishes a moving `:latest` from the same index digest |

Also removes five orphaned `packages/*` directories left over from before the extensions moved to `aexhq/extensions` (all `dist/`-only, already gitignored), and ignores `/.worktrees`.

Rebuilding the benchmark harness and restoring the cross-session isolation test are tracked as follow-ups.