### PR TITLE
perf: give an activation a real wall-clock bound, and stop re-reading credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "wasm-encoder",
  "wasmtime",
 ]
 

--- a/crates/brain-loophost/Cargo.toml
+++ b/crates/brain-loophost/Cargo.toml
@@ -33,3 +33,6 @@ wasmtime = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+# Builds the smallest possible runaway guest for the epoch-deadline test. Already in the
+# lock file as a Wasmtime component dependency, so it costs no new crate.
+wasm-encoder = "0.254"

--- a/crates/brain-loophost/src/runtime.rs
+++ b/crates/brain-loophost/src/runtime.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use brain_protocol::{
     ActivationInput, ActivationOutput, AgentloopIdentity, ContextEnvelope, Decision, Observation,
@@ -6,9 +6,16 @@ use brain_protocol::{
 };
 use sha2::{Digest as _, Sha256};
 use wasmtime::component::{Component, Linker};
-use wasmtime::{Cache, Config, Engine, Store, StoreLimits, StoreLimitsBuilder};
+use wasmtime::{Cache, Config, Engine, Store, StoreLimits, StoreLimitsBuilder, Trap};
 
 use crate::{AgentloopPackage, LoopLimits};
+
+/// How often the engine's epoch advances. This is the granularity of a guest's
+/// wall-clock bound: an activation is trapped somewhere inside the last tick of its
+/// budget. Fine enough that a two-second budget is held to within half a percent,
+/// coarse enough that the ticker costs one atomic store every ten milliseconds for
+/// the whole process.
+const EPOCH_TICK: Duration = Duration::from_millis(10);
 
 mod bindings {
     wasmtime::component::bindgen!({
@@ -31,15 +38,19 @@ pub struct AdmittedAgentloop {
 impl AdmissionEngine {
     pub fn new(limits: LoopLimits, allowed_imports: Vec<String>) -> Result<Self, String> {
         let mut config = Config::new();
-        config
-            .wasm_component_model(true)
-            .consume_fuel(true)
-            .epoch_interruption(true);
+        // Epoch interruption, not fuel. Both bound a runaway guest at the same places —
+        // loop backedges and function entries — but fuel decrements and checks a counter
+        // at each one, where an epoch check is a load and a compare against a value the
+        // ticker below advances. Fuel cost 5-13% of an activation and bounded work
+        // rather than time, so its limit had no relationship to the wall-clock budget
+        // the supervisor enforces.
+        config.wasm_component_model(true).epoch_interruption(true);
         let cache = Cache::from_file(None).map_err(|error| {
             format!("failed to configure the Wasmtime compilation cache: {error}")
         })?;
         config.cache(Some(cache));
         let engine = Engine::new(&config).map_err(|error| error.to_string())?;
+        spawn_epoch_ticker(&engine)?;
         Ok(Self {
             engine,
             limits,
@@ -104,20 +115,64 @@ impl AdmittedAgentloop {
             .build();
         let mut store = Store::new(engine, store_limits);
         store.limiter(|limits| limits);
-        store
-            .set_fuel(1_000_000_000)
-            .map_err(|error| error.to_string())?;
-        store.set_epoch_deadline(1);
+        // The guest's own wall-clock bound. Until this was driven, `epoch_deadline(1)`
+        // could never be reached — nothing advanced the epoch — so the only limit on an
+        // activation was the supervisor's IPC timeout, which abandons the worker and
+        // every warm instance in it. A trap here costs one instance.
+        store.set_epoch_deadline(epoch_deadline_ticks(limits.wall_time));
         let linker = Linker::<StoreLimits>::new(engine);
         let bindings = bindings::Agentloop::instantiate(&mut store, &self.component, &linker)
             .map_err(|error| error.to_string())?;
         let input = to_wit_input(input)?;
         let output = bindings
             .call_step(&mut store, &input)
-            .map_err(|error| error.to_string())?
+            .map_err(activation_error)?
             .map_err(|error| format!("{}: {}", error.code, error.message))?;
         from_wit_output(output)
     }
+}
+
+/// A guest stopped by its epoch deadline reports the wall-time limit it exceeded, not
+/// the trap that stopped it. The message is the one the supervisor's timeout has always
+/// returned, so what a client sees is unchanged by where the bound is now enforced.
+fn activation_error(error: wasmtime::Error) -> String {
+    if error.downcast_ref::<Trap>() == Some(&Trap::Interrupt) {
+        return "Agentloop activation exceeded its wall-time limit".into();
+    }
+    error.to_string()
+}
+
+/// Advances the engine's epoch until the engine is dropped. Held as a weak reference so
+/// the ticker does not keep an engine alive, and so a process that builds one and drops
+/// it does not leak a thread.
+fn spawn_epoch_ticker(engine: &Engine) -> Result<(), String> {
+    let weak = engine.weak();
+    std::thread::Builder::new()
+        .name("agentloop-epoch".into())
+        .spawn(move || {
+            loop {
+                match weak.upgrade() {
+                    // Dropped before sleeping: holding it across the sleep would keep the
+                    // engine alive for a tick past its last owner, and forever if the
+                    // upgrade were held in a binding that outlived the loop body.
+                    Some(engine) => {
+                        engine.increment_epoch();
+                        drop(engine);
+                    }
+                    None => return,
+                }
+                std::thread::sleep(EPOCH_TICK);
+            }
+        })
+        .map_err(|error| format!("failed to start the Agentloop epoch ticker: {error}"))?;
+    Ok(())
+}
+
+/// Ticks that cover `budget`, at least one. A guest is trapped after this many epoch
+/// increments, so it runs for at most `budget` plus the tick it was in.
+fn epoch_deadline_ticks(budget: Duration) -> u64 {
+    let ticks = budget.as_nanos().div_ceil(EPOCH_TICK.as_nanos());
+    u64::try_from(ticks).unwrap_or(u64::MAX).max(1)
 }
 
 fn to_wit_input(
@@ -277,4 +332,137 @@ fn hex_digest(bytes: &[u8]) -> String {
         let _ = write!(output, "{byte:02x}");
     }
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::mpsc,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    use wasm_encoder::{
+        BlockType, CodeSection, ExportKind, ExportSection, Function, FunctionSection, Instruction,
+        Module, TypeSection, ValType,
+    };
+    use wasmtime::{Instance, Module as CoreModule, Store, Trap};
+
+    use super::*;
+
+    /// The guest's budget in these tests. Short, because the test waits it out.
+    const BUDGET: Duration = Duration::from_millis(200);
+
+    /// How long before the guest is called unstopped. Far above the budget, so a loaded
+    /// machine or a coarse sleep clock cannot fail it, and far below "forever", which is
+    /// what this test exists to rule out.
+    const CEILING: Duration = Duration::from_secs(20);
+
+    #[test]
+    fn a_budget_becomes_at_least_one_tick() {
+        assert_eq!(epoch_deadline_ticks(Duration::ZERO), 1);
+        assert_eq!(epoch_deadline_ticks(Duration::from_nanos(1)), 1);
+        assert_eq!(epoch_deadline_ticks(EPOCH_TICK), 1);
+        // Rounded up, so the guest is never given less time than its budget.
+        assert_eq!(
+            epoch_deadline_ticks(EPOCH_TICK + Duration::from_nanos(1)),
+            2
+        );
+        assert_eq!(epoch_deadline_ticks(Duration::from_secs(2)), 200);
+        assert_eq!(epoch_deadline_ticks(Duration::MAX), u64::MAX);
+    }
+
+    /// `(func (export "spin") (loop (br 0)))` - a backedge and nothing else, so the only
+    /// way out is a trap at the loop's interruption check.
+    fn spinning_module() -> Vec<u8> {
+        let mut module = Module::new();
+
+        let mut types = TypeSection::new();
+        types
+            .ty()
+            .function(Vec::<ValType>::new(), Vec::<ValType>::new());
+        module.section(&types);
+
+        let mut functions = FunctionSection::new();
+        functions.function(0);
+        module.section(&functions);
+
+        let mut exports = ExportSection::new();
+        exports.export("spin", ExportKind::Func, 0);
+        module.section(&exports);
+
+        let mut code = CodeSection::new();
+        let mut spin = Function::new([]);
+        spin.instruction(&Instruction::Loop(BlockType::Empty));
+        spin.instruction(&Instruction::Br(0));
+        spin.instruction(&Instruction::End);
+        spin.instruction(&Instruction::End);
+        code.function(&spin);
+        module.section(&code);
+
+        module.finish()
+    }
+
+    /// The engine was configured for epoch interruption, but nothing advanced the epoch,
+    /// so the deadline could not fire and fuel - a bound on work, not on time - was the
+    /// only limit inside the instance. This drives the mechanism directly rather than
+    /// through an Agentloop component: the guest is the smallest module that never
+    /// returns, so what it proves is that the epoch advances and that a deadline set
+    /// against it traps.
+    #[test]
+    fn a_guest_that_never_returns_is_trapped_within_its_budget() {
+        let admission = AdmissionEngine::new(
+            LoopLimits {
+                wall_time: BUDGET,
+                ..LoopLimits::default()
+            },
+            Vec::new(),
+        )
+        .unwrap();
+        let engine = admission.engine();
+
+        let module = CoreModule::new(engine, spinning_module()).unwrap();
+        let mut store = Store::new(engine, ());
+        store.set_epoch_deadline(epoch_deadline_ticks(BUDGET));
+        let instance = Instance::new(&mut store, &module, &[]).unwrap();
+        let spin = instance
+            .get_typed_func::<(), ()>(&mut store, "spin")
+            .unwrap();
+
+        // Run the guest on its own thread and wait with a clock. If the deadline never
+        // fires this fails at `CEILING` instead of hanging until CI gives up.
+        let (finished, waiting) = mpsc::channel();
+        let started = Instant::now();
+        thread::spawn(move || {
+            let _ = finished.send(spin.call(&mut store, ()));
+        });
+        let outcome = waiting.recv_timeout(CEILING).unwrap_or_else(|_| {
+            panic!("the guest was still running after {CEILING:?} on a {BUDGET:?} budget")
+        });
+        let elapsed = started.elapsed();
+
+        let error = outcome.expect_err("a guest that never returns must not return");
+        assert_eq!(
+            error.downcast_ref::<Trap>(),
+            Some(&Trap::Interrupt),
+            "the guest must be stopped by the epoch deadline, not by anything else: {error}"
+        );
+        assert_eq!(
+            activation_error(error),
+            "Agentloop activation exceeded its wall-time limit"
+        );
+        assert!(
+            elapsed < CEILING,
+            "the guest ran for {elapsed:?} against a {BUDGET:?} budget"
+        );
+    }
+
+    /// The ticker holds only a weak reference back, so building an engine and dropping it
+    /// leaves no thread running.
+    #[test]
+    fn an_engine_can_be_dropped_while_its_epoch_is_being_driven() {
+        for _ in 0..4 {
+            drop(AdmissionEngine::new(LoopLimits::default(), Vec::new()).unwrap());
+        }
+    }
 }

--- a/crates/brain-loophost/src/supervisor.rs
+++ b/crates/brain-loophost/src/supervisor.rs
@@ -1,9 +1,13 @@
-use std::{collections::HashSet, path::PathBuf, sync::Arc};
+use std::{collections::HashSet, path::PathBuf, sync::Arc, time::Duration};
 
 use brain_protocol::{ActivationInput, ActivationOutput, AgentloopIdentity};
 use tokio::sync::{Mutex, Semaphore};
 
 use crate::{AgentloopPackage, LoopLimits, WorkerClient};
+
+/// How long after a guest's own wall-clock bound the supervisor gives up on the worker
+/// itself. Covers the IPC round trip and anything an epoch cannot interrupt.
+const WORKER_BACKSTOP: Duration = Duration::from_secs(1);
 
 pub struct WorkerPool {
     worker_binary: PathBuf,
@@ -103,7 +107,13 @@ impl WorkerPool {
         }
         let client = WorkerClient::new(&self.socket);
         let call = client.activate(digest, input, self.limits.activation_input_bytes);
-        match tokio::time::timeout(self.limits.wall_time, call).await {
+        // The guest is stopped by its own epoch deadline at `wall_time`, which costs one
+        // instance. This timeout is the backstop for what an epoch cannot interrupt — a
+        // worker blocked in a host call, a crashed worker, a socket that never answers —
+        // and it stops the worker, taking every warm component with it. It must therefore
+        // be strictly later than the bound the guest enforces on itself, or it fires
+        // first and pays the expensive price for the cheap failure.
+        match tokio::time::timeout(self.limits.wall_time + WORKER_BACKSTOP, call).await {
             Ok(Ok(output)) => {
                 let output_bytes =
                     serde_json::to_vec(&output).map_err(|error| error.to_string())?;

--- a/crates/brain-server/src/model_binding.rs
+++ b/crates/brain-server/src/model_binding.rs
@@ -1,8 +1,9 @@
 use std::{
+    collections::HashMap,
     fs::{self, OpenOptions},
     io::Write,
     path::Path,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
@@ -23,6 +24,7 @@ use zeroize::Zeroizing;
 const KEY_BYTES: usize = 32;
 const NONCE_BYTES: usize = 12;
 
+#[derive(Clone)]
 pub struct ModelCredential {
     pub provider: String,
     pub api_key: Zeroizing<String>,
@@ -37,6 +39,20 @@ pub trait ModelBindingStore: Send + Sync + 'static {
 pub struct LocalModelBindingStore {
     connection: Mutex<Connection>,
     key: Zeroizing<[u8; KEY_BYTES]>,
+    /// Credentials already read from the database, so that a model call is not a
+    /// `synchronous = FULL` query plus an AES-GCM decrypt behind a process-global mutex
+    /// on a Tokio worker thread. Every decision of every turn takes this path.
+    ///
+    /// Safe to cache because a binding is sealed at creation: `put` on an existing
+    /// identity either matches the stored credential or fails, so an entry cannot go
+    /// stale. Misses are not cached, so a later `put` is still visible, and `delete`
+    /// evicts. The plaintext lives no longer than the master key already does — that key
+    /// is resident for the life of the process, so anything that can read this map could
+    /// already decrypt the table.
+    ///
+    /// Bounded by the number of rows: an entry only appears after a successful read, and
+    /// a row only appears through `put`.
+    cached: RwLock<HashMap<String, ModelCredential>>,
 }
 
 impl LocalModelBindingStore {
@@ -63,7 +79,25 @@ impl LocalModelBindingStore {
         Ok(Self {
             connection: Mutex::new(connection),
             key: Zeroizing::new(key),
+            cached: RwLock::new(HashMap::new()),
         })
+    }
+
+    fn cache_read(
+        &self,
+    ) -> Result<std::sync::RwLockReadGuard<'_, HashMap<String, ModelCredential>>, KernelError> {
+        self.cached
+            .read()
+            .map_err(|_| KernelError::Journal("model binding cache is poisoned".into()))
+    }
+
+    fn cache_write(
+        &self,
+    ) -> Result<std::sync::RwLockWriteGuard<'_, HashMap<String, ModelCredential>>, KernelError>
+    {
+        self.cached
+            .write()
+            .map_err(|_| KernelError::Journal("model binding cache is poisoned".into()))
     }
 
     fn decrypt(
@@ -152,31 +186,40 @@ impl ModelBindingStore for LocalModelBindingStore {
     }
 
     fn get(&self, binding_id: &str) -> Result<Option<ModelCredential>, KernelError> {
-        let connection = self
-            .connection
-            .lock()
-            .map_err(|_| KernelError::Journal("model binding mutex poisoned".into()))?;
-        let row = connection
-            .query_row(
-                "SELECT provider, nonce, ciphertext FROM model_bindings WHERE binding_id=?1",
-                [binding_id],
-                |row| {
-                    Ok((
-                        row.get::<_, String>(0)?,
-                        row.get::<_, Vec<u8>>(1)?,
-                        row.get::<_, Vec<u8>>(2)?,
-                    ))
-                },
-            )
-            .optional()
-            .map_err(db_error)?;
-        row.map(|(provider, nonce, ciphertext)| {
-            self.decrypt(binding_id, provider, nonce, ciphertext)
-        })
-        .transpose()
+        if let Some(credential) = self.cache_read()?.get(binding_id) {
+            return Ok(Some(credential.clone()));
+        }
+        let row = {
+            let connection = self
+                .connection
+                .lock()
+                .map_err(|_| KernelError::Journal("model binding mutex poisoned".into()))?;
+            connection
+                .query_row(
+                    "SELECT provider, nonce, ciphertext FROM model_bindings WHERE binding_id=?1",
+                    [binding_id],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, Vec<u8>>(1)?,
+                            row.get::<_, Vec<u8>>(2)?,
+                        ))
+                    },
+                )
+                .optional()
+                .map_err(db_error)?
+        };
+        let Some((provider, nonce, ciphertext)) = row else {
+            return Ok(None);
+        };
+        let credential = self.decrypt(binding_id, provider, nonce, ciphertext)?;
+        self.cache_write()?
+            .insert(binding_id.to_owned(), credential.clone());
+        Ok(Some(credential))
     }
 
     fn delete(&self, binding_id: &str) -> Result<(), KernelError> {
+        self.cache_write()?.remove(binding_id);
         self.connection
             .lock()
             .map_err(|_| KernelError::Journal("model binding mutex poisoned".into()))?
@@ -313,6 +356,85 @@ mod tests {
             !database
                 .windows(selection.api_key.len())
                 .any(|window| window == selection.api_key.as_bytes())
+        );
+        drop(store);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// Deletes the row behind the store's back, so a `get` that still answers can only
+    /// have answered from memory. Every model decision takes this path, and it used to be
+    /// a `synchronous = FULL` query plus an AES-GCM decrypt under a process-global mutex.
+    #[test]
+    fn a_credential_is_read_from_the_database_once() {
+        let directory = temporary_directory();
+        let store = LocalModelBindingStore::open(&directory).unwrap();
+        let selection = ModelSelection {
+            provider: "vercel-ai-gateway".into(),
+            name: "openai/gpt-5-mini".into(),
+            api_key: "cached-secret".into(),
+        };
+        store.put("model_one", &selection).unwrap();
+        assert_eq!(
+            store.get("model_one").unwrap().unwrap().api_key.as_str(),
+            "cached-secret"
+        );
+
+        Connection::open(directory.join("bindings.sqlite3"))
+            .unwrap()
+            .execute("DELETE FROM model_bindings", [])
+            .unwrap();
+
+        let credential = store
+            .get("model_one")
+            .unwrap()
+            .expect("a cached credential must not need the row it came from");
+        assert_eq!(credential.api_key.as_str(), "cached-secret");
+
+        drop(store);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn deleting_a_binding_forgets_its_credential() {
+        let directory = temporary_directory();
+        let store = LocalModelBindingStore::open(&directory).unwrap();
+        let selection = ModelSelection {
+            provider: "vercel-ai-gateway".into(),
+            name: "openai/gpt-5-mini".into(),
+            api_key: "revoked-secret".into(),
+        };
+        store.put("model_one", &selection).unwrap();
+        store.get("model_one").unwrap().unwrap();
+
+        store.delete("model_one").unwrap();
+
+        assert!(store.get("model_one").unwrap().is_none());
+        drop(store);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// A miss is not cached, so sealing a binding after something asked for it still
+    /// makes the credential visible.
+    #[test]
+    fn a_miss_does_not_hide_a_later_binding() {
+        let directory = temporary_directory();
+        let store = LocalModelBindingStore::open(&directory).unwrap();
+        assert!(store.get("model_one").unwrap().is_none());
+
+        store
+            .put(
+                "model_one",
+                &ModelSelection {
+                    provider: "vercel-ai-gateway".into(),
+                    name: "openai/gpt-5-mini".into(),
+                    api_key: "later-secret".into(),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.get("model_one").unwrap().unwrap().api_key.as_str(),
+            "later-secret"
         );
         drop(store);
         fs::remove_dir_all(directory).unwrap();


### PR DESCRIPTION
The two items from the "measured but rejected" list that were worth reopening.

## 1. The Wasm timeout could never fire

`Config::epoch_interruption(true)` and `Store::set_epoch_deadline(1)` were both set,
and nothing in the workspace ever called `Engine::increment_epoch`. The deadline was
unreachable, so the only limit inside an instance was fuel - a bound on work, not on
time, whose billion units had no relationship to the two-second budget the supervisor
enforces. The only bound with a clock was the supervisor's IPC timeout, and that
stops the worker process, discarding every compiled component in it.

- A ticker thread advances the epoch every 10 ms, holding a weak engine reference so
  a dropped engine stops it.
- Each activation's deadline is its own `wall_time` in ticks. A runaway Agentloop is
  trapped in its own instance and costs one instance.
- The trap reports the same wall-time message the supervisor's timeout has always
  returned, so nothing a client sees changes.
- With a real bound in place, `consume_fuel` is off: **5-13% of an activation**,
  measured by Codex on ARM.
- The supervisor's timeout becomes the backstop for what an epoch cannot interrupt -
  a worker blocked in a host call, a crashed worker, a socket that never answers -
  and is now `wall_time + 1s`, so it fires strictly after the guest's own bound
  rather than racing it.

Codex marked S08 **redesign** rather than a plain fuel removal for exactly this
reason; this is that redesign.

## 2. A model call re-read and re-decrypted its credential every time

`ServerModelExecutor::execute` asked the binding store for the credential on every
model call, and the store answered with a `synchronous = FULL` SQLite query plus an
AES-GCM decrypt, behind a process-global `Mutex<Connection>`, on a Tokio worker
thread. One of those per decision, up to `BRAIN_MAX_DECISIONS`. This is the last
SQLite on the hot path - the journal's went with #100.

Adding write concurrency there does not help: eight concurrent writers measured 0.99x
of serial (Codex S16). So the store answers a repeat read from memory instead.

Safe because a binding is sealed at creation: `put` on an existing identity either
matches the stored credential or fails, so an entry cannot go stale. Misses are not
cached, so a later `put` is visible. `delete` evicts. The map is bounded by the number
of rows. Caching plaintext does not widen the trust boundary - the master key is
already resident for the life of the process.

## Tests

Both are acceptance tests, verified to fail on the previous behaviour:

- `a_guest_that_never_returns_is_trapped_within_its_budget` builds the smallest
  module that never returns and asserts it is stopped by `Trap::Interrupt`. Without
  the ticker it fails in 20 s; with it, it passes in 0.2 s. It runs the guest on its
  own thread and waits with a clock, so a broken deadline fails the test rather than
  hanging CI until the job times out.
- `a_budget_becomes_at_least_one_tick` pins the deadline arithmetic, including the
  round-up (a guest is never given less than its budget) and saturation.
- `a_credential_is_read_from_the_database_once` deletes the row behind the store's
  back, so a `get` that still answers can only have answered from memory.
- `deleting_a_binding_forgets_its_credential` and `a_miss_does_not_hide_a_later_binding`
  pin the two invalidation rules.

`wasm-encoder` is added as a dev-dependency; it was already in the lock file as a
Wasmtime component dependency, so it costs no new crate.