### PR TITLE
Pin the Brain compiler stack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,10 +2012,11 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",
+        "@bytecodealliance/jco": "1.15.1",
         "esbuild": "0.25.9",
         "typescript": "5.9.2",
         "zod": "4.4.3"
@@ -2031,6 +2032,24 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "packages/brain-sdk/node_modules/@bytecodealliance/jco": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.15.1.tgz",
+      "integrity": "sha512-xyn/mvCjMCHX5dr2m7Ijx7HK/EaPbFvAU/BQ9F6HaZ6W2N/ajx5/eP+UgkQpiN58tjKGLSKbyoOjRxpCJOYfWg==",
+      "license": "(Apache-2.0 WITH LLVM-exception)",
+      "dependencies": {
+        "@bytecodealliance/componentize-js": "^0.19.1",
+        "@bytecodealliance/preview2-shim": "^0.17.3",
+        "binaryen": "^123.0.0",
+        "commander": "^14",
+        "mkdirp": "^3",
+        "ora": "^8",
+        "terser": "^5"
+      },
+      "bin": {
+        "jco": "src/jco.js"
       }
     }
   }

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@bytecodealliance/componentize-js": "0.19.3",
+    "@bytecodealliance/jco": "1.15.1",
     "esbuild": "0.25.9",
     "typescript": "5.9.2",
     "zod": "4.4.3"

--- a/tools/package-smoke.mjs
+++ b/tools/package-smoke.mjs
@@ -44,6 +44,7 @@ try {
       `export const simple = brain((author) => { author.on.message((_message, turn) => turn.done()); });\n`,
   );
   run(["install", "--no-audit", "--no-fund"], directory);
+  run(["audit", "--audit-level=high"], directory);
   execFileSync(process.execPath, [join(directory, "node_modules/@aexhq/brain/dist/cli.js"), "build", "extension.mjs", "--out", "built"], { cwd: directory, stdio: "inherit" });
   writeFileSync(
     join(directory, "smoke.mjs"),


### PR DESCRIPTION
Pins jco to the compatible audited version so clean consumers cannot resolve the vulnerable recursive compiler stack. Package smoke now audits an empty consumer install.\n\nValidation: npm run gen; npm test; npm run package-smoke; npm audit --audit-level=high; git diff --check