### PR TITLE
docs: write the documentation next to the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,4 +14,7 @@
 - Real Linux Loophost, image, HTTP, SQLite recovery, remote-model, and remote-Environment gates run
   in CI. Hosted directory, placement, and cloud infrastructure gates belong downstream.
 - Fail fast, keep comments self-contained, and use plain English.
+- Documentation lives in `docs/` and ships to aex.dev/brain/docs. Change behaviour and its page in
+  the same pull request. The API reference is generated from `contracts/session/v1/openapi.yaml`;
+  never write it by hand. Setup and verification commands live in `CONTRIBUTING.md`.
 - Commit style: `area: imperative summary`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Brain is under early development. Contracts are replaced in place until the first stable release,
+so a change that would be a breaking change later is usually just a change today.
+
+## Setup
+
+You need Rust 1.97 and Node 22 or newer.
+
+```sh
+cargo build --workspace
+npm ci
+```
+
+## Verification
+
+Everything CI runs, in the order it will fail:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+npm ci
+npm test
+npm run package-smoke
+```
+
+CI additionally runs the loop worker integration tests, an image smoke test, and a resident-memory
+bound against a live server. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+
+## Contracts are the source of truth
+
+The schemas, OpenAPI document, protocol semantics, examples, generators, and conformance fixtures
+under [`contracts/`](contracts) define the wire. Generated views are generated, never hand-edited —
+CI regenerates them and fails on a diff.
+
+Change a schema and its generated views in the same commit:
+
+```sh
+npm run gen
+```
+
+## Documentation
+
+Pages live in [`docs/`](docs) and are rendered at
+[aex.dev/brain/docs](https://aex.dev/brain/docs). Change behaviour and its page in the same pull
+request.
+
+The API reference is not written by hand. It is generated from
+[`contracts/session/v1/openapi.yaml`](contracts/session/v1/openapi.yaml) at site build time, so it
+cannot drift from the contract.
+
+Code in the documentation comes from real files in [`examples/`](examples), which `npm test` checks.
+Do not paste a snippet into a page — reference the example.
+
+## Conventions
+
+- Commit messages are `area: imperative summary`.
+- Fail fast. Keep comments self-contained. Write plain English.
+- Journal every decision before its external effect, and record terminal results before the next
+  agent loop activation.
+- Keep the `brain` crate free of cloud SDKs. Storage, custody, and runtime behaviour go behind
+  public adapters.
+- Do not weaken a production invariant to make local development easier.
+
+[`AGENTS.md`](AGENTS.md) has the full working rules for this repository.

--- a/docs/concepts/agent-loop.mdx
+++ b/docs/concepts/agent-loop.mdx
@@ -1,0 +1,41 @@
+---
+title: Agent loop
+description: The policy that decides what happens next, and what it is not allowed to do.
+---
+
+The agent loop is the policy. Brain hands it what just happened; it returns what to do next.
+
+```ts
+import { defineAgentloop } from "@aexhq/agentloop";
+
+export default defineAgentloop({
+  step(input) {
+    return { context: input.context, decision: { type: "finish" } };
+  },
+});
+```
+
+That is the whole interface. A decision is call the model, call a tool, or finish.
+
+## It cannot reach out
+
+The loop runs as a WebAssembly component with no host imports. No sockets, no filesystem, no
+environment variables, no secrets, no clock, no way to hold a resource between activations. Every
+effect it wants, it asks Brain for, and Brain performs.
+
+Two things follow. A loop from a stranger is safe to run. And any loop can be replayed against a
+recorded log and produce the same decisions, because there is no hidden input.
+
+## No privileged loop
+
+`@aexhq/loop-pi` and `@aexhq/loop-codex` are admitted the same way yours is. There is no built-in
+loop with a shortcut into the kernel — if the shipped ones can do it, so can yours.
+
+## Building one
+
+```sh
+brain-loop build loop.mjs --out loop.brain.json
+```
+
+The toolchain handles WIT, WebAssembly, and the ABI. You write a function. See
+[Write an agent loop](/brain/docs/guides/write-a-loop).

--- a/docs/concepts/environment.mdx
+++ b/docs/concepts/environment.mdx
@@ -1,0 +1,33 @@
+---
+title: Environment
+description: Where tool calls run, and the lifecycle Brain drives.
+---
+
+An environment is somewhere tool calls actually execute. Brain drives its lifecycle over the
+`environment/v1` HTTP contract:
+
+`setup` · `attach` · `call` · `execute` · `cancel` · `detach` · `teardown`
+
+The adapter implements them. Brain decides when they happen.
+
+## Addressed by name, not by connection
+
+An environment has a stable identity, and that identity is what resolves to a workspace — not
+whichever process happens to hold a socket. Two sessions on two servers can therefore share one
+environment on purpose, and a Brain instance restarting does not orphan or duplicate it.
+
+Connections are caches. They never decide identity, and they never decide teardown.
+
+## Replay is explicit
+
+Every operation carries a stable identifier and a digest of its request. When a redelivery arrives,
+the adapter can tell "this is the same call again" from "this is a new call that looks similar", and
+Brain never replays an ambiguous effect against a replacement target.
+
+## The official adapters
+
+`@aexhq/env-app` is a language-neutral HTTP environment — bring your own runtime.
+`@aexhq/env-aws-microvm` runs tools in an AWS MicroVM.
+
+Both use the public contract, so a third-party adapter is not a second-class one. See
+[Write an environment](/brain/docs/guides/write-an-environment).

--- a/docs/concepts/meta.json
+++ b/docs/concepts/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Concepts",
+  "pages": ["sessions", "agent-loop", "model", "tool", "environment"]
+}

--- a/docs/concepts/model.mdx
+++ b/docs/concepts/model.mdx
@@ -1,0 +1,30 @@
+---
+title: Model
+description: Bindings, wire formats, and why the model is pinned.
+---
+
+A model binding is a provider, a model name, and a key:
+
+```ts
+model: {
+  provider: "vercel-ai-gateway",
+  name: "openai/gpt-5-mini",
+  apiKey: process.env.VERCEL_AI_GATEWAY_API_KEY!,
+}
+```
+
+Brain speaks the Anthropic and OpenAI wire formats natively, and talks to gateways that present
+either. `BRAIN_MODEL_BASE_URL` sets the endpoint; it defaults to the Vercel AI Gateway.
+
+## Pinned for the session
+
+The binding is fixed when the session is created and cannot change while it is alive. A turn cannot
+silently land on a different model than the one before it, and a replayed log means what it said
+when it was written.
+
+Change models by starting a new session.
+
+## Keys
+
+Keys are yours. Brain holds the binding for the session's lifetime and uses it to make calls; it
+never writes the key into the log or into an event.

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -1,0 +1,46 @@
+---
+title: Sessions
+description: The log, turns, recovery, and reading events.
+---
+
+A session is a conversation plus everything Brain did on its behalf, recorded as an ordered log.
+
+## Writes land before effects
+
+Before Brain calls a model, activates the agent loop, or dispatches a tool call, it writes the
+intent to the log. Before the loop sees a result, that result is written too.
+
+This is what makes a crash survivable. Restart the process and Brain replays the log to work out
+what had already happened, what was in flight, and what to do about it. Nothing is inferred from
+memory that outlived nothing.
+
+## Turns
+
+A turn starts when you send a message and ends when the agent loop decides it is finished. In
+between, Brain and the loop alternate: the loop returns a decision, Brain performs it, the loop sees
+the result and decides again.
+
+`BRAIN_MAX_DECISIONS` bounds how many decisions one turn may take. The default is 128.
+
+## Reading events
+
+Events are the log, exposed. Read from a cursor and you get everything committed since:
+
+```ts
+let cursor = 0;
+for await (const event of session.events(cursor)) {
+  await handle(event);
+  cursor = event.sequence;
+  await saveCursor(cursor);
+}
+```
+
+This reads the durable log, so it is replayable and gap-free. The live stream on top of it is
+bounded and best-effort: under sustained pressure it drops rather than blocking a turn or growing
+without limit. If you need at-least-once delivery into your own systems, own the cursor and do the
+forwarding yourself — Brain is not a queue.
+
+## Lifecycle
+
+`cancel` stops work in flight. `end` closes the session to new messages. `delete` removes it and its
+log. They are separate on purpose: ending a session keeps its history readable.

--- a/docs/concepts/tool.mdx
+++ b/docs/concepts/tool.mdx
@@ -1,0 +1,35 @@
+---
+title: Tool
+description: What the model sees, and where the call actually goes.
+---
+
+A tool is two separate things that happen to share a name.
+
+**What the model sees** is presentation: a name, a description, and an input schema. This is the
+part that shapes behaviour, and it is stable for the life of the session.
+
+**Where the call goes** is a binding: one remote tool in one environment.
+
+```ts
+tools: [
+  read().runIn(workspace),
+  write().runIn(workspace),
+  bash().runIn(workspace),
+]
+```
+
+## Brain does not run tool code
+
+It logs the call and sends it to the bound environment. The environment owns the implementation, the
+resources, and the blast radius. A tool that hangs, crashes, or is hostile damages its own
+environment, not the process holding your sessions.
+
+That is also why a tool can be anything with an address: a sandbox VM, a browser tab, a service you
+already run, or a process on the user's own laptop.
+
+## Splitting presentation from execution
+
+Because the two halves are independent, the same `read` the model sees can be bound to a MicroVM in
+production and to a local directory in a test, with no change to what the model was told.
+
+Leave `tools` out and the model sees none.

--- a/docs/guides/embed.mdx
+++ b/docs/guides/embed.mdx
@@ -1,0 +1,44 @@
+---
+title: Embed the kernel
+description: Run sessions inside a Rust service you already own.
+---
+
+Use the server when you want a process to talk to. Use the crate when another Rust service already
+owns startup, configuration, and deployment, and you want sessions inside it.
+
+```rust
+let kernel = brain::Kernel::open(
+    brain::KernelConfig {
+        data_dir,
+        max_decisions_per_turn: 128,
+        loop_executor,
+        model_executor,
+        tool_executor,
+    },
+    telemetry,
+)?;
+
+let session = kernel.create_session(sealed_session_config).await?;
+session
+    .message(brain_protocol::MessageRequest {
+        content: serde_json::json!("Explain the current changes."),
+    })
+    .await?;
+```
+
+## You supply the ports
+
+`loop_executor`, `model_executor`, and `tool_executor` are the same seams the server fills in. Fill
+them differently and you get a different deployment without forking the kernel: your own storage,
+your own transport, your own placement.
+
+## What the kernel keeps
+
+Writes still land before effects, and recovery still works the same way. The kernel does not become
+more permissive because it is embedded.
+
+## What stays yours
+
+When a session is admitted, when it is resident, when it is recovered, when it is evicted. Where
+environments live and how they are found. Everything about product policy. The kernel has opinions
+about correctness, not about your architecture.

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Guides",
+  "pages": ["write-a-loop", "write-an-environment", "embed"]
+}

--- a/docs/guides/write-a-loop.mdx
+++ b/docs/guides/write-a-loop.mdx
@@ -1,0 +1,63 @@
+---
+title: Write an agent loop
+description: A function in, a portable component out.
+---
+
+## Install
+
+```sh
+npm install @aexhq/agentloop
+```
+
+## Write the function
+
+`step` receives what just happened and returns what to do next. It is ordinary synchronous code.
+
+```ts
+import { defineAgentloop } from "@aexhq/agentloop";
+
+export default defineAgentloop({
+  step(input) {
+    const last = input.observation;
+
+    if (last?.type === "message") {
+      return {
+        context: [...input.context, last],
+        decision: { type: "model" },
+      };
+    }
+
+    return { context: input.context, decision: { type: "finish" } };
+  },
+});
+```
+
+You return the next context along with the decision, so context management — what to keep, what to
+drop, when to compact — is yours to control rather than something the kernel does behind you.
+
+## Build it
+
+```sh
+brain-loop build loop.mjs --out loop.brain.json
+```
+
+The toolchain generates the WIT boundary and compiles to a WebAssembly component. You do not pick a
+Wasm runtime, write host imports, or hand-maintain an ABI.
+
+## Use it
+
+```ts
+const session = await brain.createSession({
+  model: { /* ... */ },
+  agentLoop: myLoop(),
+});
+```
+
+## What you cannot do
+
+No network, no filesystem, no environment variables, no secrets, no clock, no resource held between
+activations. If you need one of those, it is a tool call or a model call — return it as a decision
+and Brain performs it.
+
+This is a constraint worth keeping. It is what lets someone else run your loop without reading it
+first, and what makes a recorded session replay identically.

--- a/docs/guides/write-an-environment.mdx
+++ b/docs/guides/write-an-environment.mdx
@@ -1,0 +1,53 @@
+---
+title: Write an environment
+description: Implement seven operations over HTTP and tools can run anywhere.
+---
+
+An environment adapter answers the `environment/v1` contract. Any language that can serve HTTP will
+do.
+
+## The operations
+
+| Operation | When Brain calls it |
+| --- | --- |
+| `setup` | The environment needs to exist |
+| `attach` | A session begins using it |
+| `call` | A tool call needs a result |
+| `execute` | Longer work that is not a single call/response |
+| `cancel` | Work in flight should stop |
+| `detach` | A session is done with it |
+| `teardown` | The environment should stop existing |
+
+`setup` and `teardown` are about the environment's existence. `attach` and `detach` are about one
+session's use of it — which is how several sessions share one workspace.
+
+## Handling redelivery
+
+Every operation carries a stable operation identifier and a digest of its request. Store the
+identifier with the result. When the same identifier arrives again, return the stored result instead
+of doing the work twice. When the identifier is new but the work looks similar, do it — that is a
+different call.
+
+Brain never replays an ambiguous effect against a replacement target, so you do not have to guess
+whether a retry is safe.
+
+## Binding tools to it
+
+```ts
+const workspace = myEnvironment({ id: "workspace-main" });
+
+const session = await brain.createSession({
+  model: { /* ... */ },
+  agentLoop: pi(),
+  tools: [read().runIn(workspace), bash().runIn(workspace)],
+});
+```
+
+The identifier is the address. Use the same one from another process and you get the same
+environment, deliberately.
+
+## Start from an official one
+
+`@aexhq/env-app` is the thin language-neutral case: it hands tool calls to an HTTP runtime you
+write. `@aexhq/env-aws-microvm` is the full case, with real machine lifecycle. Both use the same
+public contract as yours.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,43 @@
+---
+title: Introduction
+description: What Brain is, and the four things that plug into it.
+---
+
+Brain runs agent sessions. It holds the conversation, decides what happens next, calls the model,
+hands out tool calls, and writes all of it to a durable log. That is the entire job.
+
+Run it as a server your app talks to over HTTP, or embed the `brain` crate in a Rust service you
+already own.
+
+<Callout type="warn">
+Brain is under early development. Contracts are replaced in place until the first stable release,
+and there is no upgrade path from earlier builds.
+</Callout>
+
+## The four parts
+
+Everything Brain does not do itself is one of four things you supply.
+
+| Part | You supply | Brain does |
+| --- | --- | --- |
+| [Agent loop](/brain/docs/concepts/agent-loop) | The policy: given what just happened, what next | Runs it in a WebAssembly sandbox and carries out the decision |
+| [Model](/brain/docs/concepts/model) | A binding: provider, model name, key | Pins it for the life of the session and makes the call |
+| [Tool](/brain/docs/concepts/tool) | A name, description, schema, and where it runs | Logs the call and sends it to the bound environment |
+| [Environment](/brain/docs/concepts/environment) | Somewhere tool calls actually execute | Sets it up, attaches, calls, cancels, tears it down |
+
+The packages we ship use the same interface you would. Nothing built in gets a shortcut.
+
+## Why it is split this way
+
+Brain never runs tool code. That is the load-bearing decision. A tool call is a message to somewhere
+else — a sandbox VM, a browser tab, your backend, the user's laptop — so a crashing or hostile tool
+takes down its own environment, not the process holding your sessions.
+
+The agent loop is sealed off for the same reason. It receives an observation and returns a decision.
+No network, no filesystem, no secrets, no clock. Brain performs every effect the loop asks for.
+
+## Where to go next
+
+- [Quickstart](/brain/docs/quickstart) — a running server and a first session.
+- [Sessions](/brain/docs/concepts/sessions) — the log, turns, and how recovery works.
+- [API reference](/brain/docs/reference/api) — generated from the session contract.

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Brain",
+  "pages": ["index", "quickstart", "concepts", "guides", "reference"]
+}

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,63 @@
+---
+title: Quickstart
+description: Run a Brain server and drive one session from TypeScript.
+---
+
+## Run a server
+
+```sh
+docker run --rm -p 8080:8080 -v brain-data:/var/lib/brain ghcr.io/aexhq/brain:latest
+```
+
+Or build it:
+
+```sh
+cargo build --release -p brain-server --bin brain -p brain-loophost --bin brain-loop-worker
+BRAIN_DATA_DIR="$PWD/brain-data" \
+BRAIN_LOOP_WORKER="$PWD/target/release/brain-loop-worker" \
+./target/release/brain --listen 127.0.0.1:8080
+```
+
+Brain listens on loopback and needs no token there. Set `BRAIN_API_TOKEN` to listen anywhere else —
+it refuses to start on a non-loopback address without one.
+
+## Drive a session
+
+```sh
+npm install @aexhq/brain @aexhq/loop-pi
+```
+
+```ts
+import { Brain } from "@aexhq/brain";
+import { pi } from "@aexhq/loop-pi";
+
+const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });
+
+const session = await brain.createSession({
+  model: {
+    provider: "vercel-ai-gateway",
+    name: "openai/gpt-5-mini",
+    apiKey: process.env.VERCEL_AI_GATEWAY_API_KEY!,
+  },
+  agentLoop: pi(),
+  system: "Answer briefly and directly.",
+});
+
+await session.send("Explain what a session kernel does, in one sentence.");
+
+for await (const event of session.events()) {
+  console.log(event.sequence, event.type, event.data);
+}
+
+await session.end();
+await session.delete();
+```
+
+No `tools` means the model sees none. Add them once you have somewhere to run them — see
+[Tools](/brain/docs/concepts/tool) and [Environments](/brain/docs/concepts/environment).
+
+## Runnable versions
+
+The [`examples/`](https://github.com/aexhq/brain/tree/main/examples) directory in the repository has
+four working scripts: a basic session, reading event history from a cursor, the full lifecycle, and
+the same thing over raw HTTP with no SDK.

--- a/docs/reference/benchmarks.mdx
+++ b/docs/reference/benchmarks.mdx
@@ -1,0 +1,43 @@
+---
+title: Benchmarks
+description: What is measured, what CI enforces, and why there are no current numbers yet.
+---
+
+<Callout type="warn">
+The benchmark harness is being rebuilt against the current kernel. There are no current published
+figures. The archive below was measured before the rebuild and should not be quoted as present-day
+performance.
+</Callout>
+
+## What the benchmark measures
+
+The engine, not a model. It drives the real HTTP and SSE paths with an instant scripted provider and
+an in-process echo environment, so no model latency reaches the numbers. First-byte and turn figures
+include HTTP, SSE, request construction, writing to the log, and dispatch.
+
+Density and reclaim measurements need Linux `/proc/*/smaps_rollup`. Other platforms run the portable
+latency and correctness arms only. The harness refuses to substitute RSS for private memory, because
+that would double-count shared pages.
+
+## What CI enforces today
+
+Every push bounds resident memory against a live server: after 10,000 requests it must stay under
+256 MiB and must not have grown by more than 16 MiB.
+
+That is a leak guard, not a benchmark. Latency, throughput, and the cross-session isolation test are
+being rebuilt.
+
+## Archive (not current)
+
+Measured 2026-08-18 on a c7g.xlarge, against the kernel as it stood before the architecture reset.
+
+| Measurement | Result |
+| --- | ---: |
+| First visible byte, one session | p50 1.4 ms · p99 2.2 ms |
+| Complete text turn, one session | p50 2.3 ms · p99 3.2 ms |
+| Throughput, 64 sessions | 2,002 turns/s · p99 58 ms |
+| Tool loop, 64 sessions | about 3,430 tool calls/s |
+| Resident session | 21–31 KiB private memory |
+
+The current record always lives in
+[BENCHMARKS.md](https://github.com/aexhq/brain/blob/main/BENCHMARKS.md).

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -1,0 +1,38 @@
+---
+title: Configuration
+description: Every environment variable and flag the server reads.
+---
+
+Each option is a flag and an environment variable. Flags win.
+
+| Variable | Flag | Default | What it does |
+| --- | --- | --- | --- |
+| `BRAIN_LISTEN` | `--listen` | `127.0.0.1:8080` | Address to bind |
+| `BRAIN_DATA_DIR` | `--data-dir` | `brain-data` | Where the session log and local state live |
+| `BRAIN_LOOP_WORKER` | `--loop-worker` | `brain-loop-worker` | Path to the loop worker executable |
+| `BRAIN_API_TOKEN` | `--api-token` | none | Bearer token callers must present |
+| `BRAIN_MODEL_BASE_URL` | `--model-base-url` | `https://ai-gateway.vercel.sh/v1` | Model endpoint |
+| `BRAIN_ENVIRONMENT_BASE_URL` | `--environment-base-url` | empty | Default environment adapter endpoint |
+| `BRAIN_ENVIRONMENT_API_KEY` | `--environment-api-key` | none | Credential for that adapter |
+| `BRAIN_MAX_DECISIONS` | `--max-decisions` | `128` | Decision ceiling for one turn |
+
+## Listening beyond loopback
+
+Brain refuses to start on a non-loopback address without `BRAIN_API_TOKEN`. Binding `0.0.0.0` with
+no token is a mistake worth failing on rather than serving.
+
+## Docker
+
+The image sets `BRAIN_DATA_DIR=/var/lib/brain`, `BRAIN_LOOP_WORKER=/usr/local/bin/brain-loop-worker`,
+and `BRAIN_LISTEN=0.0.0.0:8080`, declares `/var/lib/brain` as a volume, and runs as uid 10001.
+
+```sh
+docker run --rm -p 8080:8080 -v brain-data:/var/lib/brain ghcr.io/aexhq/brain:latest
+```
+
+Immutable tags are `ghcr.io/aexhq/brain:sha-<commit>`. Pin those for deployments; `latest` is for
+people.
+
+## Health
+
+`GET /health/ready` answers when the server is serving.

--- a/docs/reference/meta.json
+++ b/docs/reference/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Reference",
+  "pages": ["api", "configuration", "benchmarks"]
+}


### PR DESCRIPTION
Twelve pages under `docs/`, rendered at aex.dev/brain/docs:

```
index                    what Brain is, the four parts
quickstart               run a server, drive one session
concepts/sessions        the log, turns, recovery, reading events
concepts/agent-loop      the policy, and what it cannot reach
concepts/model           bindings, wire formats, why it is pinned
concepts/tool            what the model sees vs where the call goes
concepts/environment     the seven operations, identity, replay
guides/write-a-loop      a function in, a portable component out
guides/write-an-environment
guides/embed             brain::Kernel in your own Rust service
reference/configuration  every env var and flag the server reads
reference/benchmarks     what is measured, what CI enforces
```

They live in this repository, not the site repository, so a change to behaviour and a change to the page describing it land in one pull request.

**There is no API reference page.** It is generated from `contracts/session/v1/openapi.yaml` at site build time, so it cannot drift from the contract.

Also adds `CONTRIBUTING.md`, which takes the setup and verification commands out of the README, and points `AGENTS.md` at both.