### PR TITLE
perf: land the reviewed wins from both performance passes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM rust:1.97.1-bookworm AS build
 WORKDIR /src
 COPY . .
+# Strip the symbol table from the shipped binaries: 22-25% smaller with no measured
+# change to process readiness. It is set here rather than in `[profile.release]` so
+# CI, benchmarks and local release builds keep symbolicated panic backtraces.
+ENV RUSTFLAGS="-C strip=symbols"
 RUN cargo build --locked --release -p brain-server --bin brain -p brain-loophost --bin brain-loop-worker
 
 FROM debian:bookworm-slim

--- a/crates/brain-loophost/src/client.rs
+++ b/crates/brain-loophost/src/client.rs
@@ -38,18 +38,31 @@ impl WorkerClient {
         }
     }
 
+    /// `max_input_bytes` is the caller's configured activation-input bound. It is
+    /// enforced against the frame this call is about to write, so the input is encoded
+    /// once rather than once to measure and once to send.
     pub async fn activate(
         &self,
         digest: AgentloopIdentity,
         input: ActivationInput,
+        max_input_bytes: usize,
     ) -> Result<ActivationOutput, String> {
         match self
-            .call(WorkerRequest::Activate {
-                digest,
-                input: Box::new(input),
-            })
-            .await?
-        {
+            .call_bounded(
+                WorkerRequest::Activate {
+                    digest,
+                    input: Box::new(input),
+                },
+                max_input_bytes,
+            )
+            .await
+            .map_err(|error| {
+                if error.starts_with("worker frame exceeds") {
+                    "Agentloop activation input exceeds the configured limit".to_owned()
+                } else {
+                    error
+                }
+            })? {
             WorkerResponse::Activated { output } => Ok(output),
             WorkerResponse::Error { code, message } => Err(format!("{code}: {message}")),
             response => Err(format!("unexpected worker response: {response:?}")),
@@ -58,16 +71,34 @@ impl WorkerClient {
 
     #[cfg(unix)]
     async fn call(&self, request: WorkerRequest) -> Result<WorkerResponse, String> {
+        let max = max_request_bytes(&request);
+        self.call_bounded(request, max).await
+    }
+
+    #[cfg(unix)]
+    async fn call_bounded(
+        &self,
+        request: WorkerRequest,
+        max_request: usize,
+    ) -> Result<WorkerResponse, String> {
         let mut stream = tokio::net::UnixStream::connect(&self.socket)
             .await
             .map_err(|error| error.to_string())?;
-        let max = max_request_bytes(&request);
-        write_frame(&mut stream, &request, max).await?;
+        write_frame(&mut stream, &request, max_request).await?;
         read_frame(&mut stream, MAX_RESPONSE_FRAME_BYTES).await
     }
 
     #[cfg(not(unix))]
     async fn call(&self, _request: WorkerRequest) -> Result<WorkerResponse, String> {
+        Err("brain-loop-worker IPC requires Unix domain sockets".into())
+    }
+
+    #[cfg(not(unix))]
+    async fn call_bounded(
+        &self,
+        _request: WorkerRequest,
+        _max_request: usize,
+    ) -> Result<WorkerResponse, String> {
         Err("brain-loop-worker IPC requires Unix domain sockets".into())
     }
 }

--- a/crates/brain-loophost/src/supervisor.rs
+++ b/crates/brain-loophost/src/supervisor.rs
@@ -81,10 +81,9 @@ impl WorkerPool {
         digest: AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, String> {
-        let input_bytes = serde_json::to_vec(&input).map_err(|error| error.to_string())?;
-        if input_bytes.len() > self.limits.activation_input_bytes {
-            return Err("Agentloop activation input exceeds the configured limit".into());
-        }
+        // The input bound is enforced where the input is encoded, in `write_frame`
+        // below. Encoding it here as well to measure its length meant serialising the
+        // whole context twice per decision and throwing one copy away.
         let _permit = self
             .permits
             .clone()
@@ -103,7 +102,7 @@ impl WorkerPool {
             state.admitted.insert(digest.clone());
         }
         let client = WorkerClient::new(&self.socket);
-        let call = client.activate(digest, input);
+        let call = client.activate(digest, input, self.limits.activation_input_bytes);
         match tokio::time::timeout(self.limits.wall_time, call).await {
             Ok(Ok(output)) => {
                 let output_bytes =

--- a/crates/brain-server/src/main.rs
+++ b/crates/brain-server/src/main.rs
@@ -54,7 +54,7 @@ async fn compose(config: &ServerConfig) -> anyhow::Result<ServerApi> {
         models.clone(),
         config.model_base_url.clone(),
         Duration::from_secs(120),
-    ));
+    )?);
     let http = reqwest::Client::builder()
         .no_proxy()
         .redirect(reqwest::redirect::Policy::none())

--- a/crates/brain-server/src/model_binding.rs
+++ b/crates/brain-server/src/model_binding.rs
@@ -11,7 +11,7 @@ use aes_gcm::{
     aead::{Aead, KeyInit, Payload},
 };
 use async_trait::async_trait;
-use brain::{KernelError, ModelExecutor, model::RemoteModelClient, model::RemoteModelConfig};
+use brain::{KernelError, ModelExecutor, model::ModelTransport, model::RemoteModelClient};
 use brain_protocol::{
     Identity, ModelBinding, ModelPresentation, ModelRequest, ModelResult, ModelSelection,
     ModelStreamEvent, OperationId,
@@ -191,8 +191,9 @@ impl ModelBindingStore for LocalModelBindingStore {
 
 pub struct ServerModelExecutor {
     bindings: Arc<dyn ModelBindingStore>,
-    base_url: String,
-    timeout: Duration,
+    /// One connection pool for the process. The credential is the only part of a model
+    /// call that varies by session, and a credential is a header, not a client.
+    transport: Arc<ModelTransport>,
 }
 
 impl ServerModelExecutor {
@@ -200,12 +201,11 @@ impl ServerModelExecutor {
         bindings: Arc<dyn ModelBindingStore>,
         base_url: impl Into<String>,
         timeout: Duration,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, KernelError> {
+        Ok(Self {
             bindings,
-            base_url: base_url.into(),
-            timeout,
-        }
+            transport: Arc::new(ModelTransport::new(&base_url.into(), timeout)?),
+        })
     }
 }
 
@@ -229,11 +229,8 @@ impl ModelExecutor for ServerModelExecutor {
                 "model provider is unsupported".into(),
             ));
         }
-        let client = RemoteModelClient::new(RemoteModelConfig {
-            base_url: self.base_url.clone(),
-            api_key: credential.api_key.to_string(),
-            timeout: self.timeout,
-        })?;
+        let client =
+            RemoteModelClient::bound(self.transport.clone(), credential.api_key.to_string())?;
         client
             .execute(
                 operation_id,

--- a/crates/brain-server/src/service.rs
+++ b/crates/brain-server/src/service.rs
@@ -34,29 +34,49 @@ pub struct ServerApi {
 }
 
 struct KeyedLocks<K> {
-    entries: StdMutex<HashMap<K, Weak<Mutex<()>>>>,
+    entries: StdMutex<Table<K>>,
 }
+
+struct Table<K> {
+    locks: HashMap<K, Weak<Mutex<()>>>,
+    /// Sweep once the table has doubled since the last sweep, rather than on every
+    /// acquire. A sweep is O(table) under a process-global lock, and every mutating
+    /// request acquires at least one lock, so sweeping per call made request cost grow
+    /// with the number of live sessions.
+    sweep_at: usize,
+}
+
+/// Below this a sweep is cheaper than the arithmetic deciding whether to sweep.
+const MIN_SWEEP: usize = 16;
 
 impl<K> Default for KeyedLocks<K> {
     fn default() -> Self {
         Self {
-            entries: StdMutex::new(HashMap::new()),
+            entries: StdMutex::new(Table {
+                locks: HashMap::new(),
+                sweep_at: MIN_SWEEP,
+            }),
         }
     }
 }
 
 impl<K: Clone + Eq + Hash> KeyedLocks<K> {
     fn acquire(&self, key: K) -> Result<Arc<Mutex<()>>, ApiError> {
-        let mut entries = self
+        let mut table = self
             .entries
             .lock()
             .map_err(|_| internal("keyed lock table is poisoned"))?;
-        entries.retain(|_, lock| lock.strong_count() > 0);
-        if let Some(lock) = entries.get(&key).and_then(Weak::upgrade) {
+        if table.locks.len() >= table.sweep_at {
+            table.locks.retain(|_, lock| lock.strong_count() > 0);
+            // Amortised: the next sweep is at least as far away as the work this one
+            // did, so the total sweeping stays linear in the number of acquires.
+            table.sweep_at = table.locks.len().saturating_mul(2).max(MIN_SWEEP);
+        }
+        if let Some(lock) = table.locks.get(&key).and_then(Weak::upgrade) {
             return Ok(lock);
         }
         let lock = Arc::new(Mutex::new(()));
-        entries.insert(key, Arc::downgrade(&lock));
+        table.locks.insert(key, Arc::downgrade(&lock));
         Ok(lock)
     }
 }
@@ -647,8 +667,40 @@ mod tests {
         drop(first);
         drop(replay);
 
-        let current = locks.acquire("current").unwrap();
-        assert_eq!(locks.entries.lock().unwrap().len(), 1);
-        assert_eq!(std::sync::Arc::strong_count(&current), 1);
+        // Enough distinct keys to cross the first sweep threshold, so the dead entry
+        // above is reclaimed rather than accumulating.
+        let mut held = Vec::new();
+        for key in KEYS {
+            held.push(locks.acquire(key).unwrap());
+        }
+        assert!(
+            locks.entries.lock().unwrap().locks.len() <= super::MIN_SWEEP,
+            "a sweep must reclaim the dead key once the table reaches the threshold"
+        );
+        assert!(
+            held.iter()
+                .all(|lock| std::sync::Arc::strong_count(lock) == 1)
+        );
+    }
+
+    /// Distinct static keys, so the test does not depend on a `String` key type.
+    const KEYS: [&str; super::MIN_SWEEP] = [
+        "k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8", "k9", "k10", "k11", "k12", "k13",
+        "k14", "k15",
+    ];
+
+    /// The table must not grow without bound when every key is used once and dropped,
+    /// which is what an idempotency key looks like.
+    #[test]
+    fn keyed_locks_stay_bounded_under_single_use_keys() {
+        let locks: KeyedLocks<u64> = KeyedLocks::default();
+        for key in 0..10_000_u64 {
+            drop(locks.acquire(key).unwrap());
+        }
+        let held = locks.entries.lock().unwrap().locks.len();
+        assert!(
+            held <= 2 * super::MIN_SWEEP,
+            "single-use keys must not accumulate: {held} entries remain"
+        );
     }
 }

--- a/crates/brain/src/journal/log.rs
+++ b/crates/brain/src/journal/log.rs
@@ -29,7 +29,7 @@ const SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
 const HEADER_BYTES: usize = 12;
 
 /// Frames handed to the writer but not yet flushed, keyed by segment and offset.
-type Staged = Arc<Mutex<HashMap<(u64, u64), Arc<[u8]>>>>;
+type Staged = Arc<Mutex<HashMap<(u64, u64), Arc<Vec<u8>>>>>;
 
 /// Where a frame lives. Small and `Copy` so the in-memory index can hold one per record.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -73,7 +73,7 @@ impl Frame<'_> {
 enum Message {
     Frame {
         location: Location,
-        bytes: Arc<[u8]>,
+        bytes: Arc<Vec<u8>>,
     },
     Reclaim(u64),
 }
@@ -164,7 +164,9 @@ impl SegmentLog {
     /// Assign a location, hand the bytes to the writer, and return. Does not block on
     /// the disk.
     pub(crate) fn append(&self, append: Append<'_>) -> Result<Location, KernelError> {
-        let frame: Arc<[u8]> = encode(&append)?.into();
+        // `Arc<Vec<u8>>` rather than `Arc<[u8]>`: converting a `Vec` into `Arc<[u8]>`
+        // allocates a second buffer and copies the frame into it.
+        let frame = Arc::new(encode(&append)?);
         let length = frame.len() as u64;
 
         let mut tail = self.tail.lock().map_err(|_| poisoned())?;
@@ -353,25 +355,31 @@ fn reclaim_segments(directory: &Path, keep_from: u64) {
 //
 // body = sequence u64 | recorded_at_ms u64 | session u16-prefixed | kind u16-prefixed | payload
 
+/// Builds the whole frame in one buffer: header space first, then the body written
+/// straight into it, then the header patched once the body's length and check value are
+/// known. A record's payload is the largest thing the kernel handles, so serialising it
+/// into a payload buffer, copying that into a body buffer, and copying that into a frame
+/// buffer meant three copies of it before the frame existed.
 fn encode(append: &Append<'_>) -> Result<Vec<u8>, KernelError> {
-    let payload = serde_json::to_vec(append.payload)
-        .map_err(|error| KernelError::Journal(error.to_string()))?;
     let session = append.session_id.as_bytes();
     let kind = append.kind.as_bytes();
 
-    let mut body = Vec::with_capacity(payload.len() + session.len() + kind.len() + 24);
-    body.extend_from_slice(&append.sequence.to_le_bytes());
-    body.extend_from_slice(&append.recorded_at_ms.to_le_bytes());
-    body.extend_from_slice(&(session.len() as u16).to_le_bytes());
-    body.extend_from_slice(session);
-    body.extend_from_slice(&(kind.len() as u16).to_le_bytes());
-    body.extend_from_slice(kind);
-    body.extend_from_slice(&payload);
+    let mut frame = Vec::with_capacity(HEADER_BYTES + session.len() + kind.len() + 24);
+    frame.resize(HEADER_BYTES, 0);
+    frame.extend_from_slice(&append.sequence.to_le_bytes());
+    frame.extend_from_slice(&append.recorded_at_ms.to_le_bytes());
+    frame.extend_from_slice(&(session.len() as u16).to_le_bytes());
+    frame.extend_from_slice(session);
+    frame.extend_from_slice(&(kind.len() as u16).to_le_bytes());
+    frame.extend_from_slice(kind);
+    serde_json::to_writer(&mut frame, append.payload)
+        .map_err(|error| KernelError::Journal(error.to_string()))?;
 
-    let mut frame = Vec::with_capacity(body.len() + HEADER_BYTES);
-    frame.extend_from_slice(&(body.len() as u32).to_le_bytes());
-    frame.extend_from_slice(&xxhash_rust::xxh3::xxh3_64(&body).to_le_bytes());
-    frame.extend_from_slice(&body);
+    let body = &frame[HEADER_BYTES..];
+    let length = (body.len() as u32).to_le_bytes();
+    let check = xxhash_rust::xxh3::xxh3_64(body).to_le_bytes();
+    frame[0..4].copy_from_slice(&length);
+    frame[4..HEADER_BYTES].copy_from_slice(&check);
     Ok(frame)
 }
 

--- a/crates/brain/src/journal/log.rs
+++ b/crates/brain/src/journal/log.rs
@@ -61,6 +61,13 @@ pub(crate) struct Frame<'a> {
 
 impl Frame<'_> {
     pub(crate) fn payload(&self) -> Result<serde_json::Value, KernelError> {
+        self.decode()
+    }
+
+    /// The payload as whatever shape the caller wants. Replay reads frames it will
+    /// mostly discard, and building a `Value` for one only to pull two fields out of it
+    /// materialises the whole payload twice.
+    pub(crate) fn decode<T: serde::de::DeserializeOwned>(&self) -> Result<T, KernelError> {
         serde_json::from_slice(self.payload)
             .map_err(|error| KernelError::Journal(error.to_string()))
     }

--- a/crates/brain/src/journal/observed.rs
+++ b/crates/brain/src/journal/observed.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use brain_protocol::{Identity, SessionId};
+use brain_protocol::{Identity, Session, SessionId};
 use brain_telemetry::{TelemetryKind, TelemetryPublisher, TelemetryRecord};
 
 use crate::{
@@ -59,12 +59,16 @@ impl JournalStore for ObservedJournal {
         Ok(saved)
     }
 
-    fn session(&self, session_id: &SessionId) -> Result<Option<SessionRow>, KernelError> {
-        self.inner.session(session_id)
+    fn session_row(&self, session_id: &SessionId) -> Result<Option<SessionRow>, KernelError> {
+        self.inner.session_row(session_id)
     }
 
-    fn sessions(&self) -> Result<Vec<SessionRow>, KernelError> {
-        self.inner.sessions()
+    fn session_summary(&self, session_id: &SessionId) -> Result<Option<Session>, KernelError> {
+        self.inner.session_summary(session_id)
+    }
+
+    fn session_summaries(&self) -> Result<Vec<Session>, KernelError> {
+        self.inner.session_summaries()
     }
 
     fn records_after(

--- a/crates/brain/src/journal/segment.rs
+++ b/crates/brain/src/journal/segment.rs
@@ -12,7 +12,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use brain_protocol::{Identity, JournalId, SessionId, SessionStatus};
+use brain_protocol::{Identity, JournalId, Session, SessionId, SessionStatus};
 
 use crate::{
     KernelError,
@@ -232,7 +232,7 @@ impl JournalStore for SegmentJournal {
         Ok(saved)
     }
 
-    fn session(&self, session_id: &SessionId) -> Result<Option<SessionRow>, KernelError> {
+    fn session_row(&self, session_id: &SessionId) -> Result<Option<SessionRow>, KernelError> {
         Ok(self
             .lock()?
             .sessions
@@ -240,15 +240,26 @@ impl JournalStore for SegmentJournal {
             .map(|tracked| tracked.row.clone()))
     }
 
-    fn sessions(&self) -> Result<Vec<SessionRow>, KernelError> {
-        let mut rows: Vec<SessionRow> = self
+    fn session_summary(&self, session_id: &SessionId) -> Result<Option<Session>, KernelError> {
+        Ok(self
+            .lock()?
+            .sessions
+            .get(session_id.as_str())
+            .map(|tracked| Session::from(&tracked.row)))
+    }
+
+    fn session_summaries(&self) -> Result<Vec<Session>, KernelError> {
+        // Summaries are built under the lock but copy only the five fields a caller can
+        // see. Cloning whole rows here copied every live configuration and conversation
+        // on every request that listed sessions.
+        let mut sessions: Vec<Session> = self
             .lock()?
             .sessions
             .values()
-            .map(|tracked| tracked.row.clone())
+            .map(|tracked| Session::from(&tracked.row))
             .collect();
-        rows.sort_by(|left, right| left.session_id.as_str().cmp(right.session_id.as_str()));
-        Ok(rows)
+        sessions.sort_by(|left, right| left.session_id.as_str().cmp(right.session_id.as_str()));
+        Ok(sessions)
     }
 
     fn records_after(
@@ -512,4 +523,3 @@ fn not_found() -> KernelError {
 fn ended_first() -> KernelError {
     KernelError::InvalidState("session must exist and be ended before deletion".into())
 }
-

--- a/crates/brain/src/journal/segment.rs
+++ b/crates/brain/src/journal/segment.rs
@@ -12,7 +12,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use brain_protocol::{Identity, SessionId, SessionStatus};
+use brain_protocol::{Identity, JournalId, SessionId, SessionStatus};
 
 use crate::{
     KernelError,
@@ -395,42 +395,50 @@ fn replay(state: &mut State, frame: &Frame<'_>, location: Location) -> Result<()
 
     match frame.kind {
         SESSION_STATE => {
-            let payload = frame.payload()?;
+            // Decoded straight into its own shape and moved in. Building a `Value` and
+            // then cloning the context out of it materialised the context twice, and a
+            // session writes one of these per turn — so replay paid for every context it
+            // ever had, twice over, to keep the last.
+            let payload: StateFrame = frame.decode()?;
             let tracked = match state.sessions.entry(frame.session_id.to_string()) {
                 Entry::Occupied(occupied) => occupied.into_mut(),
-                Entry::Vacant(vacant) => vacant.insert(Tracked {
-                    row: SessionRow {
-                        session_id: SessionId::new(frame.session_id.to_string()),
-                        journal_id: serde_json::from_value(payload["journal_id"].clone())
-                            .map_err(json_error)?,
-                        // A frame that introduces a session always carries both; a
-                        // later one that only moves its status hits the arm above.
-                        presentation_identity: serde_json::from_value(
-                            payload["presentation_identity"].clone(),
-                        )
-                        .map_err(json_error)?,
-                        status: SessionStatus::Idle,
-                        through_sequence: 0,
-                        configuration: serde_json::Value::Null,
-                        context: serde_json::Value::Null,
-                    },
-                    locations: Vec::new(),
-                    state_segment: location.segment,
-                    last_recorded_at_ms: frame.recorded_at_ms,
-                }),
+                Entry::Vacant(vacant) => {
+                    // A frame that introduces a session always carries both; a later one
+                    // that only moves its status finds the session already here.
+                    let (Some(journal_id), Some(presentation_identity)) =
+                        (payload.journal_id, payload.presentation_identity)
+                    else {
+                        return Err(KernelError::Journal(
+                            "the first session state frame must name the journal and the presentation".into(),
+                        ));
+                    };
+                    vacant.insert(Tracked {
+                        row: SessionRow {
+                            session_id: SessionId::new(frame.session_id.to_string()),
+                            journal_id,
+                            presentation_identity,
+                            status: SessionStatus::Idle,
+                            through_sequence: 0,
+                            configuration: serde_json::Value::Null,
+                            context: serde_json::Value::Null,
+                        },
+                        locations: Vec::new(),
+                        state_segment: location.segment,
+                        last_recorded_at_ms: frame.recorded_at_ms,
+                    })
+                }
             };
-            if let Some(status) = payload.get("status") {
-                tracked.row.status = serde_json::from_value(status.clone()).map_err(json_error)?;
+            if let Some(status) = payload.status {
+                tracked.row.status = status;
             }
-            if let Some(context) = payload.get("context") {
-                tracked.row.context = context.clone();
+            if let Some(context) = payload.context {
+                tracked.row.context = context;
             }
-            if let Some(configuration) = payload.get("configuration") {
-                tracked.row.configuration = configuration.clone();
+            if let Some(configuration) = payload.configuration {
+                tracked.row.configuration = configuration;
             }
-            if let Some(identity) = payload.get("presentation_identity") {
-                tracked.row.presentation_identity =
-                    serde_json::from_value(identity.clone()).map_err(json_error)?;
+            if let Some(identity) = payload.presentation_identity {
+                tracked.row.presentation_identity = identity;
             }
             tracked.state_segment = location.segment;
         }
@@ -438,19 +446,12 @@ fn replay(state: &mut State, frame: &Frame<'_>, location: Location) -> Result<()
             state.sessions.remove(frame.session_id);
         }
         IDEMPOTENCY => {
-            let payload = frame.payload()?;
-            let (Some(scope), Some(key)) = (payload["scope"].as_str(), payload["key"].as_str())
-            else {
-                return Err(KernelError::Journal(
-                    "idempotency frame is malformed".into(),
-                ));
-            };
+            let payload: IdempotencyFrame = frame.decode()?;
             state.idempotency.insert(
-                (scope.to_string(), key.to_string()),
+                (payload.scope, payload.key),
                 Stored {
-                    request: serde_json::from_value(payload["request"].clone())
-                        .map_err(json_error)?,
-                    response: payload["response"].clone(),
+                    request: payload.request,
+                    response: payload.response,
                     segment: location.segment,
                 },
             );
@@ -458,6 +459,26 @@ fn replay(state: &mut State, frame: &Frame<'_>, location: Location) -> Result<()
         _ => {}
     }
     Ok(())
+}
+
+/// A `$session` frame carries only the fields the update that wrote it changed, so every
+/// one is optional. Decoding into this rather than a `Value` means the context is built
+/// once and moved, not built and then cloned.
+#[derive(serde::Deserialize)]
+struct StateFrame {
+    journal_id: Option<JournalId>,
+    presentation_identity: Option<Identity>,
+    status: Option<SessionStatus>,
+    context: Option<serde_json::Value>,
+    configuration: Option<serde_json::Value>,
+}
+
+#[derive(serde::Deserialize)]
+struct IdempotencyFrame {
+    scope: String,
+    key: String,
+    request: Identity,
+    response: serde_json::Value,
 }
 
 /// The oldest segment any surviving state still lives in. Everything below it is dead
@@ -492,6 +513,3 @@ fn ended_first() -> KernelError {
     KernelError::InvalidState("session must exist and be ended before deletion".into())
 }
 
-fn json_error(error: serde_json::Error) -> KernelError {
-    KernelError::Journal(error.to_string())
-}

--- a/crates/brain/src/journal/store.rs
+++ b/crates/brain/src/journal/store.rs
@@ -1,4 +1,4 @@
-use brain_protocol::{Identity, JournalId, SessionId, SessionStatus};
+use brain_protocol::{Identity, JournalId, Session, SessionId, SessionStatus};
 
 use crate::{
     KernelError,
@@ -14,6 +14,21 @@ pub struct SessionRow {
     pub configuration: serde_json::Value,
     pub context: serde_json::Value,
     pub presentation_identity: Identity,
+}
+
+/// What a caller outside the kernel is allowed to see about a session. Building one
+/// borrows the row rather than cloning it, so listing sessions never copies a
+/// conversation or a configuration.
+impl From<&SessionRow> for Session {
+    fn from(row: &SessionRow) -> Self {
+        Self {
+            session_id: row.session_id.clone(),
+            journal_id: row.journal_id.clone(),
+            status: row.status.clone(),
+            through_sequence: row.through_sequence,
+            presentation_identity: row.presentation_identity,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -36,8 +51,11 @@ pub trait JournalStore: Send + Sync + 'static {
         records: &[AppendRecord],
         update: SessionUpdate<'_>,
     ) -> Result<Vec<JournalRecord>, KernelError>;
-    fn session(&self, session_id: &SessionId) -> Result<Option<SessionRow>, KernelError>;
-    fn sessions(&self) -> Result<Vec<SessionRow>, KernelError>;
+    /// The whole row, including configuration and context. Only rehydrating a session
+    /// actor needs this; everything else wants a summary.
+    fn session_row(&self, session_id: &SessionId) -> Result<Option<SessionRow>, KernelError>;
+    fn session_summary(&self, session_id: &SessionId) -> Result<Option<Session>, KernelError>;
+    fn session_summaries(&self) -> Result<Vec<Session>, KernelError>;
     fn records_after(
         &self,
         session_id: &SessionId,

--- a/crates/brain/src/model/http.rs
+++ b/crates/brain/src/model/http.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, net::IpAddr, time::Duration};
+use std::{collections::BTreeMap, net::IpAddr, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use brain_protocol::{
@@ -20,20 +20,29 @@ pub struct RemoteModelConfig {
     pub timeout: Duration,
 }
 
-pub struct RemoteModelClient {
+/// The half of a model client that does not depend on who is calling: the validated
+/// endpoint and the connection pool behind it. Both are expensive to build and both are
+/// the same for every session, so a process builds one and shares it. Building one per
+/// call discards the pool with it, which costs a TCP connect and a TLS handshake on
+/// every model call.
+pub struct ModelTransport {
     client: reqwest::Client,
     base_url: String,
+}
+
+pub struct RemoteModelClient {
+    transport: Arc<ModelTransport>,
     api_key: Zeroizing<String>,
 }
 
-impl RemoteModelClient {
-    pub fn new(config: RemoteModelConfig) -> Result<Self, KernelError> {
-        if config.base_url.trim().is_empty() || config.api_key.trim().is_empty() {
+impl ModelTransport {
+    pub fn new(base_url: &str, timeout: Duration) -> Result<Self, KernelError> {
+        if base_url.trim().is_empty() {
             return Err(KernelError::InvalidState(
-                "model base URL and API key are required".into(),
+                "model base URL is required".into(),
             ));
         }
-        let url = reqwest::Url::parse(&config.base_url).map_err(|error| {
+        let url = reqwest::Url::parse(base_url).map_err(|error| {
             KernelError::InvalidState(format!("model base URL is invalid: {error}"))
         })?;
         let loopback_http = url.scheme() == "http"
@@ -55,14 +64,35 @@ impl RemoteModelClient {
         let client = reqwest::Client::builder()
             .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
-            .connect_timeout(config.timeout.min(Duration::from_secs(10)))
-            .timeout(config.timeout)
+            .connect_timeout(timeout.min(Duration::from_secs(10)))
+            .timeout(timeout)
             .build()
             .map_err(|error| KernelError::Executor(error.to_string()))?;
         Ok(Self {
             client,
-            base_url: config.base_url.trim_end_matches('/').to_owned(),
-            api_key: Zeroizing::new(config.api_key),
+            base_url: base_url.trim_end_matches('/').to_owned(),
+        })
+    }
+}
+
+impl RemoteModelClient {
+    /// Builds a transport of its own. For a caller that makes one call, or a test.
+    pub fn new(config: RemoteModelConfig) -> Result<Self, KernelError> {
+        let transport = ModelTransport::new(&config.base_url, config.timeout)?;
+        Self::bound(Arc::new(transport), config.api_key)
+    }
+
+    /// Binds a credential to a transport the caller already holds. This is the shape a
+    /// server uses: one transport for the process, one credential per session.
+    pub fn bound(transport: Arc<ModelTransport>, api_key: String) -> Result<Self, KernelError> {
+        if api_key.trim().is_empty() {
+            return Err(KernelError::InvalidState(
+                "model API key is required".into(),
+            ));
+        }
+        Ok(Self {
+            transport,
+            api_key: Zeroizing::new(api_key),
         })
     }
 
@@ -160,8 +190,9 @@ impl ModelExecutor for RemoteModelClient {
         on_event: &mut (dyn FnMut(ModelStreamEvent) + Send),
     ) -> Result<ModelResult, KernelError> {
         let response = self
+            .transport
             .client
-            .post(format!("{}/chat/completions", self.base_url))
+            .post(format!("{}/chat/completions", self.transport.base_url))
             .bearer_auth(self.api_key.as_str())
             .header("content-type", "application/json")
             .header("accept", "text/event-stream")

--- a/crates/brain/src/model/mod.rs
+++ b/crates/brain/src/model/mod.rs
@@ -6,6 +6,9 @@ use brain_protocol::{
 mod http;
 mod sse;
 
+// Exported so the performance spikes can measure the shipped decoder rather than a copy.
+pub use sse::SseDecoder;
+
 pub use http::{ModelTransport, RemoteModelClient, RemoteModelConfig};
 
 use brain_protocol::Identity;

--- a/crates/brain/src/model/mod.rs
+++ b/crates/brain/src/model/mod.rs
@@ -6,7 +6,7 @@ use brain_protocol::{
 mod http;
 mod sse;
 
-pub use http::{RemoteModelClient, RemoteModelConfig};
+pub use http::{ModelTransport, RemoteModelClient, RemoteModelConfig};
 
 use brain_protocol::Identity;
 

--- a/crates/brain/src/model/sse.rs
+++ b/crates/brain/src/model/sse.rs
@@ -2,13 +2,22 @@ use crate::KernelError;
 
 pub struct SseDecoder {
     pending: Vec<u8>,
+    /// How far into `pending` the separator scan has already looked. A model delivers
+    /// one frame across many network chunks, so rescanning from the start of the buffer
+    /// on every chunk costs the square of the chunk count.
+    scanned: usize,
     max_frame: usize,
 }
+
+/// The longest separator is four bytes, so a resumed scan backs up three in case one
+/// straddles the boundary between the last chunk and this one.
+const SEPARATOR_OVERLAP: usize = 3;
 
 impl SseDecoder {
     pub fn new(max_frame: usize) -> Self {
         Self {
             pending: Vec::with_capacity(max_frame.min(8_192)),
+            scanned: 0,
             max_frame,
         }
     }
@@ -17,7 +26,13 @@ impl SseDecoder {
         self.pending.extend_from_slice(chunk);
         let mut events = Vec::new();
         loop {
-            let Some(end) = frame_end(&self.pending) else {
+            let from = self.scanned.saturating_sub(SEPARATOR_OVERLAP);
+            let found = frame_end(&self.pending[from..]).map(|end| FrameEnd {
+                content: end.content + from,
+                length: end.length + from,
+            });
+            let Some(end) = found else {
+                self.scanned = self.pending.len();
                 if self.pending.len() > self.max_frame {
                     return Err(KernelError::Executor(format!(
                         "model SSE frame exceeded {} bytes",
@@ -27,6 +42,8 @@ impl SseDecoder {
                 break;
             };
             let frame: Vec<u8> = self.pending.drain(..end.length).collect();
+            // What remains starts a fresh frame, so the next scan starts at its start.
+            self.scanned = 0;
             let text = std::str::from_utf8(&frame[..end.content]).map_err(|error| {
                 KernelError::Executor(format!("model SSE is not UTF-8: {error}"))
             })?;
@@ -73,6 +90,40 @@ fn frame_end(bytes: &[u8]) -> Option<FrameEnd> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A separator split across two chunks must still be found: the resumed scan backs
+    /// up far enough to see it whole.
+    #[test]
+    fn finds_a_separator_split_across_chunks() {
+        for separator in [&b"\n\n"[..], &b"\r\n\r\n"[..]] {
+            for split in 1..separator.len() {
+                let mut decoder = SseDecoder::new(128);
+                let mut head = b"data: one".to_vec();
+                head.extend_from_slice(&separator[..split]);
+                assert!(decoder.feed(&head).unwrap().is_empty());
+                assert_eq!(
+                    decoder.feed(&separator[split..]).unwrap(),
+                    ["one"],
+                    "a separator split at {split} must still terminate the frame"
+                );
+                assert_eq!(decoder.pending_bytes(), 0);
+            }
+        }
+    }
+
+    /// Several frames in one chunk must all come out, which means the scan offset resets
+    /// when a frame is taken rather than skipping past the next separator.
+    #[test]
+    fn decodes_several_frames_from_one_chunk() {
+        let mut decoder = SseDecoder::new(128);
+        assert_eq!(
+            decoder
+                .feed(b"data: one\n\ndata: two\n\ndata: three")
+                .unwrap(),
+            ["one", "two"]
+        );
+        assert_eq!(decoder.feed(b"\n\n").unwrap(), ["three"]);
+    }
 
     #[test]
     fn decodes_fragmented_and_crlf_frames() {

--- a/crates/brain/src/model/sse.rs
+++ b/crates/brain/src/model/sse.rs
@@ -1,10 +1,21 @@
 use crate::KernelError;
 
+/// Splits a model's byte stream into SSE frames.
+///
+/// Two things here are deliberate, and both were quadratic before:
+///
+/// The separator scan resumes where it stopped. A model delivers one frame across many
+/// network chunks, so restarting the search at the front of the buffer on every chunk
+/// searched the same bytes once per chunk.
+///
+/// Consumed bytes are dropped once per `feed`, not once per frame. Taking each frame off
+/// the front moved every byte behind it, so a chunk carrying many frames moved the tail
+/// of the buffer once per frame in it.
 pub struct SseDecoder {
     pending: Vec<u8>,
-    /// How far into `pending` the separator scan has already looked. A model delivers
-    /// one frame across many network chunks, so rescanning from the start of the buffer
-    /// on every chunk costs the square of the chunk count.
+    /// Bytes at the front of `pending` already returned as frames.
+    consumed: usize,
+    /// How far past `consumed` the separator scan has already looked.
     scanned: usize,
     max_frame: usize,
 }
@@ -17,6 +28,7 @@ impl SseDecoder {
     pub fn new(max_frame: usize) -> Self {
         Self {
             pending: Vec::with_capacity(max_frame.min(8_192)),
+            consumed: 0,
             scanned: 0,
             max_frame,
         }
@@ -25,26 +37,23 @@ impl SseDecoder {
     pub fn feed(&mut self, chunk: &[u8]) -> Result<Vec<String>, KernelError> {
         self.pending.extend_from_slice(chunk);
         let mut events = Vec::new();
+        let overflowed;
         loop {
             let from = self.scanned.saturating_sub(SEPARATOR_OVERLAP);
-            let found = frame_end(&self.pending[from..]).map(|end| FrameEnd {
+            let unread = self.pending.len() - self.consumed;
+            let found = frame_end(&self.pending[self.consumed + from..]).map(|end| FrameEnd {
                 content: end.content + from,
                 length: end.length + from,
             });
             let Some(end) = found else {
-                self.scanned = self.pending.len();
-                if self.pending.len() > self.max_frame {
-                    return Err(KernelError::Executor(format!(
-                        "model SSE frame exceeded {} bytes",
-                        self.max_frame
-                    )));
-                }
+                self.scanned = unread;
+                // Reported after the buffer is compacted below, so the decoder is left
+                // in a consistent state whichever way this call returns.
+                overflowed = unread > self.max_frame;
                 break;
             };
-            let frame: Vec<u8> = self.pending.drain(..end.length).collect();
-            // What remains starts a fresh frame, so the next scan starts at its start.
-            self.scanned = 0;
-            let text = std::str::from_utf8(&frame[..end.content]).map_err(|error| {
+            let content = &self.pending[self.consumed..self.consumed + end.content];
+            let text = std::str::from_utf8(content).map_err(|error| {
                 KernelError::Executor(format!("model SSE is not UTF-8: {error}"))
             })?;
             let data = text
@@ -55,12 +64,27 @@ impl SseDecoder {
             if !data.is_empty() {
                 events.push(data);
             }
+            self.consumed += end.length;
+            // What remains starts a fresh frame, so the next scan starts at its start.
+            self.scanned = 0;
+        }
+        if self.consumed > 0 {
+            self.pending.drain(..self.consumed);
+            self.consumed = 0;
+        }
+        if overflowed {
+            return Err(KernelError::Executor(format!(
+                "model SSE frame exceeded {} bytes",
+                self.max_frame
+            )));
         }
         Ok(events)
     }
 
+    /// Bytes held for a frame that has not terminated yet. Consumed bytes are dropped
+    /// before `feed` returns, so this never counts them.
     pub fn pending_bytes(&self) -> usize {
-        self.pending.len()
+        self.pending.len() - self.consumed
     }
 }
 
@@ -134,6 +158,38 @@ mod tests {
             ["{\"a\":1}", "[DONE]"]
         );
         assert_eq!(decoder.pending_bytes(), 0);
+    }
+
+    /// Many frames in one chunk must not cost the square of their number. The check is
+    /// on work done, not wall time: taking each frame off the front of the buffer moved
+    /// every byte behind it, so the tail was rewritten once per frame.
+    #[test]
+    fn decodes_many_frames_in_one_chunk_without_rewriting_the_buffer() {
+        const FRAMES: usize = 20_000;
+        let mut stream = Vec::new();
+        for index in 0..FRAMES {
+            stream.extend_from_slice(format!("data: {{\"n\":{index}}}\n\n").as_bytes());
+        }
+        let mut decoder = SseDecoder::new(1024 * 1024);
+        let events = decoder.feed(&stream).unwrap();
+        assert_eq!(events.len(), FRAMES);
+        assert_eq!(events[0], "{\"n\":0}");
+        assert_eq!(events[FRAMES - 1], format!("{{\"n\":{}}}", FRAMES - 1));
+        assert_eq!(decoder.pending_bytes(), 0);
+    }
+
+    /// A frame that arrives after several complete ones must still be bounded, which
+    /// means the size check counts only the bytes still held.
+    #[test]
+    fn bounds_a_frame_that_follows_complete_ones() {
+        let mut decoder = SseDecoder::new(16);
+        assert_eq!(decoder.feed(b"data: a\n\ndata: b\n\n").unwrap(), ["a", "b"]);
+        assert_eq!(decoder.pending_bytes(), 0);
+        assert!(decoder.feed(b"data: ").unwrap().is_empty());
+        assert!(
+            decoder.feed(&[b'x'; 32]).is_err(),
+            "an unterminated frame past the bound must be rejected even after complete ones"
+        );
     }
 
     #[test]

--- a/crates/brain/src/session/actor.rs
+++ b/crates/brain/src/session/actor.rs
@@ -45,7 +45,7 @@ pub struct SessionActor {
 impl SessionActor {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        row: SessionRow,
+        mut row: SessionRow,
         store: Arc<dyn JournalStore>,
         loop_executor: Arc<dyn LoopExecutor>,
         model_executor: Arc<dyn ModelExecutor>,
@@ -54,9 +54,13 @@ impl SessionActor {
         receiver: mpsc::Receiver<SessionCommand>,
         cancel_requested: Arc<AtomicBool>,
     ) -> Result<Self, KernelError> {
-        let sealed: SealedSessionConfig = serde_json::from_value(row.configuration.clone())
-            .map_err(|error| KernelError::Journal(error.to_string()))?;
-        let context = serde_json::from_value(row.context.clone())
+        // The row is owned, and neither value is read again after this: `sealed` and
+        // `context` replace them. Cloning first deep-copied the whole configuration and
+        // the whole context on every rehydration.
+        let sealed: SealedSessionConfig =
+            serde_json::from_value(std::mem::take(&mut row.configuration))
+                .map_err(|error| KernelError::Journal(error.to_string()))?;
+        let context = serde_json::from_value(std::mem::take(&mut row.context))
             .map_err(|error| KernelError::Journal(error.to_string()))?;
         let presentation_bytes = brain_protocol::canonical_json(&serde_json::json!({
             "brain_configuration": sealed.brain_configuration,

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -117,22 +117,14 @@ impl Kernel {
     }
 
     pub fn session(&self, session_id: &SessionId) -> Result<Session, KernelError> {
-        let row = self
-            .inner
+        self.inner
             .store
-            .session(session_id)?
-            .ok_or_else(|| KernelError::InvalidState("session not found".into()))?;
-        Ok(public_session(&row))
+            .session_summary(session_id)?
+            .ok_or_else(|| KernelError::InvalidState("session not found".into()))
     }
 
     pub fn sessions(&self) -> Result<Vec<Session>, KernelError> {
-        Ok(self
-            .inner
-            .store
-            .sessions()?
-            .iter()
-            .map(public_session)
-            .collect())
+        self.inner.store.session_summaries()
     }
 
     pub fn handle(&self, session_id: &SessionId) -> Result<SessionHandle, KernelError> {
@@ -153,7 +145,7 @@ impl Kernel {
         let row = self
             .inner
             .store
-            .session(session_id)?
+            .session_row(session_id)?
             .ok_or_else(|| KernelError::InvalidState("session not found".into()))?;
         self.spawn(row)
     }
@@ -192,7 +184,7 @@ impl Kernel {
         let row = self
             .inner
             .store
-            .session(session_id)?
+            .session_row(session_id)?
             .ok_or_else(|| KernelError::InvalidState("session not found".into()))?;
         serde_json::from_value(row.configuration)
             .map_err(|error| KernelError::Journal(error.to_string()))
@@ -212,7 +204,7 @@ impl Kernel {
         let row = self
             .inner
             .store
-            .session(session_id)?
+            .session_summary(session_id)?
             .ok_or_else(|| KernelError::InvalidState("session not found".into()))?;
         if !matches!(row.status, SessionStatus::Idle) {
             return Err(KernelError::InvalidState("session is not idle".into()));
@@ -242,7 +234,7 @@ impl Kernel {
         let row = self
             .inner
             .store
-            .session(session_id)?
+            .session_summary(session_id)?
             .ok_or_else(|| KernelError::InvalidState("session not found".into()))?;
         self.inner.store.append(
             session_id,
@@ -260,10 +252,10 @@ impl Kernel {
         let mut row = self
             .inner
             .store
-            .session(session_id)?
+            .session_summary(session_id)?
             .ok_or_else(|| KernelError::InvalidState("session not found".into()))?;
         if matches!(row.status, SessionStatus::Ended) {
-            return Ok(public_session(&row));
+            return Ok(row);
         }
         if !matches!(row.status, SessionStatus::Idle) {
             return Err(KernelError::InvalidState("session is not idle".into()));
@@ -285,7 +277,7 @@ impl Kernel {
             .lock()
             .map_err(|_| KernelError::InvalidState("session map poisoned".into()))?
             .remove(session_id);
-        Ok(public_session(&row))
+        Ok(row)
     }
 
     pub fn idempotency_get<T: serde::Serialize>(
@@ -300,7 +292,9 @@ impl Kernel {
     }
 
     fn recover_interrupted(&self) -> Result<(), KernelError> {
-        for row in self.inner.store.sessions()? {
+        // Summaries, not rows: recovery reads only status, id and sequence, and at
+        // startup there is one live row per session on disk to clone otherwise.
+        for row in self.inner.store.session_summaries()? {
             let classification = match row.status {
                 SessionStatus::Creating => Some("session_creation_interrupted"),
                 SessionStatus::Running => Some("operation_outcome_ambiguous"),
@@ -735,16 +729,6 @@ fn identity_valid(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-}
-
-fn public_session(row: &SessionRow) -> Session {
-    Session {
-        session_id: row.session_id.clone(),
-        journal_id: row.journal_id.clone(),
-        status: row.status.clone(),
-        through_sequence: row.through_sequence,
-        presentation_identity: row.presentation_identity,
-    }
 }
 
 fn random_id(prefix: &str) -> String {

--- a/crates/brain/tests/journal_growth.rs
+++ b/crates/brain/tests/journal_growth.rs
@@ -229,7 +229,7 @@ async fn the_session_row_still_holds_the_final_context_after_the_turn() {
     // the row is the only thing rehydration reads, and `Decision::Finish` historically
     // relied on the per-decision write having already persisted it.
     let store = brain::SegmentJournal::open(&data_dir.join("journal")).unwrap();
-    let row = brain::JournalStore::session(&store, &session_id)
+    let row = brain::JournalStore::session_row(&store, &session_id)
         .unwrap()
         .unwrap();
     let items = row.context["items"].as_array().unwrap().len();

--- a/crates/brain/tests/journal_growth.rs
+++ b/crates/brain/tests/journal_growth.rs
@@ -64,6 +64,8 @@ impl LoopExecutor for GrowingLoop {
             "role": "assistant",
             "content": "x".repeat(ITEM_BYTES),
         }));
+        // A counter seeded at `DECISIONS - 1` finishes on its first activation of every
+        // turn, which is how the turn-axis test below gets one decision per turn.
         let decision = if activation + 1 < DECISIONS {
             Decision::Model {
                 request: ModelRequest {
@@ -348,4 +350,77 @@ fn start(kernel: &Kernel, sealed: SealedSessionConfig) -> SessionHandle {
         .unwrap()
         .complete(sealed)
         .unwrap()
+}
+
+/// The same defect on the other axis: turns, not decisions.
+///
+/// `finish_turn` writes a `$session` state frame carrying the whole context at the end
+/// of every turn, and the context grows across turns as the conversation accumulates. So
+/// a session that runs T turns, each adding C bytes, writes `C*T*(T+1)/2` bytes of
+/// journal — the sum of every intermediate context, not the final one. Unlike the
+/// decision axis, which the kernel caps at `BRAIN_MAX_DECISIONS`, nothing bounds T.
+///
+/// Every one of those bytes is also read back and parsed at every restart, so the same
+/// term shows up in cold start.
+///
+/// Measured at `TURNS = 64` on 2026-08-28: one 16 KiB item per turn produced 34,199,242
+/// bytes of journal for a 1 MiB context, 32.6x. The closed form predicts `(T+1)/2` =
+/// 32.5x, so what is being measured is the per-turn write and not overhead around it.
+///
+/// IGNORED because it fails today and describes work that is not done. It is the
+/// acceptance test for that work: remove the `#[ignore]` when the per-turn context write
+/// goes away, and it will hold the fix in place. See `PERF-REVIEW.md` finding X0.
+#[tokio::test]
+#[ignore = "records a known defect: the journal grows with the square of the turn count"]
+async fn a_session_does_not_journal_one_context_copy_per_turn() {
+    /// Turns in the measured session. Far below anything a real conversation reaches.
+    const TURNS: usize = 64;
+    /// The same constant-multiple bound the decision-axis test uses, for the same
+    /// reason: a fixed number of copies of the final context is fine, one per turn
+    /// is not.
+    const MAX_RATIO: u64 = 8;
+
+    let data_dir = temporary_directory();
+    let (publisher, _worker) = telemetry_channel();
+    let kernel = Kernel::open(
+        KernelConfig {
+            data_dir: data_dir.clone(),
+            max_decisions_per_turn: 4,
+            loop_executor: Arc::new(GrowingLoop {
+                // One activation per turn, so the growth measured is turns.
+                activations: AtomicUsize::new(DECISIONS - 1),
+            }),
+            model_executor: Arc::new(TinyModel),
+            tool_executor: Arc::new(NoTools),
+        },
+        publisher,
+    )
+    .unwrap();
+    let handle = start(&kernel, request());
+    for _ in 0..TURNS {
+        handle
+            .message(MessageRequest {
+                content: serde_json::json!("go"),
+            })
+            .await
+            .unwrap();
+    }
+    drop(handle);
+    drop(kernel);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let journal_bytes: u64 = fs::read_dir(data_dir.join("journal"))
+        .unwrap()
+        .map(|entry| entry.unwrap().metadata().unwrap().len())
+        .sum();
+    let context_bytes = (TURNS * ITEM_BYTES) as u64;
+    let ratio = journal_bytes as f64 / context_bytes as f64;
+    let held = journal_bytes <= context_bytes * MAX_RATIO;
+    fs::remove_dir_all(data_dir).unwrap();
+    assert!(
+        held,
+        "a {TURNS}-turn session journalled {journal_bytes} bytes for a {context_bytes}-byte \
+         context ({ratio:.1}x, bound {MAX_RATIO}x): the kernel is writing the whole context \
+         once per turn, so the log grows with the square of the turn count"
+    );
 }

--- a/crates/brain/tests/journal_throughput.rs
+++ b/crates/brain/tests/journal_throughput.rs
@@ -80,7 +80,7 @@ fn reports_what_the_journal_costs() {
     let replay = at.elapsed().as_secs_f64() * 1e3;
     assert_eq!(
         reopened
-            .session(&session_id)
+            .session_row(&session_id)
             .unwrap()
             .unwrap()
             .through_sequence,

--- a/crates/brain/tests/kernel.rs
+++ b/crates/brain/tests/kernel.rs
@@ -281,7 +281,7 @@ async fn restart_marks_an_inflight_turn_ambiguous_instead_of_guessing() {
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
     let store = SegmentJournal::open(&data_dir.join("journal")).unwrap();
-    let row = store.session(&session_id).unwrap().unwrap();
+    let row = store.session_row(&session_id).unwrap().unwrap();
     store
         .append(
             &session_id,

--- a/crates/brain/tests/session_listing.rs
+++ b/crates/brain/tests/session_listing.rs
@@ -1,0 +1,160 @@
+//! Reading a session must not copy the conversation it is not returning.
+//!
+//! A session row holds the whole sealed configuration and the whole context. What a
+//! caller outside the kernel can see is five small fields. When the journal answered
+//! `sessions()` with cloned rows, every list of N sessions deep-copied N configurations
+//! and N conversations and then dropped them: a page of the session list allocated
+//! proportionally to how much the sessions had been used, and startup recovery — which
+//! reads only status and sequence — did the same for every session on disk.
+//!
+//! These tests bound the allocation rather than the wall time, because allocation is the
+//! part that is deterministic on any machine.
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use brain::{AppendRecord, JournalStore, SegmentJournal, journal::SessionRow};
+use brain_protocol::{Identity, JournalId, SessionId, SessionStatus};
+
+/// Counts bytes handed out, so a test can measure one call rather than a whole process.
+struct Counting;
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(pointer, layout) }
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATED.fetch_add(new_size.saturating_sub(layout.size()), Ordering::Relaxed);
+        unsafe { System.realloc(pointer, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn measure<T>(call: impl FnOnce() -> T) -> (T, usize) {
+    let before = ALLOCATED.load(Ordering::Relaxed);
+    let value = call();
+    (value, ALLOCATED.load(Ordering::Relaxed) - before)
+}
+
+/// Sessions in the listing.
+const SESSIONS: usize = 8;
+
+/// Context bytes per session. One turn of a real conversation is already this large.
+const CONTEXT_BYTES: usize = 256 * 1024;
+
+/// A listing may allocate for its own vector and its ids; it may not allocate a copy of
+/// even one session's context. Measured: 896 bytes to list eight sessions and 16 bytes to
+/// read one, against 4,205,528 and 525,595 when the journal cloned whole rows. The bound
+/// sits far from both regimes.
+const MAX_LISTING_BYTES: usize = CONTEXT_BYTES / 4;
+
+fn journal_with_sessions(directory: &Path) -> SegmentJournal {
+    let journal = SegmentJournal::open(directory).unwrap();
+    let filler = serde_json::Value::String("x".repeat(CONTEXT_BYTES));
+    for index in 0..SESSIONS {
+        let row = SessionRow {
+            session_id: SessionId::new(format!("ses_{index:04}")),
+            journal_id: JournalId::new(format!("jrn_{index:04}")),
+            status: SessionStatus::Idle,
+            through_sequence: 1,
+            configuration: serde_json::json!({ "sealed": filler }),
+            context: serde_json::json!({ "items": filler }),
+            presentation_identity: Identity::of_bytes(b"presentation"),
+        };
+        journal
+            .create_session(
+                &row,
+                AppendRecord::new("session_created", serde_json::json!({})),
+            )
+            .unwrap();
+    }
+    journal
+}
+
+fn temporary_directory(name: &str) -> PathBuf {
+    let directory = std::env::temp_dir().join(format!(
+        "brain-listing-{name}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&directory).unwrap();
+    directory
+}
+
+#[test]
+fn listing_sessions_does_not_copy_their_contexts() {
+    let directory = temporary_directory("list");
+    let journal = journal_with_sessions(&directory);
+
+    let (sessions, allocated) = measure(|| journal.session_summaries().unwrap());
+
+    assert_eq!(sessions.len(), SESSIONS);
+    assert_eq!(sessions[0].session_id.as_str(), "ses_0000");
+    assert!(
+        allocated <= MAX_LISTING_BYTES,
+        "listing {SESSIONS} sessions allocated {allocated} bytes for a \
+         {CONTEXT_BYTES}-byte context each (bound {MAX_LISTING_BYTES}): the journal is \
+         cloning whole rows to answer a summary"
+    );
+
+    drop(journal);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+#[test]
+fn reading_one_session_does_not_copy_its_context() {
+    let directory = temporary_directory("get");
+    let journal = journal_with_sessions(&directory);
+    let wanted = SessionId::new("ses_0003");
+
+    let (session, allocated) = measure(|| journal.session_summary(&wanted).unwrap());
+
+    let session = session.expect("the session was created above");
+    assert_eq!(session.session_id, wanted);
+    assert!(
+        allocated <= MAX_LISTING_BYTES,
+        "reading one session allocated {allocated} bytes for a {CONTEXT_BYTES}-byte \
+         context (bound {MAX_LISTING_BYTES})"
+    );
+
+    drop(journal);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+/// The full row is still available where it is genuinely needed — rehydrating a session
+/// actor — and it still carries what the actor rebuilds itself from.
+#[test]
+fn the_full_row_is_still_reachable_for_rehydration() {
+    let directory = temporary_directory("row");
+    let journal = journal_with_sessions(&directory);
+
+    let row = journal
+        .session_row(&SessionId::new("ses_0005"))
+        .unwrap()
+        .expect("the session was created above");
+
+    assert_eq!(row.context["items"].as_str().unwrap().len(), CONTEXT_BYTES);
+    assert_eq!(
+        row.configuration["sealed"].as_str().unwrap().len(),
+        CONTEXT_BYTES
+    );
+
+    drop(journal);
+    fs::remove_dir_all(directory).unwrap();
+}


### PR DESCRIPTION
Everything both performance reviews marked **keep**, with the measurement each one
rests on. Nothing here changes a contract, a wire field or a durable format.

## What landed

| Change | Measured |
| :--- | ---: |
| `ServerModelExecutor` shares one `reqwest::Client` instead of building one per model call | 4.1x per call, 3.9x less allocation on loopback; 12.1% lower whole-turn p50 on ARM, and a TLS handshake per call avoided against a real gateway |
| `SseDecoder` resumes its scan offset **and** drops consumed bytes once per feed, not once per frame | 37x on a fragmented 256 KiB frame; **278x** on 100k frames in one chunk (3.35 s -> 12.0 ms). Linear on both axes now |
| `KeyedLocks` sweeps when the table doubles, not on every acquire | flat instead of O(live sessions) per request; 172.9 us -> 72 ns at 50k keys |
| `SegmentLog::encode` builds the frame in one buffer; frames stage as `Arc<Vec<u8>>` | allocation per append 7.00x the payload -> **4.00x** |
| Replay decodes a `$session` frame into a struct and moves it, instead of building a `Value` and cloning out of it | opening a 259 MiB journal: 820 -> **540 MiB**, 3.01x -> 2.01x the bytes read |
| `WorkerPool::activate` stops serialising the input to measure it; the bound is enforced where the frame is written | one full context serialisation per decision removed; 1.9x-3.0x on the activation encode from 1 KiB to 16 MiB |
| `SessionActor::new` consumes the row instead of cloning it | no deep clone of configuration and context per rehydration |
| **New:** `JournalStore` distinguishes a row from a summary | 896 bytes to list eight sessions and 16 bytes to read one, against 4,205,528 and 525,595 |
| **New:** the image build strips the symbol table | 22-25% smaller server and worker |

## Tests

- `crates/brain/tests/session_listing.rs` bounds the allocation of a session read
  against a 256 KiB context. It fails on the previous behaviour (4.2 MB against a
  64 KiB bound), so it is an acceptance test rather than a placeholder.
- `crates/brain/tests/journal_growth.rs` gains a turn-axis case, committed
  `#[ignore]`d because it fails today at 32.6x against a closed form of 32.5x. It is
  the acceptance test for the largest open defect: the journal grows with the square
  of the turn count.

## What was rejected, with numbers

`InstancePre` and the pooling allocator (1.0x, 0.9x - Wasm instantiation is not the
cost); fuel metering (~10% of an activation, not 2x); the 10 ms cancellation poll
(within noise); `RUST_LOG=warn` (slower); removing Wasmtime async, Axum WebSocket or
epoch support (0.02-0.14% of binary size); parallel SQLite binding writes (0.99x of
serial). A two-pass replay - the obvious cold-start fix - was implemented, measured
at 257 ms against the forward pass's 161 ms, and reverted.

`panic=abort` is 10-12% smaller but is left out: it is a crash-policy decision, not
a performance one.

## Not in this PR

The four architectural findings both reviews rank above everything here: the
turn-axis journal quadratic, the three-permit loophost ceiling, idempotency records
that never expire and pin all disk reclamation, and the unbounded writer queue.
Each changes a durable format, a public trait or an API contract.

Evidence: `aex-research/docs/brain-performance-spikes-2026-08-28.md` (ARM/AWS) and
`brain-performance-{review,verdicts}-opus-2026-08-28.md`.