### PR TITLE
sdk: accept serialized empty tool options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -205,7 +205,7 @@ function collectTool(setup: ToolSetup<unknown, unknown, unknown>): Pick<ToolSour
 
 export async function executeTool(factory: unknown, options: unknown, input: unknown, context: { readonly signal: AbortSignal; readonly deadlineMs: number; readonly requestId?: string; readonly workspace?: string; progress?(value: unknown): void }): Promise<unknown> {
   const source = sourceOf(factory as ExtensionFactory, "tool") as ToolSource;
-  const parsedOptions = source.contract.options === undefined ? requireNoOptions(options) : source.contract.options.parse(options);
+  const parsedOptions = source.contract.options === undefined ? requireEmptyConfiguration(options) : source.contract.options.parse(options);
   if (source.initialize !== undefined) {
     let initialized = initializedTools.get(source);
     if (initialized === undefined) {
@@ -574,7 +574,7 @@ function requireNoOptions(value: unknown): Record<string, never> {
   return Object.freeze({});
 }
 function requireEmptyConfiguration(value: unknown): Record<string, never> {
-  if (!plainObject(value) || Object.keys(value).length !== 0) throw new TypeError("this Brain extension does not accept options");
+  if (!plainObject(value) || Object.keys(value).length !== 0) throw new TypeError("this extension does not accept options");
   return Object.freeze({});
 }
 function validIdentifier(value: unknown): value is string { return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(value); }

--- a/packages/brain-sdk/test/client.test.mjs
+++ b/packages/brain-sdk/test/client.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { z } from "zod";
-import { Brain, BrainError, activateBrain, brain, createEnvironmentHandler, environment, installExtensionIdentity, tool } from "../dist/index.js";
+import { Brain, BrainError, activateBrain, brain, createEnvironmentHandler, environment, executeTool, installExtensionIdentity, tool } from "../dist/index.js";
 
 const simple = brain((author) => {
   const state = author.state(z.object({ messages: z.array(z.unknown()) }), () => ({ messages: [] }));
@@ -69,6 +69,17 @@ test("runs synchronous Brain hooks and persists validated state", () => {
   });
   assert.equal(result.decision.type, "model");
   assert.deepEqual(result.context.state.slots[0].messages, [{ role: "user", content: "hello" }]);
+});
+
+test("executes zero-configuration Tools from their serialized configuration", async () => {
+  assert.equal(await executeTool(read, {}, { path: "README.md" }, {
+    signal: AbortSignal.timeout(1_000),
+    deadlineMs: Date.now() + 1_000,
+  }), "README.md");
+  await assert.rejects(executeTool(read, { unexpected: true }, { path: "README.md" }, {
+    signal: AbortSignal.timeout(1_000),
+    deadlineMs: Date.now() + 1_000,
+  }), /does not accept options/u);
 });
 
 test("surfaces structured errors and rejects detached Environment calls", async () => {


### PR DESCRIPTION
Allows a built Tool without an options schema to execute from the empty configuration serialized by the SDK. Adds a regression test and releases @aexhq/brain 0.8.3.