### PR TITLE
docs: give the README a technical profile and a reproducible number

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -27,6 +27,21 @@ of `BRAIN_MAX_DECISIONS=128` that is the difference between a megabyte of conver
 megabytes of permanently retained journal. `crates/brain/tests/journal_growth.rs` holds a turn's
 journal, and one page of its event stream, to a small constant multiple of the final context.
 
+## What the journal costs
+
+`crates/brain/tests/journal_throughput.rs` reports the cost of the journal itself, apart from HTTP,
+the model and the loop:
+
+```sh
+cargo test --release -p brain --test journal_throughput -- --ignored --nocapture
+```
+
+It reports rather than asserts, and it is ignored by default. A threshold that passes on a laptop
+says nothing about a server, so the numbers quoted in the README are from one machine and are worth
+exactly what re-running them on yours is worth. The shape is the durable part: an append is a
+serialise, a hash of those bytes and a channel send, with no syscall on the turn's path, and a
+restart pays for the log that was kept rather than for every record ever written.
+
 That job is a leak guard, not a benchmark, and it does not check leakage between sessions;
 the name is older than what it does. Latency, throughput, and the cross-session isolation test are
 being rebuilt — see **Status** in the [README](README.md).

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -29,7 +29,7 @@ journal, and one page of its event stream, to a small constant multiple of the f
 
 That job is a leak guard, not a benchmark, and it does not check leakage between sessions;
 the name is older than what it does. Latency, throughput, and the cross-session isolation test are
-being rebuilt — see the roadmap in the [README](README.md).
+being rebuilt — see **Status** in the [README](README.md).
 
 ## Pre-rebuild archive (not current)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">Brain</h1>
 
-<p align="center"><strong>The durable session kernel for AI agents.</strong></p>
+<p align="center"><strong>A tiny, blazing fast, extensible agent kernel.</strong></p>
 
 <p align="center">
   <a href="https://github.com/aexhq/brain/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/aexhq/brain/actions/workflows/ci.yml/badge.svg" /></a>
@@ -20,7 +20,8 @@
 </p>
 
 Brain runs agent sessions. It holds the conversation, decides what happens next, calls the model,
-hands out tool calls, and writes all of it to a durable log. That is the entire job.
+hands out tool calls, and appends every step to a log. That is the entire job, in about 7,300 lines
+of Rust across six crates.
 
 Four things plug into it, and all four are yours to replace: the **agent loop**, the **model**, the
 **tools**, and the **environment** tools run in. Run Brain as a server your app talks to over HTTP,
@@ -91,28 +92,63 @@ Brain owns the session. Everything it does not do itself is one of four things y
 flowchart TD
     app["Your app — @aexhq/brain over HTTP/SSE"]
     kernel["brain — session kernel"]
-    log[("session log on disk")]
+    log[("append-only segment log")]
     loop["Agent loop — Wasm, sealed off"]
     model["Model API"]
     env["Environment — sandbox, browser, your backend, a laptop"]
 
     app <--> kernel
