### PR TITLE
Keep built Brain extensions on one SDK identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,11 +2012,10 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",
-        "@bytecodealliance/jco": "1.15.1",
         "esbuild": "0.25.9",
         "typescript": "5.9.2",
         "zod": "4.4.3"
@@ -2032,24 +2031,9 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "packages/brain-sdk/node_modules/@bytecodealliance/jco": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.15.1.tgz",
-      "integrity": "sha512-xyn/mvCjMCHX5dr2m7Ijx7HK/EaPbFvAU/BQ9F6HaZ6W2N/ajx5/eP+UgkQpiN58tjKGLSKbyoOjRxpCJOYfWg==",
-      "license": "(Apache-2.0 WITH LLVM-exception)",
-      "dependencies": {
-        "@bytecodealliance/componentize-js": "^0.19.1",
-        "@bytecodealliance/preview2-shim": "^0.17.3",
-        "binaryen": "^123.0.0",
-        "commander": "^14",
-        "mkdirp": "^3",
-        "ora": "^8",
-        "terser": "^5"
       },
-      "bin": {
-        "jco": "src/jco.js"
+      "peerDependencies": {
+        "@bytecodealliance/jco": "1.17.9"
       }
     }
   }

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {
@@ -49,9 +49,11 @@
   },
   "dependencies": {
     "@bytecodealliance/componentize-js": "0.19.3",
-    "@bytecodealliance/jco": "1.15.1",
     "esbuild": "0.25.9",
     "typescript": "5.9.2",
     "zod": "4.4.3"
+  },
+  "peerDependencies": {
+    "@bytecodealliance/jco": "1.17.9"
   }
 }

--- a/packages/brain-sdk/src/build.ts
+++ b/packages/brain-sdk/src/build.ts
@@ -59,6 +59,7 @@ export async function build(options: BuildOptions = {}): Promise<readonly BuiltE
     await mkdir(join(out, "runtime"), { recursive: true });
     await writeFile(join(out, "runtime", "registry.json"), `${JSON.stringify(toolRegistry, null, 2)}\n`);
   }
+  await bundle({ entryPoints: [entry], outfile: sourcePath, bundle: true, format: "esm", platform: "node", target: "node22", legalComments: "none", external: ["@aexhq/brain"] });
   const imports = built.map(({ name, artifact }) => {
     const runtimeName = environmentRuntimeNames.get(name);
     const identityArguments = artifact !== undefined

--- a/tools/package-smoke.mjs
+++ b/tools/package-smoke.mjs
@@ -52,9 +52,11 @@ try {
       `import * as brainSdk from "@aexhq/brain";\n` +
       `import { simple } from "./built/index.mjs";\n` +
       `const { Brain } = brainSdk;\n` +
+      `globalThis.fetch = async () => { throw new Error("validated Brain reached fetch"); };\n` +
       `const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });\n` +
       `assert.equal(typeof brain.sessions.create, "function");\n` +
       `assert.deepEqual(Object.keys(simple()), []);\n` +
+      `await assert.rejects(brain.sessions.create({ model: { provider: "vercel-ai-gateway", name: "openai/test", apiKey: "test" }, brain: simple() }), /validated Brain reached fetch/u);\n` +
       `assert.equal(typeof brainSdk.tool, "function");\n` +
       `assert.equal(typeof brainSdk.environment, "function");\n` +
       `assert.equal("DurableEventBridge" in brainSdk, false);\n`,


### PR DESCRIPTION
## Summary
- externalize @aexhq/brain from generated extension source bundles
- constrain the compiler stack with the exact safe jco peer
- verify fresh consumer audit and sessions.create identity in package smoke

## Verification
- npm run gen
- npm test
- npm run package-smoke
- npm audit --audit-level=high
- git diff --check
- Rust changes: none; Linux CI owns fmt/clippy/test (Windows checkout converts untouched Rust sources to CRLF)