### PR TITLE
sdk: normalize omitted Tool options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -205,7 +205,9 @@ function collectTool(setup: ToolSetup<unknown, unknown, unknown>): Pick<ToolSour
 
 export async function executeTool(factory: unknown, options: unknown, input: unknown, context: { readonly signal: AbortSignal; readonly deadlineMs: number; readonly requestId?: string; readonly workspace?: string; progress?(value: unknown): void }): Promise<unknown> {
   const source = sourceOf(factory as ExtensionFactory, "tool") as ToolSource;
-  const parsedOptions = source.contract.options === undefined ? requireEmptyConfiguration(options) : source.contract.options.parse(options);
+  const parsedOptions = source.contract.options === undefined
+    ? options === undefined ? Object.freeze({}) : requireEmptyConfiguration(options)
+    : source.contract.options.parse(options);
   if (source.initialize !== undefined) {
     let initialized = initializedTools.get(source);
     if (initialized === undefined) {

--- a/packages/brain-sdk/test/client.test.mjs
+++ b/packages/brain-sdk/test/client.test.mjs
@@ -72,14 +72,13 @@ test("runs synchronous Brain hooks and persists validated state", () => {
 });
 
 test("executes zero-configuration Tools from their serialized configuration", async () => {
-  assert.equal(await executeTool(read, {}, { path: "README.md" }, {
+  const context = {
     signal: AbortSignal.timeout(1_000),
     deadlineMs: Date.now() + 1_000,
-  }), "README.md");
-  await assert.rejects(executeTool(read, { unexpected: true }, { path: "README.md" }, {
-    signal: AbortSignal.timeout(1_000),
-    deadlineMs: Date.now() + 1_000,
-  }), /does not accept options/u);
+  };
+  assert.equal(await executeTool(read, {}, { path: "README.md" }, context), "README.md");
+  assert.equal(await executeTool(read, undefined, { path: "README.md" }, context), "README.md");
+  await assert.rejects(executeTool(read, { unexpected: true }, { path: "README.md" }, context), /does not accept options/u);
 });
 
 test("surfaces structured errors and rejects detached Environment calls", async () => {


### PR DESCRIPTION
Allows zero-configuration built Tools to execute from either the omitted local runtime field or the empty object serialized across the hosted boundary. Non-empty options still fail closed. Releases @aexhq/brain 0.8.4.