-    kernel --> log
+    kernel -.->|"behind the turn"| log
     kernel -->|"observation to decision"| loop
     kernel -->|"pinned model call"| model
     kernel -->|"tool call"| env
 ```
 
-The packages we ship use the same interface you would — nothing built in gets a shortcut.
+## Tiny
 
-## Why Brain
+Six crates, about 7,300 lines of Rust. The session kernel is 3,400 of them and its journal is 1,337,
+of which the entire on-disk format — frames, segment rotation, torn-tail recovery, reclamation — is
+one 610-line file. There is no ORM, no query planner and no embedded database: the kernel's
+dependency on SQLite was removed outright, and `sha2` went with it.
 
-- **Sessions survive crashes.** Brain writes each step to disk before it runs. Kill the process
-  mid-turn, start it again, and the session carries on from where it stopped.
+## Blazing fast
+
+The journal is an append-only segment log written *behind* the turn. An append is a serialise, an
+xxh3 over the bytes just serialised, and a channel send — no syscall on the turn's path, and no
+fsync anywhere. Session state, the record index and idempotency all live in memory, so a running
+session never reads the disk; paging a client's history resolves locations under the lock but reads
+outside it, so replaying history never blocks an append.
+
+```sh
+cargo test --release -p brain --test journal_throughput -- --ignored --nocapture
+```
+
+```
+append 20000 x 1024 B   684168 records/s   p50 1.30 us   p99 4.60 us
+page 1000 records          9.2 ms
+restart replay              10 ms for 20001 records
+```
+
+One run on one machine — a 12th-gen i7-12700K, Windows 11, NVMe — where three consecutive runs held
+the append rate within 1.5% and p50 at 1.30 µs. The harness reports rather than asserts, because a
+threshold that passes here says nothing about your server, so run it on your own hardware. What does
+not move is the shape: an append never waits on a disk, and a restart pays for the log it kept
+rather than for every record ever written.
+
+**Durability is not Brain's job.** Nothing is fsynced, so a crash can lose the log's tail. Restart
+replays what reached the disk and rebuilds every session from it. Operation identifiers are derived
+from `(journal_id, sequence)` and so are stable across a replay, which is the seam a layer above
+Brain uses to recognise an effect it has already issued.
+
+## Extensible
+
+- **Nothing built in gets a shortcut.** The agent loops, models, tools and environments we ship use
+  the same four interfaces yours would.
 - **Brain never executes tool code.** A tool call is a message to the environment you bound it to,
   so a crashing or hostile tool takes down its own sandbox, not the process holding your sessions.
-- **The agent loop is sealed off.** It gets an observation and returns a decision. No network, no
-  filesystem, no secrets, no clock — Brain performs every effect.
+- **The agent loop is sealed off.** It gets an observation and returns a decision, inside a
+  WebAssembly sandbox. No network, no filesystem, no secrets, no clock — Brain performs every
+  effect, and that seal is what makes a decision reproducible from its position in the journal.
 - **Any language.** Agent loops compile to WebAssembly; tools and environments talk plain HTTP. One
   tool in Rust and another in Node, in the same session.
 - **Any loop, any model.** Pi, Codex-style, or your own, against Anthropic and OpenAI wire formats,
@@ -138,26 +174,30 @@ The packages we ship use the same interface you would — nothing built in gets 
 The schemas and OpenAPI document under [`contracts/`](contracts) are the source of truth, and the
 [API Reference](https://aex.dev/brain/docs/reference/api) is generated from them.
 
-## Performance
+## What CI holds
 
-The benchmark measures the engine, not a model: it drives the real HTTP and SSE paths with an
-instant scripted provider and an in-process echo environment, so no model latency reaches the
-numbers. CI enforces a resource bound on every push — after 10,000 requests, resident memory must
-stay under 256 MiB and must not have grown by more than 16 MiB.
+Every push runs these against a live server, so they are bounds rather than claims:
 
-Latency, throughput, and the cross-session isolation test are being rebuilt against the current
-kernel. Figures measured before the architecture reset are archived in
-[BENCHMARKS.md](BENCHMARKS.md) and are not current.
+| Bound | Enforced |
+| --- | --- |
+| Resident memory after 10,000 requests | under 256 MiB, and grown by no more than 16 MiB |
+| A turn's journal, over 64 decisions on a 1 MiB context | no more than 8x the final context |
+| One page of that turn's event stream | no more than 8x the final context |
+
+End-to-end latency, throughput and the cross-session isolation test are being rebuilt against the
+current kernel. Figures measured before the architecture reset are archived in
+[BENCHMARKS.md](BENCHMARKS.md) and are not current — the journal numbers above come from the harness
+in this repository and are reproducible with the command shown.
 
 ## Status
 
 **Shipped** — the four-part kernel; unified `brain`, `tool`, and `environment` authoring with
-`brain build`; a SQLite log with crash recovery and writing to disk before acting; the HTTP/SSE
-session API and the `@aexhq/brain` SDK; the remote environment contract with `env-app` and
-`env-aws-microvm`.
+`brain build`; an append-only segment log with restart recovery; content identity as a type rather
+than a digest string; the HTTP/SSE session API and the `@aexhq/brain` SDK; the remote environment
+contract with `env-app` and `env-aws-microvm`.
 
-**In progress** — splitting storage apart from sandboxing, rebuilding the benchmarks and the
-cross-session isolation test, and freezing a v1 API with tagged releases.
+**In progress** — rebuilding the end-to-end benchmarks and the cross-session isolation test, and
+freezing a v1 API with tagged releases.
 
 **Next** — an MCP client, subagents, file access and workspace sync, `web_search` and `web_fetch`,
 and crates.io publication.

--- a/README.md
+++ b/README.md
@@ -12,145 +12,34 @@
 
 <p align="center">
   <a href="https://aex.dev/brain/docs"><strong>Docs</strong></a> ·
-  <a href="https://aex.dev/brain">Website</a> ·
+  <a href="https://aex.dev/brain/docs/quickstart">Quickstart</a> ·
   <a href="https://aex.dev/brain/docs/reference/api">API Reference</a> ·
+  <a href="https://aex.dev/brain">Website</a> ·
   <a href="https://github.com/aexhq/extensions">Extensions</a> ·
   <a href="https://discord.gg/Qk2YnHMHVb">Discord</a>
 </p>
+
+Brain runs agent sessions. It holds the conversation, decides what happens next, calls the model,
+hands out tool calls, and writes all of it to a durable log. That is the entire job.
+
+Four things plug into it, and all four are yours to replace: the **agent loop**, the **model**, the
+**tools**, and the **environment** tools run in. Run Brain as a server your app talks to over HTTP,
+or embed the `brain` crate in a Rust service you already own.
 
 > [!NOTE]
 > **Brain is under early development.** Contracts are replaced in place until the first stable
 > release, and there is no upgrade path from earlier builds. APIs, package names, and wire formats
 > will change without notice.
 
-## What it is
+## Quickstart
 
-Brain runs agent sessions. It holds the conversation, decides what happens next, calls the model,
-hands out tool calls, and writes all of it to a durable log. That is the entire job.
+Run a server:
 
-Four things plug in, and all four are yours to replace: the **agent loop**, the **model**, the
-**tools**, and the **environment** tools run in. The packages we ship use the same interface you
-would — nothing built in gets a shortcut.
-
-The name comes from Anthropic's split of
-[the brain from the hands](https://www.anthropic.com/engineering/managed-agents). Brain is the
-brain: it decides. Environments are the hands — a sandbox, a browser, your backend, someone's
-laptop — where the work actually happens. The small-and-extensible shape follows
-[Pi](https://github.com/earendil-works/pi).
-
-## Features
-
-| | |
-| --- | --- |
-| **Sessions survive crashes** | Brain writes each step to disk before it runs. Kill the process mid-turn, start it again, and the session carries on from where it stopped. |
-| **Tools run wherever you want** | Brain never executes tool code. It calls whatever you bind the tool to — a sandbox VM, a browser tab, your own backend, the user's laptop. |
-| **Any language** | Agent loops compile to WebAssembly. Tools and environments talk to Brain over plain HTTP. One tool in Rust and another in Node, in the same session. |
-| **Any agent loop** | Pi, Codex-style, or your own. Brain is not an agent — it is what agents run on, and the loop we ship has no privileges yours doesn't. |
-| **Any model** | Anthropic and OpenAI wire formats, gateways, your own keys. The model is pinned when the session starts, so nothing swaps it out mid-conversation. |
-| **The loop is sealed off** | An agent loop gets an observation and returns a decision. No network, no filesystem, no secrets, no clock. Brain performs every effect. |
-| **More than one machine** | Environments are addressed by a stable name, so two sessions on two servers can share one workspace when you want them to. |
-| **Server or library** | Run the binary against a log directory, or embed the `brain` crate in your own Rust service and supply your own storage and transport. |
-| **Everything is an event log** | A session is an ordered, replayable log of what happened. Live streaming sits on top and drops events rather than stalling a turn. |
-
-## Benchmark
-
-> **{N}× faster first byte, {N}× smaller sessions, and it survives a crash.**
-> _Numbers below are placeholders pending re-measurement on the current kernel — see
-> [BENCHMARKS.md](BENCHMARKS.md) for methodology._
-
-<!-- Pre-architecture-reset reference (2026-08-18, c7g.xlarge): TTFB 1.4 ms p50, turn 2.3 ms p50,
-     2,002 turns/s at 64 sessions, ~3,430 tool calls/s, 21-31 KiB per resident session.
-     Do not publish these as current: the kernel was rebuilt after they were taken. -->
-
-| | Brain | LangGraph Server | Temporal-backed loop | Plain in-process loop |
-| --- | ---: | ---: | ---: | ---: |
-| First visible byte, one session | TBD | TBD | TBD | TBD |
-| Complete text turn, one session | TBD | TBD | TBD | TBD |
-| Throughput, 64 sessions | TBD | TBD | TBD | TBD |
-| Tool calls per second, 64 sessions | TBD | TBD | TBD | TBD |
-| Memory per live session | TBD | TBD | TBD | TBD |
-| Survives process death mid-turn | **yes** | TBD | TBD | no |
-| Tool code isolated from the kernel | **yes** | TBD | TBD | no |
-
-The benchmark measures the engine, not a model: it drives the real HTTP and SSE paths with an
-instant scripted provider and an in-process echo environment, so nothing here is model latency.
-The harness is being rebuilt against the current kernel — see [BENCHMARKS.md](BENCHMARKS.md).
-
-## Architecture
-
-Brain owns the session. Four kinds of component plug into it.
-
-| Kind | You supply | Brain does |
-| --- | --- | --- |
-| **Agent loop** | The policy: given what just happened, what next | Runs it in a WebAssembly sandbox and carries out the decision |
-| **Model** | A binding: provider, model name, key | Pins it for the life of the session and makes the call |
-| **Tool** | A name, description, schema, and where it runs | Logs the call and sends it to the bound environment |
-| **Environment** | Somewhere tool calls actually execute | Sets it up, attaches, calls, cancels, tears it down |
-
-```text
-TypeScript application
-        |
-        | @aexhq/brain over HTTP/SSE
-        v
-+---------------------------- brain process ----------------------------+
-| brain-http -> brain-server -> brain session kernel                    |
-|                         |         |                                   |
-|                         |         +-> session log on disk             |
-|                         |         +-> context in memory               |
-|                         |                                             |
-|                         +-> loop workers -> agent loops (Wasm)        |
-|                         +-> shared model clients -> model APIs        |
-|                         +-> environment lookup/cache                  |
-|                                      |                                |
-+--------------------------------------|--------------------------------+
-                                       v
-                          Environment adapter/provider
-                          setup / attach / call / execute
-                          cancel / detach / teardown
-                                       |
-                                       v
-                          Tool runtime, sandbox, browser,
-                          application, or user machine
+```sh
+docker run --rm -p 8080:8080 -v brain-data:/var/lib/brain ghcr.io/aexhq/brain:latest
 ```
 
-| Crate / package | What it does |
-| --- | --- |
-| `brain-protocol` | The session, loop, model, tool, environment, event, and error contracts |
-| `brain-telemetry` | Logs, traces, metrics, and the live event stream |
-| `brain-loophost` | Loads Brain Components, compiles and caches Wasm, isolates workers, enforces limits |
-| `brain` | The session log, the context, the turn loop, recovery, and dispatch |
-| `brain-http` | HTTP and SSE routing, validation, error mapping |
-| `brain-server` | The runnable server, session lifecycle, environment adapters |
-| `@aexhq/brain` | TypeScript client for any Brain URL |
-
-The schemas and OpenAPI document under [`contracts/`](contracts) are the source of truth, and the
-[API Reference](https://aex.dev/brain/docs/reference/api) is generated from them.
-
-## Roadmap
-
-| | | |
-| --- | --- | --- |
-| ✅ | Four-part kernel: agent loop, model, tool, environment | Shipped |
-| ✅ | Unified `brain`, `tool`, and `environment` authoring with `brain build` | Shipped |
-| ✅ | Append-only segment log, written behind the turn, replayed on restart | Shipped |
-| ✅ | HTTP/SSE session API and the `@aexhq/brain` TypeScript SDK | Shipped |
-| ✅ | Remote environment contract with `env-app` and `env-aws-microvm` | Shipped |
-| 🚧 | Storage split apart from sandboxing | In progress |
-| 🚧 | Benchmarks and the cross-session isolation test, rebuilt on the current kernel | In progress |
-| 🚧 | A frozen v1 API and tagged releases | In progress |
-| ☐ | MCP client | Next |
-| ☐ | Subagents | Next |
-| ☐ | File access and workspace sync | Next |
-| ☐ | `web_search` and `web_fetch` | Next |
-| ☐ | crates.io publication | Next |
-| ☐ | Sessions spread across machines, sharing environments | Later |
-| ☐ | `checkpoint` and `restore` | Later |
-| ☐ | Custom images, scoped credentials, network metering | Later |
-| ☐ | Hosted Brain at [aex.dev](https://aex.dev/brain) | Later |
-
-## Getting started
-
-### Drive a session from TypeScript
+Drive a session from TypeScript:
 
 ```sh
 npm install @aexhq/brain @aexhq/brain-pi @aexhq/env-aws-microvm @aexhq/tools
@@ -179,49 +68,117 @@ await session.send("Read README.md and summarize it.");
 for await (const event of session.events()) console.log(event);
 ```
 
-Leave out `tools` and the model sees none.
+Leave out `tools` and the model sees none. Brain listens on loopback and needs no token there; set
+`BRAIN_API_TOKEN` to listen anywhere else.
 
-### Run Brain
+Four runnable scripts — a basic session, event history, the full lifecycle, and the same thing over
+raw HTTP with no SDK — are in [`examples/`](examples). Building from source and embedding the crate
+in Rust are covered in the [Quickstart](https://aex.dev/brain/docs/quickstart) and the
+[embedding guide](https://aex.dev/brain/docs/guides/embed).
 
-```sh
-docker run --rm -p 8080:8080 -v brain-data:/var/lib/brain ghcr.io/aexhq/brain:latest
+## How it works
+
+Brain owns the session. Everything it does not do itself is one of four things you supply.
+
+| Part | You supply | Brain does |
+| --- | --- | --- |
+| [**Agent loop**](https://aex.dev/brain/docs/concepts/agent-loop) | The policy: given what just happened, what next | Runs it in a WebAssembly sandbox and carries out the decision |
+| [**Model**](https://aex.dev/brain/docs/concepts/model) | A binding: provider, model name, key | Pins it for the life of the session and makes the call |
+| [**Tool**](https://aex.dev/brain/docs/concepts/tool) | A name, description, schema, and where it runs | Logs the call and sends it to the bound environment |
+| [**Environment**](https://aex.dev/brain/docs/concepts/environment) | Somewhere tool calls actually execute | Sets it up, attaches, calls, cancels, tears it down |
+
+```mermaid
+flowchart TD
+    app["Your app — @aexhq/brain over HTTP/SSE"]
+    kernel["brain — session kernel"]
+    log[("session log on disk")]
+    loop["Agent loop — Wasm, sealed off"]
+    model["Model API"]
+    env["Environment — sandbox, browser, your backend, a laptop"]
+
+    app <--> kernel
+    kernel --> log
+    kernel -->|"observation to decision"| loop
+    kernel -->|"pinned model call"| model
+    kernel -->|"tool call"| env
 ```
 
-Or from source:
+The packages we ship use the same interface you would — nothing built in gets a shortcut.
 
-```sh
-cargo build --release -p brain-server --bin brain -p brain-loophost --bin brain-loop-worker
-BRAIN_DATA_DIR="$PWD/brain-data" \
-BRAIN_LOOP_WORKER="$PWD/target/release/brain-loop-worker" \
-./target/release/brain --listen 127.0.0.1:8080
-```
+## Why Brain
 
-Brain listens on loopback by default. Set `BRAIN_API_TOKEN` to listen anywhere else.
+- **Sessions survive crashes.** Brain writes each step to disk before it runs. Kill the process
+  mid-turn, start it again, and the session carries on from where it stopped.
+- **Brain never executes tool code.** A tool call is a message to the environment you bound it to,
+  so a crashing or hostile tool takes down its own sandbox, not the process holding your sessions.
+- **The agent loop is sealed off.** It gets an observation and returns a decision. No network, no
+  filesystem, no secrets, no clock — Brain performs every effect.
+- **Any language.** Agent loops compile to WebAssembly; tools and environments talk plain HTTP. One
+  tool in Rust and another in Node, in the same session.
+- **Any loop, any model.** Pi, Codex-style, or your own, against Anthropic and OpenAI wire formats,
+  gateways, or your own keys. The model is pinned when the session starts, so nothing swaps it out
+  mid-conversation.
+- **More than one machine.** Environments are addressed by a stable name, so two sessions on two
+  servers can share one workspace when you want them to.
+- **Everything is an event log.** A session is an ordered, replayable log of what happened. Live
+  streaming sits on top and drops events rather than stalling a turn.
 
-### Embed Brain in Rust
+## Repository
 
-```rust,ignore
-let kernel = brain::Kernel::open(
-    brain::KernelConfig {
-        data_dir,
-        max_decisions_per_turn: 128,
-        loop_executor,
-        model_executor,
-        tool_executor,
-    },
-    telemetry,
-)?;
+| Crate / package | What it does |
+| --- | --- |
+| [`brain-protocol`](crates/brain-protocol) | The session, loop, model, tool, environment, event, and error contracts |
+| [`brain-telemetry`](crates/brain-telemetry) | Logs, traces, metrics, and the live event stream |
+| [`brain-loophost`](crates/brain-loophost) | Loads Brain Components, compiles and caches Wasm, isolates workers, enforces limits |
+| [`brain`](crates/brain) | The session log, the context, the turn loop, recovery, and dispatch |
+| [`brain-http`](crates/brain-http) | HTTP and SSE routing, validation, error mapping |
+| [`brain-server`](crates/brain-server) | The runnable server, session lifecycle, environment adapters |
+| [`@aexhq/brain`](packages/brain-sdk) | TypeScript client for any Brain URL |
 
-let session = kernel.create_session(sealed_session_config).await?;
-session
-    .message(brain_protocol::MessageRequest {
-        content: serde_json::json!("Explain the current changes."),
-    })
-    .await?;
-```
+The schemas and OpenAPI document under [`contracts/`](contracts) are the source of truth, and the
+[API Reference](https://aex.dev/brain/docs/reference/api) is generated from them.
 
-Guides, concepts, and the API reference: **[aex.dev/brain/docs](https://aex.dev/brain/docs)**.
-Setting up to contribute: [CONTRIBUTING.md](CONTRIBUTING.md).
+## Performance
+
+The benchmark measures the engine, not a model: it drives the real HTTP and SSE paths with an
+instant scripted provider and an in-process echo environment, so no model latency reaches the
+numbers. CI enforces a resource bound on every push — after 10,000 requests, resident memory must
+stay under 256 MiB and must not have grown by more than 16 MiB.
+
+Latency, throughput, and the cross-session isolation test are being rebuilt against the current
+kernel. Figures measured before the architecture reset are archived in
+[BENCHMARKS.md](BENCHMARKS.md) and are not current.
+
+## Status
+
+**Shipped** — the four-part kernel; unified `brain`, `tool`, and `environment` authoring with
+`brain build`; a SQLite log with crash recovery and writing to disk before acting; the HTTP/SSE
+session API and the `@aexhq/brain` SDK; the remote environment contract with `env-app` and
+`env-aws-microvm`.
+
+**In progress** — splitting storage apart from sandboxing, rebuilding the benchmarks and the
+cross-session isolation test, and freezing a v1 API with tagged releases.
+
+**Next** — an MCP client, subagents, file access and workspace sync, `web_search` and `web_fetch`,
+and crates.io publication.
+
+**Later** — sessions spread across machines sharing environments, `checkpoint` and `restore`, custom
+images with scoped credentials and network metering, and hosted Brain at
+[aex.dev](https://aex.dev/brain).
+
+## Contributing
+
+Setup, the verification commands CI runs, and how contracts change are in
+[CONTRIBUTING.md](CONTRIBUTING.md). Issues and pull requests are welcome — because contracts are
+replaced in place before v1, a change that would be breaking later is usually just a change today.
+
+## Acknowledgements
+
+The name comes from Anthropic's split of
+[the brain from the hands](https://www.anthropic.com/engineering/managed-agents). Brain is the
+brain: it decides. Environments are the hands — a sandbox, a browser, your backend, someone's
+laptop — where the work actually happens. The small-and-extensible shape follows
+[Pi](https://github.com/earendil-works/pi).
 
 ## License
 

--- a/crates/brain/tests/journal_throughput.rs
+++ b/crates/brain/tests/journal_throughput.rs
@@ -1,0 +1,102 @@
+//! What the journal costs a turn.
+//!
+//! Ignored by default because it reports rather than asserts: the numbers move with
+//! the disk and the machine, and a threshold that passes on a laptop says nothing
+//! about a server. The shape is what matters and does not move — an append is a
+//! serialise, a hash of the bytes just serialised, and a channel send, with no
+//! syscall on the turn's path, and a restart pays for the log it kept rather than
+//! for every record ever written.
+//!
+//!     cargo test --release -p brain --test journal_throughput -- --ignored --nocapture
+
+use std::time::Instant;
+
+use brain::{AppendRecord, JournalStore, SegmentJournal, SessionUpdate, journal::SessionRow};
+use brain_protocol::{Identity, JournalId, SessionId, SessionStatus};
+
+const RECORDS: u64 = 20_000;
+const PAYLOAD_BYTES: usize = 1024;
+const PAGE: usize = 1_000;
+
+fn percentile(sorted: &[f64], fraction: f64) -> f64 {
+    sorted[((sorted.len() as f64 * fraction) as usize).min(sorted.len() - 1)]
+}
+
+#[test]
+#[ignore = "reports timings; run it deliberately"]
+fn reports_what_the_journal_costs() {
+    let directory = std::env::temp_dir().join(format!(
+        "brain-journal-throughput-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let store = SegmentJournal::open(&directory).unwrap();
+
+    let session_id = SessionId::new("ses_throughput");
+    store
+        .create_session(
+            &SessionRow {
+                session_id: session_id.clone(),
+                journal_id: JournalId::new("jrn_throughput"),
+                status: SessionStatus::Idle,
+                through_sequence: 1,
+                configuration: serde_json::json!({}),
+                context: serde_json::json!({}),
+                presentation_identity: Identity::of(&"presentation").unwrap(),
+            },
+            AppendRecord::new("session_created", serde_json::json!({})),
+        )
+        .unwrap();
+
+    let payload = serde_json::json!({ "text": "x".repeat(PAYLOAD_BYTES) });
+    let mut latencies = Vec::with_capacity(RECORDS as usize);
+    let started = Instant::now();
+    for sequence in 0..RECORDS {
+        let at = Instant::now();
+        store
+            .append(
+                &session_id,
+                sequence + 1,
+                &[AppendRecord::new("model_result", payload.clone())],
+                SessionUpdate::default(),
+            )
+            .unwrap();
+        latencies.push(at.elapsed().as_secs_f64() * 1e6);
+    }
+    let appending = started.elapsed().as_secs_f64();
+    latencies.sort_by(|left, right| left.partial_cmp(right).unwrap());
+
+    let at = Instant::now();
+    let page = store.records_after(&session_id, 0, PAGE).unwrap();
+    let paging = at.elapsed().as_secs_f64() * 1e3;
+    assert_eq!(page.len(), PAGE);
+    drop(store);
+
+    let at = Instant::now();
+    let reopened = SegmentJournal::open(&directory).unwrap();
+    let replay = at.elapsed().as_secs_f64() * 1e3;
+    assert_eq!(
+        reopened
+            .session(&session_id)
+            .unwrap()
+            .unwrap()
+            .through_sequence,
+        RECORDS + 1
+    );
+    drop(reopened);
+
+    println!(
+        "append {RECORDS} x {PAYLOAD_BYTES} B   {:.0} records/s   p50 {:.2} us   p99 {:.2} us\n\
+         page {PAGE} records          {paging:.1} ms\n\
+         restart replay              {replay:.0} ms for {} records",
+        RECORDS as f64 / appending,
+        percentile(&latencies, 0.5),
+        percentile(&latencies, 0.99),
+        RECORDS + 1,
+    );
+
+    std::fs::remove_dir_all(directory).unwrap();
+}


### PR DESCRIPTION
Pushes the README restructure that was sitting unpushed on a local branch, and rewrites it around a technical profile.

## Why it needed more than a push

The headline promised *the durable session kernel* and the body still described one — "writes each step to disk before it runs", "a SQLite log with crash recovery and writing to disk before acting". None of that survived #100. A reader comparing the README against the code would have found them disagreeing on the one property the headline led with.

## Headline

> **A tiny, blazing fast, extensible agent kernel.**

Each of those three words is now attached to something checkable rather than left as an adjective:

- **Tiny** — six crates, ~7,300 lines of Rust; the kernel is 3,400 and its journal 1,337, of which the whole on-disk format is one 610-line file. No ORM, no query planner, no embedded database.
- **Blazing fast** — the shape of the write path (serialise, xxh3 the bytes just serialised, channel send; no syscall on the turn's path, no fsync anywhere), plus a command that prints numbers.
- **Extensible** — the four interfaces, and the fact that everything shipped uses them.

## A number you can reproduce

`crates/brain/tests/journal_throughput.rs` is new, `#[ignore]`d, and 100 lines:

```sh
cargo test --release -p brain --test journal_throughput -- --ignored --nocapture
```
```
append 20000 x 1024 B   684168 records/s   p50 1.30 us   p99 4.60 us
page 1000 records          9.2 ms
restart replay              10 ms for 20001 records
```

It **reports rather than asserts** — a threshold that passes on a laptop says nothing about a server. The README says which machine, and that three consecutive runs held the append rate within 1.5%. The repo had just deleted a placeholder table full of `{N}×` and TBD cells; quoting an unreproducible number would have put one straight back, so either the number went or the harness had to exist.

## Durability gets a paragraph, not a quiet deletion

It is the property that changed, so it is stated outright: nothing is fsynced, a crash can lose the log's tail, restart replays what reached the disk, and a layer above Brain recognises a reissued effect by an operation id that is stable across a replay.

## Also

- `## Performance` prose → a **What CI holds** table of the three bounds actually enforced in `ci.yml` (RSS ≤ 256 MiB and ≤ 16 MiB growth after 10,000 requests; a turn's journal and one event page each ≤ 8× the final context).
- `Status` no longer claims SQLite.
- The mermaid diagram shows the log written *behind* the turn.
- `BENCHMARKS.md` documents the new harness and repeats that it reports rather than asserts.

The first commit is the original unpushed restructure, cherry-picked onto main with its README conflict resolved; the second is this rewrite.