### PR TITLE
perf: fix the four architectural blockers

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -21,11 +21,13 @@ Every push runs a resource bound against a live server: after 10,000 requests, r
 stay under 256 MiB and must not have grown by more than 16 MiB. See the `benchmark-leakage` job
 in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
-The same job bounds journal growth. A turn's context envelope grows with every decision, so
-anything written per decision costs the sum of every intermediate size; at the production ceiling
-of `BRAIN_MAX_DECISIONS=128` that is the difference between a megabyte of conversation and tens of
-megabytes of permanently retained journal. `crates/brain/tests/journal_growth.rs` holds a turn's
-journal, and one page of its event stream, to a small constant multiple of the final context.
+The same job bounds journal growth, on both axes. A context envelope grows with every decision
+*and* across every turn, so anything written per decision or per turn costs the sum of every
+intermediate size rather than the final one. On the decision axis the kernel caps it at
+`BRAIN_MAX_DECISIONS=128`; on the turn axis nothing caps it, and 64 turns holding a 1 MiB context
+once wrote 34 MB of journal — every byte of it read back at each restart.
+`crates/brain/tests/journal_growth.rs` holds both, and one page of the event stream, to a small
+constant multiple of the final context.
 
 ## What the journal costs
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ flowchart TD
 
 ## Tiny
 
-Six crates, about 7,300 lines of Rust. The session kernel is 3,400 of them and its journal is 1,337,
+Six crates, about 7,600 lines of Rust. The session kernel is 3,400 of them and its journal is 1,556,
 of which the entire on-disk format — frames, segment rotation, torn-tail recovery, reclamation — is
-one 610-line file. There is no ORM, no query planner and no embedded database: the kernel's
+one 703-line file. There is no ORM, no query planner and no embedded database: the kernel's
 dependency on SQLite was removed outright, and `sha2` went with it.
 
 ## Blazing fast
@@ -118,6 +118,16 @@ xxh3 over the bytes just serialised, and a channel send — no syscall on the tu
 fsync anywhere. Session state, the record index and idempotency all live in memory, so a running
 session never reads the disk; paging a client's history resolves locations under the lock but reads
 outside it, so replaying history never blocks an append.
+
+What is *not* in the log matters as much. A session's state is rewritten at the end of every turn
+and only its latest value is ever read, so it lives in a file per session that the writer replaces
+in place — appended, it grew the journal with the square of the turn count. A recorded idempotency
+answer expires, so it stops holding back the segments behind it. And the writer is bounded: past
+64 MiB of frames it has not yet put on disk, an append waits, so a stalled disk shows up as a slow
+turn rather than as a process that grows until it is killed.
+
+Agentloop activations run concurrently, bounded at sixteen per worker: each one is a live Wasm
+instance, so that number is the worker's memory ceiling rather than a throughput dial.
 
 ```sh
 cargo test --release -p brain --test journal_throughput -- --ignored --nocapture
@@ -182,6 +192,7 @@ Every push runs these against a live server, so they are bounds rather than clai
 | --- | --- |
 | Resident memory after 10,000 requests | under 256 MiB, and grown by no more than 16 MiB |
 | A turn's journal, over 64 decisions on a 1 MiB context | no more than 8x the final context |
+| A session's journal, over 64 turns on a 1 MiB context | no more than 8x the final context |
 | One page of that turn's event stream | no more than 8x the final context |
 
 End-to-end latency, throughput and the cross-session isolation test are being rebuilt against the

--- a/crates/brain-loophost/Cargo.toml
+++ b/crates/brain-loophost/Cargo.toml
@@ -28,7 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["fs", "process", "net", "io-util"] }
+tokio = { workspace = true, features = ["fs", "process", "net", "io-util", "sync", "macros", "rt-multi-thread"] }
 wasmtime = { workspace = true }
 
 [dev-dependencies]

--- a/crates/brain-loophost/src/lib.rs
+++ b/crates/brain-loophost/src/lib.rs
@@ -4,12 +4,14 @@ mod client;
 mod limits;
 mod package;
 mod runtime;
+mod service;
 mod supervisor;
 mod wire;
 
 pub use limits::LoopLimits;
 pub use package::{AgentloopManifest, AgentloopPackage};
 pub use runtime::{AdmissionEngine, AdmittedAgentloop};
+pub use service::WorkerService;
 pub use supervisor::WorkerPool;
 pub use wire::{WorkerRequest, WorkerResponse};
 
@@ -17,6 +19,18 @@ pub const MAX_PACKAGE_BYTES: usize = 32 * 1024 * 1024;
 pub const MAX_ACTIVATION_INPUT_BYTES: usize = 32 * 1024 * 1024;
 pub const MAX_ACTIVATION_OUTPUT_BYTES: usize = 32 * 1024 * 1024;
 pub const MAX_LINEAR_MEMORY_BYTES: usize = 128 * 1024 * 1024;
+
+/// Activations one worker runs at once by default.
+///
+/// This was effectively one: the supervisor held a process-global mutex across the whole
+/// activation, and its semaphore admitted three, so a fourth was refused outright. At
+/// concurrency 64 only 12 of 256 turns reached the model, and a throughput measurement
+/// taken against that counted the refusals as successes.
+///
+/// It cannot simply be unbounded either: each activation is a live Wasm instance, and 48
+/// at once measured 1.03 GiB. Sixteen measured 160 turns/s against 48.6 at one, and is
+/// the number the memory arithmetic supports.
+pub const DEFAULT_CONCURRENT_ACTIVATIONS: usize = 16;
 pub const RUNTIME_SHIM_IMPORTS: &[&str] = &["aex:agentloop/types@1.0.0"];
 
 #[doc(hidden)]

--- a/crates/brain-loophost/src/limits.rs
+++ b/crates/brain-loophost/src/limits.rs
@@ -7,6 +7,13 @@ pub struct LoopLimits {
     pub activation_output_bytes: usize,
     pub linear_memory_bytes: usize,
     pub wall_time: Duration,
+    /// Activations a worker runs at once. Each is a live Wasm instance, so this times
+    /// `linear_memory_bytes` is the worst case a worker can hold, and concurrency here
+    /// has to stay explicitly bounded for that reason: 48 at once measured 1.03 GiB.
+    pub concurrent_activations_per_worker: usize,
+    /// How many more may be waiting for one of those slots before the pool says no.
+    /// Beyond this an activation is refused rather than queued, so a busy Brain reports
+    /// that it is busy instead of building a backlog nobody is waiting on any more.
     pub queued_activations_per_worker: usize,
 }
 
@@ -18,6 +25,7 @@ impl Default for LoopLimits {
             activation_output_bytes: super::MAX_ACTIVATION_OUTPUT_BYTES,
             linear_memory_bytes: super::MAX_LINEAR_MEMORY_BYTES,
             wall_time: Duration::from_secs(2),
+            concurrent_activations_per_worker: super::DEFAULT_CONCURRENT_ACTIVATIONS,
             queued_activations_per_worker: 2,
         }
     }

--- a/crates/brain-loophost/src/service.rs
+++ b/crates/brain-loophost/src/service.rs
@@ -1,0 +1,210 @@
+//! What the worker process does with a request, independent of the socket it arrived on.
+//!
+//! One worker holds every admitted component, because compiling one costs seconds and the
+//! compiled form is what makes an activation cost milliseconds. It therefore has to serve
+//! more than one session at a time: reading one request, running it to completion and only
+//! then reading the next made the whole of Brain as concurrent as a single agent loop,
+//! whatever the supervisor allowed through.
+//!
+//! Concurrency stays explicitly bounded. Each activation is a live Wasm instance, so the
+//! number running at once is what sets the worker's memory ceiling.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use tokio::sync::Semaphore;
+
+use crate::{AdmissionEngine, AdmittedAgentloop, LoopLimits, WorkerRequest, WorkerResponse};
+
+pub struct WorkerService {
+    engine: Arc<AdmissionEngine>,
+    /// Read on every activation, written only by admission.
+    admitted: RwLock<HashMap<String, Arc<AdmittedAgentloop>>>,
+    /// The memory ceiling, expressed as instances rather than bytes. Requests wait here
+    /// rather than being refused: the supervisor already refused everything beyond its
+    /// own queue, so whatever reaches this point is worth a slot.
+    running: Semaphore,
+}
+
+impl WorkerService {
+    pub fn new(limits: LoopLimits, allowed_imports: Vec<String>) -> Result<Self, String> {
+        let running = Semaphore::new(limits.concurrent_activations_per_worker.max(1));
+        Ok(Self {
+            engine: Arc::new(AdmissionEngine::new(limits, allowed_imports)?),
+            admitted: RwLock::new(HashMap::new()),
+            running,
+        })
+    }
+
+    /// Read one request from `stream`, answer it, and write the answer back.
+    pub async fn serve<S>(self: Arc<Self>, stream: &mut S)
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        let response = match crate::worker_read(stream).await {
+            Ok(request) => self.handle(request).await,
+            Err(message) => failed("invalid_frame", message),
+        };
+        // The caller is waiting on this connection and nothing else. A failure to answer
+        // is its timeout to notice, not something this task can repair.
+        let _ = crate::worker_write(stream, &response).await;
+    }
+
+    pub async fn handle(self: Arc<Self>, request: WorkerRequest) -> WorkerResponse {
+        match request {
+            WorkerRequest::Ping => WorkerResponse::Pong,
+            WorkerRequest::Admit { package_json } => self.admit(package_json).await,
+            WorkerRequest::Activate { digest, input } => {
+                self.activate(digest.as_str().to_owned(), *input).await
+            }
+        }
+    }
+
+    async fn admit(&self, package_json: String) -> WorkerResponse {
+        let engine = self.engine.clone();
+        // Compiling a component is seconds of CPU. It does not belong on the runtime's
+        // threads any more than an activation does.
+        let compiled =
+            tokio::task::spawn_blocking(move || engine.admit(package_json.as_bytes())).await;
+        let component = match compiled {
+            Ok(Ok(component)) => component,
+            Ok(Err(message)) => return failed("admission_failed", message),
+            Err(_) => return failed("admission_failed", "the worker stopped compiling".into()),
+        };
+        let digest = component.digest.clone();
+        match self.admitted.write() {
+            Ok(mut admitted) => {
+                admitted.insert(digest.as_str().to_owned(), Arc::new(component));
+                WorkerResponse::Admitted { digest }
+            }
+            Err(_) => failed("admission_failed", "the worker lost its state".into()),
+        }
+    }
+
+    async fn activate(
+        &self,
+        digest: String,
+        input: brain_protocol::ActivationInput,
+    ) -> WorkerResponse {
+        let component = self
+            .admitted
+            .read()
+            .ok()
+            .and_then(|admitted| admitted.get(&digest).cloned());
+        let Some(component) = component else {
+            return failed(
+                "not_admitted",
+                "Agentloop digest is not admitted in this worker".into(),
+            );
+        };
+        // Held across the whole activation, so what it counts is instances alive rather
+        // than requests started.
+        let Ok(_slot) = self.running.acquire().await else {
+            return failed("activation_failed", "the worker is shutting down".into());
+        };
+        let engine = self.engine.clone();
+        // Wasmtime executes synchronously. Left on a runtime thread it blocks every other
+        // connection this worker is serving for as long as the guest runs.
+        let activated = tokio::task::spawn_blocking(move || {
+            component.activate(engine.engine(), engine.limits(), input)
+        })
+        .await;
+        match activated {
+            Ok(Ok(output)) => WorkerResponse::Activated { output },
+            Ok(Err(message)) => failed("activation_failed", message),
+            Err(_) => failed("activation_failed", "the activation was lost".into()),
+        }
+    }
+}
+
+fn failed(code: &str, message: String) -> WorkerResponse {
+    WorkerResponse::Error {
+        code: code.to_owned(),
+        message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn service() -> Arc<WorkerService> {
+        Arc::new(WorkerService::new(LoopLimits::default(), Vec::new()).unwrap())
+    }
+
+    fn input() -> brain_protocol::ActivationInput {
+        brain_protocol::ActivationInput {
+            context: brain_protocol::ContextEnvelope {
+                protocol_version: "agentloop/v1".into(),
+                items: Vec::new(),
+                state: None,
+            },
+            observation: brain_protocol::Observation::SessionStarted,
+            configuration: serde_json::json!({}),
+            presentation: brain_protocol::Presentation {
+                bytes: Vec::new(),
+                identity: brain_protocol::Identity::of_bytes(b"presentation"),
+            },
+            runtime: brain_protocol::RuntimeEnvelope::at(
+                &brain_protocol::JournalId::new("jrn_test"),
+                1,
+                0,
+            ),
+        }
+    }
+
+    /// Reading one request, running it to completion and only then reading the next made
+    /// every session in the process wait for the one in front of it. Requests that do not
+    /// depend on each other must not.
+    #[tokio::test]
+    async fn requests_are_answered_without_waiting_for_each_other() {
+        let service = service();
+        let answers = async {
+            tokio::join!(
+                service.clone().handle(WorkerRequest::Ping),
+                service.clone().handle(WorkerRequest::Ping),
+                service.clone().handle(WorkerRequest::Activate {
+                    digest: brain_protocol::AgentloopIdentity::new("agl_missing"),
+                    input: Box::new(input()),
+                }),
+            )
+        };
+        let (first, second, third) = tokio::time::timeout(Duration::from_secs(5), answers)
+            .await
+            .expect("concurrent requests must not deadlock on each other");
+
+        assert!(matches!(first, WorkerResponse::Pong));
+        assert!(matches!(second, WorkerResponse::Pong));
+        assert!(
+            matches!(third, WorkerResponse::Error { ref code, .. } if code == "not_admitted"),
+            "expected a miss, got {third:?}"
+        );
+    }
+
+    /// A request that arrives over a connection is answered over the same connection.
+    #[tokio::test]
+    async fn a_request_on_a_connection_is_answered_on_it() {
+        let service = service();
+        let (mut client, mut server) = tokio::io::duplex(64 * 1024);
+        let serving = tokio::spawn(async move { service.serve(&mut server).await });
+
+        crate::wire::write_frame(
+            &mut client,
+            &WorkerRequest::Ping,
+            crate::wire::MAX_RESPONSE_FRAME_BYTES,
+        )
+        .await
+        .unwrap();
+        let response: WorkerResponse =
+            crate::wire::read_frame(&mut client, crate::wire::MAX_RESPONSE_FRAME_BYTES)
+                .await
+                .unwrap();
+
+        assert!(matches!(response, WorkerResponse::Pong));
+        serving.await.unwrap();
+    }
+}

--- a/crates/brain-loophost/src/supervisor.rs
+++ b/crates/brain-loophost/src/supervisor.rs
@@ -37,8 +37,14 @@ impl WorkerPool {
             worker_binary: worker_binary.into(),
             socket: run_dir.join("brain-loop-worker.sock"),
             packages: packages.into(),
+            // Admission, not execution: what runs at once is bounded inside the worker,
+            // where the instances actually live. This is how many callers may be in
+            // flight or waiting for one of those slots before the pool refuses.
             permits: Arc::new(Semaphore::new(
-                limits.queued_activations_per_worker.saturating_add(1),
+                limits
+                    .concurrent_activations_per_worker
+                    .saturating_add(limits.queued_activations_per_worker)
+                    .max(1),
             )),
             limits,
             state: Mutex::new(WorkerState::default()),
@@ -93,17 +99,22 @@ impl WorkerPool {
             .clone()
             .try_acquire_owned()
             .map_err(|_| "Loophost queue is full".to_owned())?;
-        let mut state = self.state.lock().await;
-        self.ensure_worker(&mut state).await?;
-        if !state.admitted.contains(&digest) {
-            let package = tokio::fs::read(package_path(&self.packages, &digest))
-                .await
-                .map_err(|_| "Agentloop digest is not admitted".to_owned())?;
-            let admitted = WorkerClient::new(&self.socket).admit(&package).await?;
-            if admitted != digest {
-                return Err("persisted Agentloop package changed digest".into());
+        // Everything that needs the worker's identity happens under the lock; the
+        // activation itself does not. Holding it across the call serialised every session
+        // in the process onto one activation at a time, whatever the permits allowed.
+        {
+            let mut state = self.state.lock().await;
+            self.ensure_worker(&mut state).await?;
+            if !state.admitted.contains(&digest) {
+                let package = tokio::fs::read(package_path(&self.packages, &digest))
+                    .await
+                    .map_err(|_| "Agentloop digest is not admitted".to_owned())?;
+                let admitted = WorkerClient::new(&self.socket).admit(&package).await?;
+                if admitted != digest {
+                    return Err("persisted Agentloop package changed digest".into());
+                }
+                state.admitted.insert(digest.clone());
             }
-            state.admitted.insert(digest.clone());
         }
         let client = WorkerClient::new(&self.socket);
         let call = client.activate(digest, input, self.limits.activation_input_bytes);
@@ -118,15 +129,22 @@ impl WorkerPool {
                 let output_bytes =
                     serde_json::to_vec(&output).map_err(|error| error.to_string())?;
                 if output_bytes.len() > self.limits.activation_output_bytes {
-                    self.stop_worker(&mut state).await;
+                    // The frame that carried it was already bounded on the way in, and
+                    // the instance that produced it is gone. Stopping the worker for this
+                    // would take every other session's warm component with it, which is
+                    // a far larger price than the violation.
                     return Err("Agentloop activation output exceeds the configured limit".into());
                 }
                 Ok(output)
             }
             Ok(Err(error)) => Err(error),
             Err(_) => {
+                // The guest's own epoch deadline fires before this, so reaching here
+                // means the worker itself is not answering. That is the case this is
+                // for, and restarting it is the only thing left.
+                let mut state = self.state.lock().await;
                 self.stop_worker(&mut state).await;
-                Err("Agentloop activation exceeded its wall-time limit".into())
+                Err("brain-loop-worker stopped answering".into())
             }
         }
     }

--- a/crates/brain-loophost/src/worker/main.rs
+++ b/crates/brain-loophost/src/worker/main.rs
@@ -1,11 +1,15 @@
+//! The Agentloop worker process: a Unix socket in front of [`WorkerService`].
+//!
+//! Every connection is served on its own task, so one long activation does not hold up
+//! the sessions behind it. What runs at once is bounded inside the service, where the
+//! Wasm instances actually live.
+
 #[cfg(unix)]
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    use brain_loophost::{
-        AdmissionEngine, AdmittedAgentloop, LoopLimits, RUNTIME_SHIM_IMPORTS, WorkerRequest,
-        WorkerResponse,
-    };
-    use std::{collections::HashMap, path::PathBuf};
+    use std::{path::PathBuf, sync::Arc};
+
+    use brain_loophost::{LoopLimits, RUNTIME_SHIM_IMPORTS, WorkerService};
     use tokio::net::UnixListener;
 
     let socket = std::env::args_os()
@@ -16,52 +20,18 @@ async fn main() -> Result<(), String> {
         std::fs::remove_file(&socket).map_err(|error| error.to_string())?;
     }
     let listener = UnixListener::bind(&socket).map_err(|error| error.to_string())?;
-    let engine = AdmissionEngine::new(
+    let service = Arc::new(WorkerService::new(
         LoopLimits::default(),
         RUNTIME_SHIM_IMPORTS
             .iter()
             .map(|name| (*name).to_owned())
             .collect(),
-    )?;
-    let mut admitted: HashMap<String, AdmittedAgentloop> = HashMap::new();
+    )?);
+
     loop {
         let (mut stream, _) = listener.accept().await.map_err(|error| error.to_string())?;
-        let response = match brain_loophost::worker_read(&mut stream).await {
-            Ok(WorkerRequest::Ping) => WorkerResponse::Pong,
-            Ok(WorkerRequest::Admit { package_json }) => {
-                match engine.admit(package_json.as_bytes()) {
-                    Ok(component) => {
-                        let digest = component.digest.clone();
-                        admitted.insert(digest.as_str().to_owned(), component);
-                        WorkerResponse::Admitted { digest }
-                    }
-                    Err(message) => WorkerResponse::Error {
-                        code: "admission_failed".into(),
-                        message,
-                    },
-                }
-            }
-            Ok(WorkerRequest::Activate { digest, input }) => match admitted.get(digest.as_str()) {
-                Some(component) => {
-                    match component.activate(engine.engine(), engine.limits(), *input) {
-                        Ok(output) => WorkerResponse::Activated { output },
-                        Err(message) => WorkerResponse::Error {
-                            code: "activation_failed".into(),
-                            message,
-                        },
-                    }
-                }
-                None => WorkerResponse::Error {
-                    code: "not_admitted".into(),
-                    message: "Agentloop digest is not admitted in this worker".into(),
-                },
-            },
-            Err(message) => WorkerResponse::Error {
-                code: "invalid_frame".into(),
-                message,
-            },
-        };
-        brain_loophost::worker_write(&mut stream, &response).await?;
+        let service = service.clone();
+        tokio::spawn(async move { service.serve(&mut stream).await });
     }
 }
 

--- a/crates/brain-loophost/tests/worker_process.rs
+++ b/crates/brain-loophost/tests/worker_process.rs
@@ -1,5 +1,7 @@
 #![cfg(unix)]
 
+use std::sync::Arc;
+
 use brain_loophost::{LoopLimits, WorkerPool};
 use brain_protocol::{
     ActivationInput, ContextEnvelope, Decision, Observation, Presentation, RuntimeEnvelope,
@@ -47,5 +49,74 @@ async fn real_worker_admits_and_activates_the_typescript_diagnostic_loop() {
             Some(serde_json::json!({"activations":1,"observation":"user_message"}))
         ),
         decision => panic!("expected terminal Brain decision, got {decision:?}"),
+    }
+}
+
+/// The real ceiling was about three sessions: the supervisor admitted three activations
+/// and then held a process-global mutex across the whole of each one, and the worker
+/// served one connection at a time behind that. At concurrency 64, only 12 of 256 turns
+/// reached the model, and everything else came back as a failed session that still
+/// answered HTTP 200.
+///
+/// Twelve at once is comfortably past the old cap of three and inside the default of
+/// sixteen, so every one of these must complete.
+#[tokio::test]
+async fn concurrent_activations_all_reach_the_agentloop() {
+    const AT_ONCE: usize = 12;
+
+    let package_path = std::env::var("BRAIN_TEST_AGENTLOOP_PACKAGE")
+        .expect("BRAIN_TEST_AGENTLOOP_PACKAGE must name the built diagnostic package");
+    let package = tokio::fs::read(package_path).await.unwrap();
+    let directory = tempfile::tempdir().unwrap();
+    let pool = Arc::new(WorkerPool::new(
+        env!("CARGO_BIN_EXE_brain-loop-worker"),
+        directory.path().join("run"),
+        directory.path().join("packages"),
+        LoopLimits::default(),
+    ));
+    let digest = pool.admit(package).await.unwrap();
+
+    let mut activations = Vec::with_capacity(AT_ONCE);
+    for index in 0..AT_ONCE {
+        let pool = pool.clone();
+        let digest = digest.clone();
+        activations.push(tokio::spawn(async move {
+            pool.activate(digest, activation(index)).await
+        }));
+    }
+
+    let mut reached = 0;
+    let mut refused = Vec::new();
+    for activation in activations {
+        match activation.await.unwrap() {
+            Ok(output) => {
+                assert_eq!(output.context.state.unwrap()["slots"][0]["activations"], 1);
+                reached += 1;
+            }
+            Err(message) => refused.push(message),
+        }
+    }
+    assert_eq!(
+        reached, AT_ONCE,
+        "only {reached} of {AT_ONCE} concurrent activations reached the Agentloop;          the rest were refused: {refused:?}"
+    );
+}
+
+fn activation(index: usize) -> ActivationInput {
+    ActivationInput {
+        context: ContextEnvelope {
+            protocol_version: "agentloop/v1".into(),
+            items: Vec::new(),
+            state: None,
+        },
+        observation: Observation::UserMessage {
+            content: serde_json::json!({ "scenario": "tools", "index": index }),
+        },
+        configuration: serde_json::json!({}),
+        presentation: Presentation {
+            bytes: Vec::new(),
+            identity: brain_protocol::Identity::of(&"presentation").unwrap(),
+        },
+        runtime: RuntimeEnvelope::at(&brain_protocol::JournalId::new("jrn_test"), 1, 0),
     }
 }

--- a/crates/brain/src/journal/log.rs
+++ b/crates/brain/src/journal/log.rs
@@ -149,22 +149,26 @@ impl SegmentLog {
         visit_state: impl FnMut(&str, &[u8]) -> Result<(), KernelError>,
         visit: impl FnMut(Frame<'_>, Location) -> Result<(), KernelError>,
     ) -> Result<Self, KernelError> {
-        Self::open_inner(directory, visit_state, visit, Duration::ZERO)
+        Self::open_inner(directory, visit_state, visit, None)
     }
 
-    /// A log whose writer stalls once, before its first frame, so a test can fill the
-    /// queue behind it and watch what happens rather than racing it. Never used outside
-    /// tests: a real writer is as fast as the disk it is writing to.
+    /// A log whose writer waits, before its first frame, until `release` is set. A test
+    /// can then fill the queue behind it and see what happens without racing it, and let
+    /// it go the moment it has seen enough. Never used outside tests: a real writer is as
+    /// fast as the disk it is writing to.
     #[cfg(test)]
-    pub(crate) fn open_stalled(directory: &Path, stall: Duration) -> Result<Self, KernelError> {
-        Self::open_inner(directory, |_, _| Ok(()), |_, _| Ok(()), stall)
+    pub(crate) fn open_stalled(
+        directory: &Path,
+        release: Arc<std::sync::atomic::AtomicBool>,
+    ) -> Result<Self, KernelError> {
+        Self::open_inner(directory, |_, _| Ok(()), |_, _| Ok(()), Some(release))
     }
 
     fn open_inner(
         directory: &Path,
         mut visit_state: impl FnMut(&str, &[u8]) -> Result<(), KernelError>,
         mut visit: impl FnMut(Frame<'_>, Location) -> Result<(), KernelError>,
-        writer_delay: Duration,
+        release: Option<Arc<std::sync::atomic::AtomicBool>>,
     ) -> Result<Self, KernelError> {
         fs::create_dir_all(directory).map_err(log_error)?;
         for (session_id, bytes) in read_states(directory)? {
@@ -224,7 +228,7 @@ impl SegmentLog {
             receiver,
             pending.clone(),
             backlog.clone(),
-            writer_delay,
+            release,
         );
 
         Ok(Self {
@@ -412,12 +416,12 @@ fn spawn_writer(
     receiver: mpsc::Receiver<Message>,
     pending: Staged,
     backlog: Backlog,
-    stall: Duration,
+    hold: Option<Arc<std::sync::atomic::AtomicBool>>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         // Tests hold the writer here once, before it has written anything, so they can
         // fill the queue behind it deterministically instead of racing it.
-        let mut stalled = stall.is_zero();
+        let mut held = hold;
         let mut open: Option<(u64, BufWriter<File>)> = None;
         let mut written: Vec<(u64, u64)> = Vec::new();
         // Bytes this batch took off the queue, released once they are on the disk.
@@ -436,9 +440,15 @@ fn spawn_writer(
                         states.insert(session_id, bytes);
                     }
                     Message::Frame { location, bytes } => {
-                        if !stalled {
-                            thread::sleep(stall);
-                            stalled = true;
+                        if let Some(release) = held.take() {
+                            // Capped so a test that never releases fails on its own
+                            // assertions rather than hanging the job.
+                            let until = std::time::Instant::now() + Duration::from_secs(30);
+                            while !release.load(std::sync::atomic::Ordering::Acquire)
+                                && std::time::Instant::now() < until
+                            {
+                                thread::sleep(Duration::from_millis(1));
+                            }
                         }
                         drained += bytes.len() as u64;
                         if open.as_ref().is_none_or(|(id, _)| *id != location.segment) {
@@ -704,6 +714,8 @@ fn log_error(error: std::io::Error) -> KernelError {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use super::*;
 
     fn payload(kind: &str) -> serde_json::Value {
@@ -832,21 +844,31 @@ mod tests {
         assert!(!frame.is_sequenced());
     }
 
+    /// A writer that is not being held at all.
+    fn released() -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(true))
+    }
+
     /// Writing behind the caller turns disk latency into memory. With a deliberately
     /// slow writer, producers queued 250 MiB of frames in 218 ms and every byte stayed
     /// on the heap. Past the allowance the append waits, so a stalled disk is a slow
     /// turn rather than a process that grows until it is killed.
     ///
-    /// The writer is held still rather than merely slowed, so what this measures is the
-    /// bound and not which of the two threads happens to be faster on the machine
-    /// running it.
+    /// The writer is held still and let go by this test rather than slowed, so what is
+    /// measured is the bound and not which of the two threads happens to be faster on
+    /// the machine running it. An earlier version slowed the writer by a millisecond a
+    /// frame and passed on one machine while the queue reached a single frame on
+    /// another.
     #[test]
     fn a_stalled_writer_makes_appends_wait_instead_of_growing_the_queue() {
-        const STALL: Duration = Duration::from_secs(3);
         const FRAME_BYTES: usize = 64 * 1024;
+        /// Long enough for any machine to serialise the allowance, and only ever waited
+        /// out when something is actually wrong.
+        const DEADLINE: Duration = Duration::from_secs(20);
 
         let directory = temporary();
-        let log = Arc::new(SegmentLog::open_stalled(&directory, STALL).unwrap());
+        let release = Arc::new(AtomicBool::new(false));
+        let log = Arc::new(SegmentLog::open_stalled(&directory, release.clone()).unwrap());
         let body = serde_json::json!({ "filler": "x".repeat(FRAME_BYTES) });
 
         // Twice what the allowance can hold, so the producer must be made to wait.
@@ -861,26 +883,31 @@ mod tests {
             })
         };
 
-        // Watch the queue while the writer is still held, stopping as soon as it is
-        // full so a fast machine does not wait out the stall it no longer needs.
+        // Full, to within the frame that did not fit: the producer waits when the next
+        // frame would cross the allowance, so the queue settles just under it.
+        let full = MAX_QUEUED_BYTES - 2 * FRAME_BYTES as u64;
+
+        // Watch the queue fill behind the held writer, and stop as soon as it is full.
         let mut peak = 0;
         let watching = std::time::Instant::now();
-        while peak < MAX_QUEUED_BYTES && watching.elapsed() < STALL / 2 {
+        while peak < full && watching.elapsed() < DEADLINE {
             peak = peak.max(log.backlog.0.lock().unwrap().bytes);
             thread::sleep(Duration::from_millis(1));
         }
+        let waiting = !producer.is_finished();
+        release.store(true, Ordering::Release);
 
         assert!(
             peak <= MAX_QUEUED_BYTES,
             "the writer was allowed to fall {peak} bytes behind, past the              {MAX_QUEUED_BYTES}-byte allowance"
         );
         assert!(
-            peak > MAX_QUEUED_BYTES / 2,
-            "the queue only reached {peak} bytes, so this run never tested the bound"
+            peak >= full,
+            "the queue only reached {peak} bytes of {MAX_QUEUED_BYTES} in {DEADLINE:?},              so this run never tested the bound"
         );
         assert!(
-            !producer.is_finished(),
-            "the producer queued {frames} frames past a stalled writer without waiting"
+            waiting,
+            "the producer queued {frames} frames past a held writer without waiting"
         );
 
         producer.join().unwrap();
@@ -893,7 +920,7 @@ mod tests {
     #[test]
     fn a_frame_larger_than_the_allowance_is_still_written() {
         let directory = temporary();
-        let log = SegmentLog::open_stalled(&directory, Duration::ZERO).unwrap();
+        let log = SegmentLog::open_stalled(&directory, released()).unwrap();
         let body = serde_json::json!({
             "filler": "x".repeat(MAX_QUEUED_BYTES as usize + 1),
         });
@@ -913,7 +940,7 @@ mod tests {
     #[test]
     fn a_writer_failure_stops_the_log_rather_than_being_swallowed() {
         let directory = temporary();
-        let log = SegmentLog::open_stalled(&directory, Duration::ZERO).unwrap();
+        let log = SegmentLog::open_stalled(&directory, released()).unwrap();
         fail(&log.backlog, "the disk went away".to_owned());
 
         let body = payload("turn_finished");

--- a/crates/brain/src/journal/log.rs
+++ b/crates/brain/src/journal/log.rs
@@ -152,15 +152,12 @@ impl SegmentLog {
         Self::open_inner(directory, visit_state, visit, Duration::ZERO)
     }
 
-    /// A log whose writer sleeps before each frame, so a test can hold it behind and
-    /// watch what the queue does. Never used outside tests: a real writer is as fast as
-    /// the disk it is writing to.
+    /// A log whose writer stalls once, before its first frame, so a test can fill the
+    /// queue behind it and watch what happens rather than racing it. Never used outside
+    /// tests: a real writer is as fast as the disk it is writing to.
     #[cfg(test)]
-    pub(crate) fn open_behind(
-        directory: &Path,
-        writer_delay: Duration,
-    ) -> Result<Self, KernelError> {
-        Self::open_inner(directory, |_, _| Ok(()), |_, _| Ok(()), writer_delay)
+    pub(crate) fn open_stalled(directory: &Path, stall: Duration) -> Result<Self, KernelError> {
+        Self::open_inner(directory, |_, _| Ok(()), |_, _| Ok(()), stall)
     }
 
     fn open_inner(
@@ -415,9 +412,12 @@ fn spawn_writer(
     receiver: mpsc::Receiver<Message>,
     pending: Staged,
     backlog: Backlog,
-    delay: Duration,
+    stall: Duration,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
+        // Tests hold the writer here once, before it has written anything, so they can
+        // fill the queue behind it deterministically instead of racing it.
+        let mut stalled = stall.is_zero();
         let mut open: Option<(u64, BufWriter<File>)> = None;
         let mut written: Vec<(u64, u64)> = Vec::new();
         // Bytes this batch took off the queue, released once they are on the disk.
@@ -436,8 +436,9 @@ fn spawn_writer(
                         states.insert(session_id, bytes);
                     }
                     Message::Frame { location, bytes } => {
-                        if !delay.is_zero() {
-                            thread::sleep(delay);
+                        if !stalled {
+                            thread::sleep(stall);
+                            stalled = true;
                         }
                         drained += bytes.len() as u64;
                         if open.as_ref().is_none_or(|(id, _)| *id != location.segment) {
@@ -831,40 +832,59 @@ mod tests {
         assert!(!frame.is_sequenced());
     }
 
-    /// Writing behind the caller turns disk latency into memory. With a slow writer,
-    /// producers queued 250 MiB of frames in 218 ms and every byte stayed on the heap.
-    /// Past the allowance the append waits, so a stalled disk is a slow turn rather than
-    /// a process that grows until it is killed.
+    /// Writing behind the caller turns disk latency into memory. With a deliberately
+    /// slow writer, producers queued 250 MiB of frames in 218 ms and every byte stayed
+    /// on the heap. Past the allowance the append waits, so a stalled disk is a slow
+    /// turn rather than a process that grows until it is killed.
+    ///
+    /// The writer is held still rather than merely slowed, so what this measures is the
+    /// bound and not which of the two threads happens to be faster on the machine
+    /// running it.
     #[test]
-    fn a_slow_writer_makes_appends_wait_instead_of_growing_the_queue() {
-        let directory = temporary();
-        // One millisecond per frame, which is roughly what the original spike used to
-        // hold the writer behind its producers.
-        let log = SegmentLog::open_behind(&directory, Duration::from_millis(1)).unwrap();
-        let body = serde_json::json!({ "filler": "x".repeat(64 * 1024) });
+    fn a_stalled_writer_makes_appends_wait_instead_of_growing_the_queue() {
+        const STALL: Duration = Duration::from_secs(3);
+        const FRAME_BYTES: usize = 64 * 1024;
 
+        let directory = temporary();
+        let log = Arc::new(SegmentLog::open_stalled(&directory, STALL).unwrap());
+        let body = serde_json::json!({ "filler": "x".repeat(FRAME_BYTES) });
+
+        // Twice what the allowance can hold, so the producer must be made to wait.
+        let frames = 2 * (MAX_QUEUED_BYTES / FRAME_BYTES as u64);
+        let producer = {
+            let log = log.clone();
+            thread::spawn(move || {
+                for sequence in 1..=frames {
+                    log.append(append("ses_test", sequence, "turn_finished", &body))
+                        .unwrap();
+                }
+            })
+        };
+
+        // Watch the queue while the writer is still held, stopping as soon as it is
+        // full so a fast machine does not wait out the stall it no longer needs.
         let mut peak = 0;
-        // Enough frames that an unbounded queue would hold several times the allowance.
-        for sequence in 1..=2_048 {
-            log.append(append("ses_test", sequence, "turn_finished", &body))
-                .unwrap();
+        let watching = std::time::Instant::now();
+        while peak < MAX_QUEUED_BYTES && watching.elapsed() < STALL / 2 {
             peak = peak.max(log.backlog.0.lock().unwrap().bytes);
-            if peak > MAX_QUEUED_BYTES {
-                break;
-            }
+            thread::sleep(Duration::from_millis(1));
         }
 
         assert!(
             peak <= MAX_QUEUED_BYTES,
             "the writer was allowed to fall {peak} bytes behind, past the              {MAX_QUEUED_BYTES}-byte allowance"
         );
-        // And the allowance was actually reached, so the bound above is holding
-        // something back rather than being satisfied by a queue that never filled.
         assert!(
             peak > MAX_QUEUED_BYTES / 2,
             "the queue only reached {peak} bytes, so this run never tested the bound"
         );
-        drop(log);
+        assert!(
+            !producer.is_finished(),
+            "the producer queued {frames} frames past a stalled writer without waiting"
+        );
+
+        producer.join().unwrap();
+        drop(Arc::into_inner(log).expect("the producer is finished with it"));
         fs::remove_dir_all(directory).unwrap();
     }
 
@@ -873,7 +893,7 @@ mod tests {
     #[test]
     fn a_frame_larger_than_the_allowance_is_still_written() {
         let directory = temporary();
-        let log = SegmentLog::open_behind(&directory, Duration::ZERO).unwrap();
+        let log = SegmentLog::open_stalled(&directory, Duration::ZERO).unwrap();
         let body = serde_json::json!({
             "filler": "x".repeat(MAX_QUEUED_BYTES as usize + 1),
         });
@@ -893,7 +913,7 @@ mod tests {
     #[test]
     fn a_writer_failure_stops_the_log_rather_than_being_swallowed() {
         let directory = temporary();
-        let log = SegmentLog::open_behind(&directory, Duration::ZERO).unwrap();
+        let log = SegmentLog::open_stalled(&directory, Duration::ZERO).unwrap();
         fail(&log.backlog, "the disk went away".to_owned());
 
         let body = payload("turn_finished");

--- a/crates/brain/src/journal/log.rs
+++ b/crates/brain/src/journal/log.rs
@@ -24,8 +24,9 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{BufWriter, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, mpsc},
+    sync::{Arc, Condvar, Mutex, mpsc},
     thread::{self, JoinHandle},
+    time::Duration,
 };
 
 use crate::KernelError;
@@ -35,6 +36,28 @@ use crate::KernelError;
 const SEGMENT_BYTES: u64 = 64 * 1024 * 1024;
 
 const HEADER_BYTES: usize = 12;
+
+/// How far the writer may fall behind before a caller waits for it.
+///
+/// Writing behind the caller turns disk latency into memory: with a deliberately slow
+/// writer, producers queued 250 MiB of frames in 218 ms and every byte stayed on the
+/// heap. Above this the append waits instead, so a stalled disk shows up as a slow turn
+/// rather than as a process that grows until it is killed. Large enough that a healthy
+/// disk never reaches it.
+const MAX_QUEUED_BYTES: u64 = 64 * 1024 * 1024;
+
+/// What the writer has been handed and has not yet put on disk, and whether it has
+/// failed. Shared with the writer thread, which is the only thing that subtracts.
+#[derive(Default)]
+struct Queue {
+    bytes: u64,
+    /// Set once. A write-behind log has no caller left to tell when a write fails, so
+    /// the failure is kept and every later append reports it: losing records silently is
+    /// the one outcome worth refusing.
+    failure: Option<String>,
+}
+
+type Backlog = Arc<(Mutex<Queue>, Condvar)>;
 
 /// Frames handed to the writer but not yet flushed, keyed by segment and offset.
 type Staged = Arc<Mutex<HashMap<(u64, u64), Arc<Vec<u8>>>>>;
@@ -106,6 +129,7 @@ pub(crate) struct SegmentLog {
     /// The writer flushes before it removes an entry, so a miss here means the bytes
     /// are on disk.
     pending: Staged,
+    backlog: Backlog,
     sender: Option<mpsc::Sender<Message>>,
     writer: Option<JoinHandle<()>>,
 }
@@ -122,8 +146,28 @@ impl SegmentLog {
     /// the last frame of a crashed process — is truncated away.
     pub(crate) fn open(
         directory: &Path,
+        visit_state: impl FnMut(&str, &[u8]) -> Result<(), KernelError>,
+        visit: impl FnMut(Frame<'_>, Location) -> Result<(), KernelError>,
+    ) -> Result<Self, KernelError> {
+        Self::open_inner(directory, visit_state, visit, Duration::ZERO)
+    }
+
+    /// A log whose writer sleeps before each frame, so a test can hold it behind and
+    /// watch what the queue does. Never used outside tests: a real writer is as fast as
+    /// the disk it is writing to.
+    #[cfg(test)]
+    pub(crate) fn open_behind(
+        directory: &Path,
+        writer_delay: Duration,
+    ) -> Result<Self, KernelError> {
+        Self::open_inner(directory, |_, _| Ok(()), |_, _| Ok(()), writer_delay)
+    }
+
+    fn open_inner(
+        directory: &Path,
         mut visit_state: impl FnMut(&str, &[u8]) -> Result<(), KernelError>,
         mut visit: impl FnMut(Frame<'_>, Location) -> Result<(), KernelError>,
+        writer_delay: Duration,
     ) -> Result<Self, KernelError> {
         fs::create_dir_all(directory).map_err(log_error)?;
         for (session_id, bytes) in read_states(directory)? {
@@ -176,16 +220,44 @@ impl SegmentLog {
         }
 
         let pending: Staged = Arc::default();
+        let backlog: Backlog = Arc::default();
         let (sender, receiver) = mpsc::channel::<Message>();
-        let writer = spawn_writer(directory.to_path_buf(), receiver, pending.clone());
+        let writer = spawn_writer(
+            directory.to_path_buf(),
+            receiver,
+            pending.clone(),
+            backlog.clone(),
+            writer_delay,
+        );
 
         Ok(Self {
             directory: directory.to_path_buf(),
             tail: Mutex::new(tail),
             pending,
+            backlog,
             sender: Some(sender),
             writer: Some(writer),
         })
+    }
+
+    /// Wait until the writer is far enough ahead to accept `bytes`, and refuse outright
+    /// if it has already failed. A frame larger than the whole allowance goes through
+    /// once the queue is empty rather than waiting for room that can never appear.
+    fn reserve(&self, bytes: u64) -> Result<(), KernelError> {
+        let (queue, room) = &*self.backlog;
+        let mut queue = queue.lock().map_err(|_| poisoned())?;
+        loop {
+            if let Some(failure) = &queue.failure {
+                return Err(KernelError::Journal(format!(
+                    "journal writer failed and the log is no longer being written: {failure}"
+                )));
+            }
+            if queue.bytes == 0 || queue.bytes + bytes <= MAX_QUEUED_BYTES {
+                queue.bytes += bytes;
+                return Ok(());
+            }
+            queue = room.wait(queue).map_err(|_| poisoned())?;
+        }
     }
 
     /// Assign a location, hand the bytes to the writer, and return. Does not block on
@@ -195,6 +267,7 @@ impl SegmentLog {
         // allocates a second buffer and copies the frame into it.
         let frame = Arc::new(encode(&append)?);
         let length = frame.len() as u64;
+        self.reserve(length)?;
 
         let mut tail = self.tail.lock().map_err(|_| poisoned())?;
         if tail.offset > 0 && tail.offset + length > SEGMENT_BYTES {
@@ -230,6 +303,7 @@ impl SegmentLog {
         check_session_id(session_id)?;
         let bytes =
             serde_json::to_vec(payload).map_err(|error| KernelError::Journal(error.to_string()))?;
+        self.reserve(bytes.len() as u64)?;
         self.send(Message::State {
             session_id: session_id.to_owned(),
             bytes: Some(bytes),
@@ -340,10 +414,14 @@ fn spawn_writer(
     directory: PathBuf,
     receiver: mpsc::Receiver<Message>,
     pending: Staged,
+    backlog: Backlog,
+    delay: Duration,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         let mut open: Option<(u64, BufWriter<File>)> = None;
         let mut written: Vec<(u64, u64)> = Vec::new();
+        // Bytes this batch took off the queue, released once they are on the disk.
+        let mut drained = 0_u64;
         // The last state seen for each session in this batch. A session that finished
         // three turns while the disk was busy is written once, not three times.
         let mut states: HashMap<String, Option<Vec<u8>>> = HashMap::new();
@@ -352,28 +430,45 @@ fn spawn_writer(
             while let Some(message) = next.take() {
                 match message {
                     Message::State { session_id, bytes } => {
+                        drained += bytes.as_ref().map_or(0, |bytes| bytes.len() as u64);
+                        // A state superseded before it reached the disk is dropped, and
+                        // its allowance goes back with the one that replaced it.
                         states.insert(session_id, bytes);
                     }
                     Message::Frame { location, bytes } => {
+                        if !delay.is_zero() {
+                            thread::sleep(delay);
+                        }
+                        drained += bytes.len() as u64;
                         if open.as_ref().is_none_or(|(id, _)| *id != location.segment) {
                             if let Some((_, mut file)) = open.take() {
                                 let _ = file.flush();
                             }
-                            open = OpenOptions::new()
+                            match OpenOptions::new()
                                 .create(true)
                                 .append(true)
                                 .open(segment_path(&directory, location.segment))
-                                .ok()
-                                .map(|file| {
-                                    (location.segment, BufWriter::with_capacity(1 << 20, file))
-                                });
+                            {
+                                Ok(file) => {
+                                    open = Some((
+                                        location.segment,
+                                        BufWriter::with_capacity(1 << 20, file),
+                                    ));
+                                }
+                                Err(error) => {
+                                    open = None;
+                                    fail(&backlog, format!("cannot open a segment: {error}"));
+                                }
+                            }
                         }
-                        // If the segment could not be opened the frame stays staged in
-                        // `pending` and stays readable; there is no caller left to tell.
-                        if let Some((_, file)) = open.as_mut()
-                            && file.write_all(&bytes).is_ok()
-                        {
-                            written.push((location.segment, location.offset));
+                        match open.as_mut() {
+                            Some((_, file)) => match file.write_all(&bytes) {
+                                Ok(()) => written.push((location.segment, location.offset)),
+                                Err(error) => {
+                                    fail(&backlog, format!("cannot write a frame: {error}"))
+                                }
+                            },
+                            None => fail(&backlog, "the segment is not open".to_owned()),
                         }
                     }
                     Message::Reclaim(keep_from) => reclaim_segments(&directory, keep_from),
@@ -393,12 +488,34 @@ fn spawn_writer(
                     pending.remove(&key);
                 }
             }
+            release(&backlog, std::mem::take(&mut drained));
         }
         write_states(&directory, states.drain());
+        release(&backlog, drained);
         if let Some((_, mut file)) = open.take() {
             let _ = file.flush();
         }
     })
+}
+
+/// Hand back the queue allowance for bytes that have reached the disk, and wake whoever
+/// is waiting for room.
+fn release(backlog: &Backlog, bytes: u64) {
+    let (queue, room) = &**backlog;
+    if let Ok(mut queue) = queue.lock() {
+        queue.bytes = queue.bytes.saturating_sub(bytes);
+    }
+    room.notify_all();
+}
+
+/// Record the first failure and wake everyone waiting: a log that cannot be written is
+/// not going to drain, so waiting for room in it is waiting forever.
+fn fail(backlog: &Backlog, reason: String) {
+    let (queue, room) = &**backlog;
+    if let Ok(mut queue) = queue.lock() {
+        queue.failure.get_or_insert(reason);
+    }
+    room.notify_all();
 }
 
 /// Replace or delete each session's state file. A state is written to a temporary file
@@ -712,6 +829,85 @@ mod tests {
         let bytes = encode(&append("ses_test", 0, "session_state", &body)).unwrap();
         let (frame, _) = decode(&bytes).unwrap();
         assert!(!frame.is_sequenced());
+    }
+
+    /// Writing behind the caller turns disk latency into memory. With a slow writer,
+    /// producers queued 250 MiB of frames in 218 ms and every byte stayed on the heap.
+    /// Past the allowance the append waits, so a stalled disk is a slow turn rather than
+    /// a process that grows until it is killed.
+    #[test]
+    fn a_slow_writer_makes_appends_wait_instead_of_growing_the_queue() {
+        let directory = temporary();
+        // One millisecond per frame, which is roughly what the original spike used to
+        // hold the writer behind its producers.
+        let log = SegmentLog::open_behind(&directory, Duration::from_millis(1)).unwrap();
+        let body = serde_json::json!({ "filler": "x".repeat(64 * 1024) });
+
+        let mut peak = 0;
+        // Enough frames that an unbounded queue would hold several times the allowance.
+        for sequence in 1..=2_048 {
+            log.append(append("ses_test", sequence, "turn_finished", &body))
+                .unwrap();
+            peak = peak.max(log.backlog.0.lock().unwrap().bytes);
+            if peak > MAX_QUEUED_BYTES {
+                break;
+            }
+        }
+
+        assert!(
+            peak <= MAX_QUEUED_BYTES,
+            "the writer was allowed to fall {peak} bytes behind, past the              {MAX_QUEUED_BYTES}-byte allowance"
+        );
+        // And the allowance was actually reached, so the bound above is holding
+        // something back rather than being satisfied by a queue that never filled.
+        assert!(
+            peak > MAX_QUEUED_BYTES / 2,
+            "the queue only reached {peak} bytes, so this run never tested the bound"
+        );
+        drop(log);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// A frame bigger than the whole allowance must go through rather than wait for room
+    /// that can never appear.
+    #[test]
+    fn a_frame_larger_than_the_allowance_is_still_written() {
+        let directory = temporary();
+        let log = SegmentLog::open_behind(&directory, Duration::ZERO).unwrap();
+        let body = serde_json::json!({
+            "filler": "x".repeat(MAX_QUEUED_BYTES as usize + 1),
+        });
+
+        let location = log
+            .append(append("ses_test", 1, "turn_finished", &body))
+            .unwrap();
+        assert!(u64::from(location.length) > MAX_QUEUED_BYTES);
+
+        drop(log);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// A write-behind log has no caller left to tell when a write fails. Keeping the
+    /// failure and refusing every later append is the difference between a loud stop and
+    /// silently losing records.
+    #[test]
+    fn a_writer_failure_stops_the_log_rather_than_being_swallowed() {
+        let directory = temporary();
+        let log = SegmentLog::open_behind(&directory, Duration::ZERO).unwrap();
+        fail(&log.backlog, "the disk went away".to_owned());
+
+        let body = payload("turn_finished");
+        let error = log
+            .append(append("ses_test", 1, "turn_finished", &body))
+            .expect_err("an append after a writer failure must not report success");
+        assert!(
+            error.to_string().contains("the disk went away"),
+            "the failure must say what happened: {error}"
+        );
+        assert!(log.write_state("ses_test", &body).is_err());
+
+        drop(log);
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/crates/brain/src/journal/log.rs
+++ b/crates/brain/src/journal/log.rs
@@ -10,6 +10,14 @@
 //! to a crash mid-write, so every frame carries a check value over its own bytes and
 //! recovery truncates at the first frame that does not verify. Nothing above this
 //! module sees that value or needs to know it exists.
+//!
+//! Session state does not go in the log. A session's state is the whole conversation so
+//! far, it is rewritten at the end of every turn, and only its latest value is ever read
+//! — appending it would write the sum of every context the session ever had and read all
+//! of them back at startup. It lives in a file per session, rewritten in place by the
+//! same writer thread, which drops a state superseded before it reached the disk. The
+//! writer handles both in order, so a state that a record depends on is on disk before
+//! that record is.
 
 use std::{
     collections::HashMap,
@@ -82,6 +90,12 @@ enum Message {
         location: Location,
         bytes: Arc<Vec<u8>>,
     },
+    /// `None` deletes the session's state file. Later states for one session supersede
+    /// earlier ones, so the writer keeps only the last of each batch.
+    State {
+        session_id: String,
+        bytes: Option<Vec<u8>>,
+    },
     Reclaim(u64),
 }
 
@@ -102,13 +116,19 @@ struct Tail {
 }
 
 impl SegmentLog {
-    /// Open the log at `directory`, handing every frame it holds to `visit` in write
-    /// order. A torn tail — the last frame of a crashed process — is truncated away.
+    /// Open the log at `directory`. Every session state it holds goes to `visit_state`
+    /// first, then every frame goes to `visit_frame` in write order — states first
+    /// because a frame belongs to a session and says nothing about which. A torn tail —
+    /// the last frame of a crashed process — is truncated away.
     pub(crate) fn open(
         directory: &Path,
+        mut visit_state: impl FnMut(&str, &[u8]) -> Result<(), KernelError>,
         mut visit: impl FnMut(Frame<'_>, Location) -> Result<(), KernelError>,
     ) -> Result<Self, KernelError> {
         fs::create_dir_all(directory).map_err(log_error)?;
+        for (session_id, bytes) in read_states(directory)? {
+            visit_state(&session_id, &bytes)?;
+        }
         let mut segments = Vec::new();
         for entry in fs::read_dir(directory).map_err(log_error)? {
             let path = entry.map_err(log_error)?.path();
@@ -197,6 +217,33 @@ impl SegmentLog {
             bytes: frame,
         })?;
         Ok(location)
+    }
+
+    /// Replace a session's state on disk. Queued behind whatever is already waiting, so
+    /// it lands before any record appended after this call, and superseded by any later
+    /// state for the same session that is still queued.
+    pub(crate) fn write_state(
+        &self,
+        session_id: &str,
+        payload: &serde_json::Value,
+    ) -> Result<(), KernelError> {
+        check_session_id(session_id)?;
+        let bytes =
+            serde_json::to_vec(payload).map_err(|error| KernelError::Journal(error.to_string()))?;
+        self.send(Message::State {
+            session_id: session_id.to_owned(),
+            bytes: Some(bytes),
+        })
+    }
+
+    /// Forget a session's state. Its records stay in the log until their segments are
+    /// reclaimed, exactly as they did when its state was a frame among them.
+    pub(crate) fn remove_state(&self, session_id: &str) -> Result<(), KernelError> {
+        check_session_id(session_id)?;
+        self.send(Message::State {
+            session_id: session_id.to_owned(),
+            bytes: None,
+        })
     }
 
     /// Read a run of frames, in order, handing each to `read`. A page of a session's
@@ -297,10 +344,16 @@ fn spawn_writer(
     thread::spawn(move || {
         let mut open: Option<(u64, BufWriter<File>)> = None;
         let mut written: Vec<(u64, u64)> = Vec::new();
+        // The last state seen for each session in this batch. A session that finished
+        // three turns while the disk was busy is written once, not three times.
+        let mut states: HashMap<String, Option<Vec<u8>>> = HashMap::new();
         while let Ok(first) = receiver.recv() {
             let mut next = Some(first);
             while let Some(message) = next.take() {
                 match message {
+                    Message::State { session_id, bytes } => {
+                        states.insert(session_id, bytes);
+                    }
                     Message::Frame { location, bytes } => {
                         if open.as_ref().is_none_or(|(id, _)| *id != location.segment) {
                             if let Some((_, mut file)) = open.take() {
@@ -327,6 +380,9 @@ fn spawn_writer(
                 }
                 next = receiver.try_recv().ok();
             }
+            // State before the segment flush: a record that a state must precede is
+            // still in the `BufWriter`, so the state reaches the disk first.
+            write_states(&directory, states.drain());
             if let Some((_, file)) = open.as_mut() {
                 let _ = file.flush();
             }
@@ -338,10 +394,81 @@ fn spawn_writer(
                 }
             }
         }
+        write_states(&directory, states.drain());
         if let Some((_, mut file)) = open.take() {
             let _ = file.flush();
         }
     })
+}
+
+/// Replace or delete each session's state file. A state is written to a temporary file
+/// and renamed over the old one, so a reader — including the next process to open this
+/// directory — sees either the whole previous state or the whole new one.
+fn write_states(directory: &Path, states: impl Iterator<Item = (String, Option<Vec<u8>>)>) {
+    for (session_id, bytes) in states {
+        let Some(path) = state_path(directory, &session_id) else {
+            continue;
+        };
+        match bytes {
+            None => {
+                let _ = fs::remove_file(&path);
+            }
+            Some(bytes) => {
+                let staging = path.with_extension("state-writing");
+                if fs::write(&staging, &bytes).is_ok() {
+                    let _ = fs::rename(&staging, &path);
+                }
+            }
+        }
+    }
+}
+
+/// Every session state in `directory`, as raw bytes. A file left behind by a crash
+/// between write and rename carries the `.state-writing` extension and is removed rather
+/// than read: the state it was replacing is still whole under its own name.
+fn read_states(directory: &Path) -> Result<Vec<(String, Vec<u8>)>, KernelError> {
+    let mut states = Vec::new();
+    for entry in fs::read_dir(directory).map_err(log_error)? {
+        let path = entry.map_err(log_error)?.path();
+        match path.extension().and_then(|extension| extension.to_str()) {
+            Some("state-writing") => {
+                let _ = fs::remove_file(&path);
+            }
+            Some("state") => {
+                let Some(session_id) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                    continue;
+                };
+                let session_id = session_id.to_owned();
+                states.push((session_id, fs::read(&path).map_err(log_error)?));
+            }
+            _ => {}
+        }
+    }
+    // Deterministic, so a directory listing's order cannot change what recovery sees.
+    states.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(states)
+}
+
+fn state_path(directory: &Path, session_id: &str) -> Option<PathBuf> {
+    check_session_id(session_id).ok()?;
+    Some(directory.join(format!("{session_id}.state")))
+}
+
+/// A session id becomes a file name, so it may not be able to name anything but a file
+/// in this directory. Ids are generated, not supplied, so this never fires today — it is
+/// here so that it fires loudly rather than silently if that ever changes.
+fn check_session_id(session_id: &str) -> Result<(), KernelError> {
+    let usable = !session_id.is_empty()
+        && session_id.len() <= 128
+        && session_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'));
+    if usable {
+        return Ok(());
+    }
+    Err(KernelError::Journal(
+        "session id cannot name a state file".into(),
+    ))
 }
 
 fn reclaim_segments(directory: &Path, keep_from: u64) {
@@ -494,13 +621,37 @@ mod tests {
     }
 
     fn collect(directory: &Path) -> (SegmentLog, Vec<(u64, String, Location)>) {
-        let mut seen = Vec::new();
-        let log = SegmentLog::open(directory, |frame, location| {
-            seen.push((frame.sequence, frame.kind.to_string(), location));
-            Ok(())
-        })
-        .unwrap();
+        let (log, seen, _) = collect_all(directory);
         (log, seen)
+    }
+
+    /// Frames and session states, in the order `open` hands them over.
+    #[allow(clippy::type_complexity)]
+    fn collect_all(
+        directory: &Path,
+    ) -> (
+        SegmentLog,
+        Vec<(u64, String, Location)>,
+        Vec<(String, serde_json::Value)>,
+    ) {
+        let mut seen = Vec::new();
+        let mut states = Vec::new();
+        let log = SegmentLog::open(
+            directory,
+            |session_id, bytes| {
+                states.push((
+                    session_id.to_owned(),
+                    serde_json::from_slice(bytes).unwrap(),
+                ));
+                Ok(())
+            },
+            |frame, location| {
+                seen.push((frame.sequence, frame.kind.to_string(), location));
+                Ok(())
+            },
+        )
+        .unwrap();
+        (log, seen, states)
     }
 
     #[test]
@@ -561,6 +712,77 @@ mod tests {
         let bytes = encode(&append("ses_test", 0, "session_state", &body)).unwrap();
         let (frame, _) = decode(&bytes).unwrap();
         assert!(!frame.is_sequenced());
+    }
+
+    #[test]
+    fn a_session_state_is_replaced_rather_than_accumulated() {
+        let directory = temporary();
+        let (log, _, states) = collect_all(&directory);
+        assert!(states.is_empty());
+
+        for turn in 1..=8 {
+            log.write_state("ses_test", &serde_json::json!({ "turn": turn }))
+                .unwrap();
+        }
+        drop(log);
+
+        let (log, _, states) = collect_all(&directory);
+        assert_eq!(states.len(), 1, "one file per session, not one per write");
+        assert_eq!(states[0].0, "ses_test");
+        assert_eq!(states[0].1, serde_json::json!({ "turn": 8 }));
+        drop(log);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn a_removed_session_state_does_not_come_back() {
+        let directory = temporary();
+        let (log, _, _) = collect_all(&directory);
+        log.write_state("ses_test", &serde_json::json!({ "turn": 1 }))
+            .unwrap();
+        log.remove_state("ses_test").unwrap();
+        drop(log);
+
+        let (log, _, states) = collect_all(&directory);
+        assert!(states.is_empty());
+        drop(log);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// A crash between writing the replacement and renaming it over the old one leaves a
+    /// staging file. The state under its own name is still whole, so the staging file is
+    /// discarded rather than read.
+    #[test]
+    fn a_half_written_state_is_discarded_and_the_whole_one_kept() {
+        let directory = temporary();
+        let (log, _, _) = collect_all(&directory);
+        log.write_state("ses_test", &serde_json::json!({ "turn": 1 }))
+            .unwrap();
+        drop(log);
+        fs::write(directory.join("ses_test.state-writing"), b"{\"turn\":").unwrap();
+
+        let (log, _, states) = collect_all(&directory);
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].1, serde_json::json!({ "turn": 1 }));
+        assert!(!directory.join("ses_test.state-writing").exists());
+        drop(log);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// A session id becomes a file name. Ids are generated today, so this only fires if
+    /// that changes — which is the point.
+    #[test]
+    fn a_session_id_that_could_escape_the_directory_is_refused() {
+        let directory = temporary();
+        let (log, _, _) = collect_all(&directory);
+        for hostile in ["../escape", "a/b", "", "."] {
+            assert!(
+                log.write_state(hostile, &serde_json::json!({})).is_err(),
+                "{hostile:?} must not name a state file"
+            );
+        }
+        drop(log);
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/crates/brain/src/journal/log.rs
+++ b/crates/brain/src/journal/log.rs
@@ -301,7 +301,7 @@ impl SegmentLog {
         session_id: &str,
         payload: &serde_json::Value,
     ) -> Result<(), KernelError> {
-        check_session_id(session_id)?;
+        usable_as_a_file_name(session_id)?;
         let bytes =
             serde_json::to_vec(payload).map_err(|error| KernelError::Journal(error.to_string()))?;
         self.reserve(bytes.len() as u64)?;
@@ -314,7 +314,7 @@ impl SegmentLog {
     /// Forget a session's state. Its records stay in the log until their segments are
     /// reclaimed, exactly as they did when its state was a frame among them.
     pub(crate) fn remove_state(&self, session_id: &str) -> Result<(), KernelError> {
-        check_session_id(session_id)?;
+        usable_as_a_file_name(session_id)?;
         self.send(Message::State {
             session_id: session_id.to_owned(),
             bytes: None,
@@ -578,17 +578,17 @@ fn read_states(directory: &Path) -> Result<Vec<(String, Vec<u8>)>, KernelError> 
 }
 
 fn state_path(directory: &Path, session_id: &str) -> Option<PathBuf> {
-    check_session_id(session_id).ok()?;
+    usable_as_a_file_name(session_id).ok()?;
     Some(directory.join(format!("{session_id}.state")))
 }
 
-/// A session id becomes a file name, so it may not be able to name anything but a file
-/// in this directory. Ids are generated, not supplied, so this never fires today — it is
-/// here so that it fires loudly rather than silently if that ever changes.
-fn check_session_id(session_id: &str) -> Result<(), KernelError> {
-    let usable = !session_id.is_empty()
-        && session_id.len() <= 128
-        && session_id
+/// Whether `name` can be a file in a directory and nothing else. A session id becomes a
+/// state file's name, and ids are generated rather than supplied, so this never fires
+/// today — it is here so that it fires loudly rather than silently if that changes.
+fn usable_as_a_file_name(name: &str) -> Result<(), KernelError> {
+    let usable = !name.is_empty()
+        && name.len() <= 128
+        && name
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'));
     if usable {

--- a/crates/brain/src/journal/mod.rs
+++ b/crates/brain/src/journal/mod.rs
@@ -8,5 +8,5 @@ mod store;
 pub use cursor::event_page;
 pub(crate) use observed::ObservedJournal;
 pub use record::{AppendRecord, JournalRecord};
-pub use segment::SegmentJournal;
+pub use segment::{DEFAULT_IDEMPOTENCY_RETENTION, SegmentJournal};
 pub use store::{JournalStore, SessionRow, SessionUpdate};

--- a/crates/brain/src/journal/segment.rs
+++ b/crates/brain/src/journal/segment.rs
@@ -17,7 +17,7 @@ use std::{
     collections::HashMap,
     path::Path,
     sync::Mutex,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use brain_protocol::{Identity, JournalId, Session, SessionId, SessionStatus};
@@ -35,9 +35,25 @@ use crate::{
 /// namespace a session's record kinds are drawn from.
 const IDEMPOTENCY: &str = "$idempotency";
 
+/// How long a recorded answer is kept, and so how long a redelivery of the same request
+/// is answered from the record rather than executed again.
+///
+/// A window is unavoidable: a record that never expires is a record that pins the
+/// segment it was written in forever, and Brain measured exactly that — one entry from
+/// a deleted session held back every reclaimable segment, and a million entries held
+/// 2 GiB of memory across a restart. What the window buys is that the cost is bounded
+/// by traffic within it rather than by traffic since the process was first started.
+///
+/// A day is far longer than any retry a client makes and far shorter than forever.
+pub const DEFAULT_IDEMPOTENCY_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Below this an eviction sweep costs more than the entries it would find.
+const MIN_IDEMPOTENCY_SWEEP: usize = 64;
+
 pub struct SegmentJournal {
     log: SegmentLog,
     state: Mutex<State>,
+    idempotency_retention: Duration,
 }
 
 #[derive(Default)]
@@ -45,6 +61,9 @@ struct State {
     /// Keyed by the raw session id so replay and lookups never allocate one.
     sessions: HashMap<String, Tracked>,
     idempotency: HashMap<(String, String), Stored>,
+    /// Sweep expired records once the table has doubled since the last sweep, so the
+    /// total cost of sweeping stays linear in the number of records written.
+    idempotency_sweep_at: usize,
 }
 
 struct Tracked {
@@ -58,10 +77,13 @@ struct Stored {
     request: Identity,
     response: serde_json::Value,
     segment: u64,
+    expires_at_ms: u64,
 }
 
 impl SegmentJournal {
-    pub fn open(directory: &Path) -> Result<Self, KernelError> {
+    /// `idempotency_retention` is how long a recorded answer stays answerable. See
+    /// [`DEFAULT_IDEMPOTENCY_RETENTION`] for why it is finite.
+    pub fn open(directory: &Path, idempotency_retention: Duration) -> Result<Self, KernelError> {
         // Both visitors need the same state and neither ever runs while the other is
         // borrowed, which the borrow checker cannot see across two closures.
         let state = RefCell::new(State::default());
@@ -70,9 +92,12 @@ impl SegmentJournal {
             |session_id, bytes| restore_session(&mut state.borrow_mut(), session_id, bytes),
             |frame, location| replay(&mut state.borrow_mut(), &frame, location),
         )?;
+        let mut state = state.into_inner();
+        state.idempotency_sweep_at = state.idempotency.len().max(MIN_IDEMPOTENCY_SWEEP);
         Ok(Self {
             log,
-            state: Mutex::new(state.into_inner()),
+            state: Mutex::new(state),
+            idempotency_retention,
         })
     }
 
@@ -100,6 +125,67 @@ impl SegmentJournal {
             kind,
             payload,
         })
+    }
+}
+
+impl SegmentJournal {
+    /// Free every segment nothing live still needs.
+    ///
+    /// Sessions pin the segment their oldest record is in, and that is inherent: those
+    /// records are the history a client can still page through. Idempotency records are
+    /// not — they are small, they are not addressable, and one of them sitting in an old
+    /// segment used to hold back every reclaimable segment behind it. Expired ones are
+    /// dropped, and live ones below the floor are appended again at the head so the
+    /// segment they were in can go.
+    fn reclaim(&self) -> Result<(), KernelError> {
+        let now = wall_clock_ms()?;
+        let current = self.log.current_segment()?;
+        let stale = {
+            let mut state = self.lock()?;
+            state
+                .idempotency
+                .retain(|_, stored| stored.expires_at_ms > now);
+            let floor = session_floor(&state, current);
+            state
+                .idempotency
+                .iter()
+                .filter(|(_, stored)| stored.segment < floor)
+                .map(|((scope, key), stored)| {
+                    (
+                        scope.clone(),
+                        key.clone(),
+                        stored.request,
+                        stored.response.clone(),
+                        stored.expires_at_ms,
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for (scope, key, request, response, expires_at_ms) in stale {
+            let location = self.write(
+                "",
+                0,
+                now,
+                IDEMPOTENCY,
+                &serde_json::json!({
+                    "scope": scope,
+                    "key": key,
+                    "request": request,
+                    "response": response,
+                    "expires_at_ms": expires_at_ms,
+                }),
+            )?;
+            if let Some(stored) = self.lock()?.idempotency.get_mut(&(scope, key)) {
+                stored.segment = location.segment;
+            }
+        }
+
+        let floor = {
+            let state = self.lock()?;
+            reclaim_floor(&state, current)
+        };
+        self.log.reclaim(floor)
     }
 }
 
@@ -305,11 +391,10 @@ impl JournalStore for SegmentJournal {
         }
         self.log.remove_state(session_id.as_str())?;
         state.sessions.remove(session_id.as_str());
+        drop(state);
 
         // The session's records were the only thing keeping its segments alive.
-        let floor = reclaim_floor(&state, self.log.current_segment()?);
-        drop(state);
-        self.log.reclaim(floor)
+        self.reclaim()
     }
 
     fn idempotency_get(
@@ -318,8 +403,18 @@ impl JournalStore for SegmentJournal {
         key: &str,
         request: &Identity,
     ) -> Result<Option<serde_json::Value>, KernelError> {
-        match self.lock()?.idempotency.get(&(scope.into(), key.into())) {
+        let now = wall_clock_ms()?;
+        let mut state = self.lock()?;
+        let entry = (scope.to_string(), key.to_string());
+        match state.idempotency.get(&entry) {
             None => Ok(None),
+            // Past its retention it is not a record any more. Dropped here rather than
+            // returned, so the caller executes the request instead of replaying an
+            // answer Brain has stopped promising to keep.
+            Some(stored) if stored.expires_at_ms <= now => {
+                state.idempotency.remove(&entry);
+                Ok(None)
+            }
             Some(stored) if stored.request != *request => Err(KernelError::InvalidState(
                 "idempotency key reused with different request".into(),
             )),
@@ -334,23 +429,42 @@ impl JournalStore for SegmentJournal {
         request: &Identity,
         response: &serde_json::Value,
     ) -> Result<(), KernelError> {
+        let recorded_at_ms = wall_clock_ms()?;
+        let expires_at_ms = recorded_at_ms.saturating_add(
+            u64::try_from(self.idempotency_retention.as_millis()).unwrap_or(u64::MAX),
+        );
         let mut state = self.lock()?;
         let entry = (scope.to_string(), key.to_string());
-        if state.idempotency.contains_key(&entry) {
+        if state
+            .idempotency
+            .get(&entry)
+            .is_some_and(|stored| stored.expires_at_ms > recorded_at_ms)
+        {
             return Err(KernelError::InvalidState(
                 "idempotency key already recorded".into(),
             ));
         }
+        if state.idempotency.len() >= state.idempotency_sweep_at {
+            state
+                .idempotency
+                .retain(|_, stored| stored.expires_at_ms > recorded_at_ms);
+            state.idempotency_sweep_at = state
+                .idempotency
+                .len()
+                .saturating_mul(2)
+                .max(MIN_IDEMPOTENCY_SWEEP);
+        }
         let location = self.write(
             "",
             0,
-            wall_clock_ms()?,
+            recorded_at_ms,
             IDEMPOTENCY,
             &serde_json::json!({
                 "scope": scope,
                 "key": key,
                 "request": request,
                 "response": response,
+                "expires_at_ms": expires_at_ms,
             }),
         )?;
         state.idempotency.insert(
@@ -359,6 +473,7 @@ impl JournalStore for SegmentJournal {
                 request: *request,
                 response: response.clone(),
                 segment: location.segment,
+                expires_at_ms,
             },
         );
         Ok(())
@@ -420,6 +535,10 @@ fn replay(state: &mut State, frame: &Frame<'_>, location: Location) -> Result<()
                 request: payload.request,
                 response: payload.response,
                 segment: location.segment,
+                // A frame written before expiry was recorded describes a record from a
+                // journal that kept them forever. Treating it as already expired is what
+                // the retention now says, and it is what lets its segment be reclaimed.
+                expires_at_ms: payload.expires_at_ms.unwrap_or(0),
             },
         );
     }
@@ -443,17 +562,24 @@ struct IdempotencyFrame {
     key: String,
     request: Identity,
     response: serde_json::Value,
+    expires_at_ms: Option<u64>,
 }
 
 /// The oldest segment any surviving state still lives in. Everything below it is dead
 /// and can be unlinked whole. With nothing left alive, every closed segment goes.
 fn reclaim_floor(state: &State, current_segment: u64) -> u64 {
-    let sessions = state
+    let idempotency = state.idempotency.values().map(|stored| stored.segment);
+    session_floor(state, current_segment).min(idempotency.min().unwrap_or(u64::MAX))
+}
+
+/// The oldest segment a live session's history still lives in.
+fn session_floor(state: &State, current_segment: u64) -> u64 {
+    state
         .sessions
         .values()
-        .filter_map(|tracked| tracked.locations.first().map(|location| location.segment));
-    let idempotency = state.idempotency.values().map(|stored| stored.segment);
-    sessions.chain(idempotency).min().unwrap_or(current_segment)
+        .filter_map(|tracked| tracked.locations.first().map(|location| location.segment))
+        .min()
+        .unwrap_or(current_segment)
 }
 
 fn wall_clock_ms() -> Result<u64, KernelError> {
@@ -471,4 +597,154 @@ fn not_found() -> KernelError {
 
 fn ended_first() -> KernelError {
     KernelError::InvalidState("session must exist and be ended before deletion".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::journal::AppendRecord;
+
+    fn temporary() -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "brain-segment-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn row() -> SessionRow {
+        SessionRow {
+            session_id: SessionId::new("ses_0000".to_owned()),
+            journal_id: JournalId::new("jrn_0000".to_owned()),
+            status: SessionStatus::Idle,
+            through_sequence: 1,
+            configuration: serde_json::json!({}),
+            context: serde_json::json!({}),
+            presentation_identity: Identity::of_bytes(b"presentation"),
+        }
+    }
+
+    /// The floor is what decides which segments can be unlinked. A record that is not a
+    /// session's history has no business holding it down.
+    #[test]
+    fn an_expired_record_leaves_the_floor_to_the_sessions() {
+        let mut state = State::default();
+        state.idempotency.insert(
+            ("scope".to_owned(), "key".to_owned()),
+            Stored {
+                request: Identity::of_bytes(b"request"),
+                response: serde_json::json!({}),
+                segment: 0,
+                expires_at_ms: 0,
+            },
+        );
+        assert_eq!(
+            reclaim_floor(&state, 9),
+            0,
+            "a record still in the table is still at the floor"
+        );
+
+        state
+            .idempotency
+            .retain(|_, stored| stored.expires_at_ms > 1);
+        assert_eq!(
+            reclaim_floor(&state, 9),
+            9,
+            "once swept, nothing holds the floor below the open segment"
+        );
+    }
+
+    /// A live record cannot be dropped, so reclamation writes it again at the head and
+    /// leaves the old copy behind to be unlinked with its segment. Without this it holds
+    /// that segment for its whole retention.
+    ///
+    /// The move itself is only visible once the log has rotated, which costs 64 MiB to
+    /// reach, so what is asserted here is that the record was written a second time and
+    /// is still answerable.
+    #[test]
+    fn a_live_record_below_the_floor_is_written_again_at_the_head() {
+        let directory = temporary();
+        let journal = SegmentJournal::open(&directory, Duration::from_secs(3_600)).unwrap();
+        let request = Identity::of_bytes(b"request");
+        journal
+            .idempotency_put("scope", "key", &request, &serde_json::json!({ "ok": true }))
+            .unwrap();
+
+        // A session whose history starts above the record, which is what an old segment
+        // means once the log has rotated past it.
+        journal.lock().unwrap().sessions.insert(
+            "ses_pin".to_owned(),
+            Tracked {
+                row: row(),
+                locations: vec![Location {
+                    segment: 1,
+                    offset: 0,
+                    length: 1,
+                }],
+                last_recorded_at_ms: 0,
+            },
+        );
+
+        journal.reclaim().unwrap();
+        assert_eq!(
+            journal.idempotency_get("scope", "key", &request).unwrap(),
+            Some(serde_json::json!({ "ok": true }))
+        );
+        drop(journal);
+
+        let mut records = 0;
+        let log = SegmentLog::open(
+            &directory,
+            |_, _| Ok(()),
+            |frame, _| {
+                if frame.kind == IDEMPOTENCY {
+                    records += 1;
+                }
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            records, 2,
+            "the record below the floor must be written again rather than pinning its segment"
+        );
+        drop(log);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    /// Session state is the one thing that is never a record, so a session that has
+    /// written nothing since it was created must still come back.
+    #[test]
+    fn a_session_comes_back_from_its_state_file() {
+        let directory = temporary();
+        let journal = SegmentJournal::open(&directory, DEFAULT_IDEMPOTENCY_RETENTION).unwrap();
+        let mut created = row();
+        created.context = serde_json::json!({ "items": ["one", "two"] });
+        journal
+            .create_session(
+                &created,
+                AppendRecord::new("session_created", serde_json::json!({})),
+            )
+            .unwrap();
+        drop(journal);
+
+        let journal = SegmentJournal::open(&directory, DEFAULT_IDEMPOTENCY_RETENTION).unwrap();
+        let restored = journal
+            .session_row(&created.session_id)
+            .unwrap()
+            .expect("the session was created above");
+        assert_eq!(restored.context, created.context);
+        assert_eq!(restored.journal_id, created.journal_id);
+        assert_eq!(
+            restored.through_sequence, 1,
+            "the sequence comes from the records on disk, not from the state file"
+        );
+        drop(journal);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
 }

--- a/crates/brain/src/journal/segment.rs
+++ b/crates/brain/src/journal/segment.rs
@@ -4,9 +4,17 @@
 //! behind the caller and is only read to rebuild this state at startup, or to page a
 //! client back through records it has not seen. Appending costs a serialise and a
 //! channel send; no journal call waits on the disk.
+//!
+//! A session's own state — its status, its sealed configuration, its context — is not a
+//! record. It is rewritten at the end of every turn and only its latest value is ever
+//! read, so it lives in a file per session that the log rewrites in place. Appending it
+//! instead wrote the sum of every context the session ever had: a 64-turn session
+//! holding a 1 MiB context left 34 MB of journal, all of it read back at every restart,
+//! and nothing bounds the turn count.
 
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    cell::RefCell,
+    collections::HashMap,
     path::Path,
     sync::Mutex,
     time::{SystemTime, UNIX_EPOCH},
@@ -22,11 +30,9 @@ use crate::{
     },
 };
 
-/// Frame kinds the journal writes for itself. They carry no sequence number, so they
-/// never reach a client's event stream, and the `$` prefix keeps them out of the
+/// The one frame kind the journal writes for itself. It carries no sequence number, so
+/// it never reaches a client's event stream, and the `$` prefix keeps it out of the
 /// namespace a session's record kinds are drawn from.
-const SESSION_STATE: &str = "$session";
-const SESSION_DELETED: &str = "$deleted";
 const IDEMPOTENCY: &str = "$idempotency";
 
 pub struct SegmentJournal {
@@ -45,8 +51,6 @@ struct Tracked {
     row: SessionRow,
     /// `locations[i]` holds the record at sequence `i + 1`.
     locations: Vec<Location>,
-    /// Where the session's own state was last written, so reclamation keeps it.
-    state_segment: u64,
     last_recorded_at_ms: u64,
 }
 
@@ -58,13 +62,17 @@ struct Stored {
 
 impl SegmentJournal {
     pub fn open(directory: &Path) -> Result<Self, KernelError> {
-        let mut state = State::default();
-        let log = SegmentLog::open(directory, |frame, location| {
-            replay(&mut state, &frame, location)
-        })?;
+        // Both visitors need the same state and neither ever runs while the other is
+        // borrowed, which the borrow checker cannot see across two closures.
+        let state = RefCell::new(State::default());
+        let log = SegmentLog::open(
+            directory,
+            |session_id, bytes| restore_session(&mut state.borrow_mut(), session_id, bytes),
+            |frame, location| replay(&mut state.borrow_mut(), &frame, location),
+        )?;
         Ok(Self {
             log,
-            state: Mutex::new(state),
+            state: Mutex::new(state.into_inner()),
         })
     }
 
@@ -109,19 +117,8 @@ impl JournalStore for SegmentJournal {
 
         // State before the record: a replay that stops between the two still knows the
         // session, and the record it is missing is one nothing has acted on yet.
-        let state_location = self.write(
-            row.session_id.as_str(),
-            0,
-            recorded_at_ms,
-            SESSION_STATE,
-            &serde_json::json!({
-                "journal_id": row.journal_id,
-                "status": row.status,
-                "configuration": row.configuration,
-                "context": row.context,
-                "presentation_identity": row.presentation_identity,
-            }),
-        )?;
+        self.log
+            .write_state(row.session_id.as_str(), &state_payload(row))?;
         let location = self.write(
             row.session_id.as_str(),
             1,
@@ -137,7 +134,6 @@ impl JournalStore for SegmentJournal {
             Tracked {
                 row: row.clone(),
                 locations: vec![location],
-                state_segment: state_location.segment,
                 last_recorded_at_ms: recorded_at_ms,
             },
         );
@@ -198,17 +194,6 @@ impl JournalStore for SegmentJournal {
             });
         }
 
-        let state_location = match state_payload(&update) {
-            Some(payload) => Some(self.write(
-                session_id.as_str(),
-                0,
-                recorded_at_ms,
-                SESSION_STATE,
-                &payload,
-            )?),
-            None => None,
-        };
-
         let tracked = state
             .sessions
             .get_mut(session_id.as_str())
@@ -216,6 +201,8 @@ impl JournalStore for SegmentJournal {
         tracked.locations.extend(locations);
         tracked.row.through_sequence = expected_through + records.len() as u64;
         tracked.last_recorded_at_ms = recorded_at_ms;
+        let changed =
+            update.status.is_some() || update.context.is_some() || update.configuration.is_some();
         if let Some(status) = update.status {
             tracked.row.status = status;
         }
@@ -225,8 +212,14 @@ impl JournalStore for SegmentJournal {
         if let Some(configuration) = update.configuration {
             tracked.row.configuration = configuration.clone();
         }
-        if let Some(location) = state_location {
-            tracked.state_segment = location.segment;
+        // Rewritten only when the update moved something. A turn whose records change
+        // nothing about the session — a batch of intents mid-turn — leaves the state
+        // file alone, so the context is written once per turn and not once per commit.
+        if changed {
+            let payload = state_payload(&tracked.row);
+            let session = session_id.as_str().to_owned();
+            drop(state);
+            self.log.write_state(&session, &payload)?;
         }
 
         Ok(saved)
@@ -310,13 +303,7 @@ impl JournalStore for SegmentJournal {
         if !matches!(tracked.row.status, SessionStatus::Ended) {
             return Err(ended_first());
         }
-        self.write(
-            session_id.as_str(),
-            0,
-            wall_clock_ms()?,
-            SESSION_DELETED,
-            &serde_json::json!({}),
-        )?;
+        self.log.remove_state(session_id.as_str())?;
         state.sessions.remove(session_id.as_str());
 
         // The session's records were the only thing keeping its segments alive.
@@ -378,20 +365,41 @@ impl JournalStore for SegmentJournal {
     }
 }
 
-/// Only the fields an update actually changes, so a turn that touches nothing but its
-/// status does not rewrite the context envelope.
-fn state_payload(update: &SessionUpdate<'_>) -> Option<serde_json::Value> {
-    let mut payload = serde_json::Map::new();
-    if let Some(status) = &update.status {
-        payload.insert("status".into(), serde_json::json!(status));
-    }
-    if let Some(context) = update.context {
-        payload.insert("context".into(), context.clone());
-    }
-    if let Some(configuration) = update.configuration {
-        payload.insert("configuration".into(), configuration.clone());
-    }
-    (!payload.is_empty()).then_some(serde_json::Value::Object(payload))
+/// The whole state, because the file it goes to replaces its predecessor rather than
+/// following it. `through_sequence` is deliberately absent: it is what the records on
+/// disk say it is, and deriving it there keeps the two from disagreeing.
+fn state_payload(row: &SessionRow) -> serde_json::Value {
+    serde_json::json!({
+        "journal_id": row.journal_id,
+        "status": row.status,
+        "configuration": row.configuration,
+        "context": row.context,
+        "presentation_identity": row.presentation_identity,
+    })
+}
+
+/// Rebuild one session from its state file. Called for every session before any record
+/// is replayed, so a record always finds the session it belongs to.
+fn restore_session(state: &mut State, session_id: &str, bytes: &[u8]) -> Result<(), KernelError> {
+    let payload: StateFile = serde_json::from_slice(bytes)
+        .map_err(|error| KernelError::Journal(format!("session state is unreadable: {error}")))?;
+    state.sessions.insert(
+        session_id.to_owned(),
+        Tracked {
+            row: SessionRow {
+                session_id: SessionId::new(session_id.to_owned()),
+                journal_id: payload.journal_id,
+                presentation_identity: payload.presentation_identity,
+                status: payload.status,
+                through_sequence: 0,
+                configuration: payload.configuration,
+                context: payload.context,
+            },
+            locations: Vec::new(),
+            last_recorded_at_ms: 0,
+        },
+    );
+    Ok(())
 }
 
 fn replay(state: &mut State, frame: &Frame<'_>, location: Location) -> Result<(), KernelError> {
@@ -404,84 +412,29 @@ fn replay(state: &mut State, frame: &Frame<'_>, location: Location) -> Result<()
         return Ok(());
     }
 
-    match frame.kind {
-        SESSION_STATE => {
-            // Decoded straight into its own shape and moved in. Building a `Value` and
-            // then cloning the context out of it materialised the context twice, and a
-            // session writes one of these per turn — so replay paid for every context it
-            // ever had, twice over, to keep the last.
-            let payload: StateFrame = frame.decode()?;
-            let tracked = match state.sessions.entry(frame.session_id.to_string()) {
-                Entry::Occupied(occupied) => occupied.into_mut(),
-                Entry::Vacant(vacant) => {
-                    // A frame that introduces a session always carries both; a later one
-                    // that only moves its status finds the session already here.
-                    let (Some(journal_id), Some(presentation_identity)) =
-                        (payload.journal_id, payload.presentation_identity)
-                    else {
-                        return Err(KernelError::Journal(
-                            "the first session state frame must name the journal and the presentation".into(),
-                        ));
-                    };
-                    vacant.insert(Tracked {
-                        row: SessionRow {
-                            session_id: SessionId::new(frame.session_id.to_string()),
-                            journal_id,
-                            presentation_identity,
-                            status: SessionStatus::Idle,
-                            through_sequence: 0,
-                            configuration: serde_json::Value::Null,
-                            context: serde_json::Value::Null,
-                        },
-                        locations: Vec::new(),
-                        state_segment: location.segment,
-                        last_recorded_at_ms: frame.recorded_at_ms,
-                    })
-                }
-            };
-            if let Some(status) = payload.status {
-                tracked.row.status = status;
-            }
-            if let Some(context) = payload.context {
-                tracked.row.context = context;
-            }
-            if let Some(configuration) = payload.configuration {
-                tracked.row.configuration = configuration;
-            }
-            if let Some(identity) = payload.presentation_identity {
-                tracked.row.presentation_identity = identity;
-            }
-            tracked.state_segment = location.segment;
-        }
-        SESSION_DELETED => {
-            state.sessions.remove(frame.session_id);
-        }
-        IDEMPOTENCY => {
-            let payload: IdempotencyFrame = frame.decode()?;
-            state.idempotency.insert(
-                (payload.scope, payload.key),
-                Stored {
-                    request: payload.request,
-                    response: payload.response,
-                    segment: location.segment,
-                },
-            );
-        }
-        _ => {}
+    if frame.kind == IDEMPOTENCY {
+        let payload: IdempotencyFrame = frame.decode()?;
+        state.idempotency.insert(
+            (payload.scope, payload.key),
+            Stored {
+                request: payload.request,
+                response: payload.response,
+                segment: location.segment,
+            },
+        );
     }
     Ok(())
 }
 
-/// A `$session` frame carries only the fields the update that wrote it changed, so every
-/// one is optional. Decoding into this rather than a `Value` means the context is built
-/// once and moved, not built and then cloned.
+/// A session's state file. Every field is required: the file is the whole state, and a
+/// file that cannot supply one of them describes no session that can be resumed.
 #[derive(serde::Deserialize)]
-struct StateFrame {
-    journal_id: Option<JournalId>,
-    presentation_identity: Option<Identity>,
-    status: Option<SessionStatus>,
-    context: Option<serde_json::Value>,
-    configuration: Option<serde_json::Value>,
+struct StateFile {
+    journal_id: JournalId,
+    presentation_identity: Identity,
+    status: SessionStatus,
+    context: serde_json::Value,
+    configuration: serde_json::Value,
 }
 
 #[derive(serde::Deserialize)]
@@ -495,14 +448,10 @@ struct IdempotencyFrame {
 /// The oldest segment any surviving state still lives in. Everything below it is dead
 /// and can be unlinked whole. With nothing left alive, every closed segment goes.
 fn reclaim_floor(state: &State, current_segment: u64) -> u64 {
-    let sessions = state.sessions.values().map(|tracked| {
-        tracked
-            .locations
-            .first()
-            .map_or(tracked.state_segment, |location| {
-                location.segment.min(tracked.state_segment)
-            })
-    });
+    let sessions = state
+        .sessions
+        .values()
+        .filter_map(|tracked| tracked.locations.first().map(|location| location.segment));
     let idempotency = state.idempotency.values().map(|stored| stored.segment);
     sessions.chain(idempotency).min().unwrap_or(current_segment)
 }

--- a/crates/brain/src/lib.rs
+++ b/crates/brain/src/lib.rs
@@ -11,7 +11,10 @@ pub mod tool;
 
 pub use agentloop::LoopExecutor;
 pub use error::KernelError;
-pub use journal::{AppendRecord, JournalRecord, JournalStore, SegmentJournal, SessionUpdate};
+pub use journal::{
+    AppendRecord, DEFAULT_IDEMPOTENCY_RETENTION, JournalRecord, JournalStore, SegmentJournal,
+    SessionUpdate,
+};
 pub use model::ModelExecutor;
 pub use session::{CreatingSession, Kernel, KernelConfig, SessionHandle};
 pub use tool::ToolExecutor;

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -64,7 +64,10 @@ impl Kernel {
     pub fn open(config: KernelConfig, telemetry: TelemetryPublisher) -> Result<Self, KernelError> {
         fs::create_dir_all(&config.data_dir)
             .map_err(|error| KernelError::Journal(error.to_string()))?;
-        let store = Arc::new(SegmentJournal::open(&config.data_dir.join("journal"))?);
+        let store = Arc::new(SegmentJournal::open(
+            &config.data_dir.join("journal"),
+            crate::journal::DEFAULT_IDEMPOTENCY_RETENTION,
+        )?);
         Self::with_store(config, store, telemetry)
     }
 

--- a/crates/brain/tests/idempotency_retention.rs
+++ b/crates/brain/tests/idempotency_retention.rs
@@ -1,0 +1,215 @@
+//! A recorded answer must not pin the disk it was written on forever.
+//!
+//! Every idempotency record stayed in memory and in the log for the life of the process,
+//! and the reclamation floor included the oldest of them. One record — the one that
+//! deleting a session writes — was enough to hold back every segment behind it, so a
+//! server that created and deleted sessions grew without bound. Measured before this:
+//! deleting a session with no idempotency record freed 2 of 3 segments; with one old
+//! record, 0 of 3. A million records held about 2 GiB of private memory after a restart.
+//!
+//! Records now carry an expiry. Past it they are not answers any more, so they are
+//! dropped and they stop pinning anything; a live one below the floor is written forward
+//! rather than holding its segment.
+
+use std::{fs, path::PathBuf, time::Duration};
+
+use brain::{AppendRecord, JournalStore, SegmentJournal, SessionUpdate, journal::SessionRow};
+use brain_protocol::{Identity, JournalId, SessionId, SessionStatus};
+
+/// The scope every recorded answer in these tests is filed under.
+const SCOPE: &str = "session:test:message";
+
+fn temporary_directory(name: &str) -> PathBuf {
+    let directory = std::env::temp_dir().join(format!(
+        "brain-idempotency-{name}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&directory).unwrap();
+    directory
+}
+
+fn session(index: usize) -> SessionRow {
+    SessionRow {
+        session_id: SessionId::new(format!("ses_{index:04}")),
+        journal_id: JournalId::new(format!("jrn_{index:04}")),
+        status: SessionStatus::Idle,
+        through_sequence: 1,
+        configuration: serde_json::json!({}),
+        context: serde_json::json!({ "items": [] }),
+        presentation_identity: Identity::of_bytes(b"presentation"),
+    }
+}
+
+fn put(journal: &SegmentJournal, key: &str) {
+    let request = Identity::of_bytes(key.as_bytes());
+    journal
+        .idempotency_put(
+            SCOPE,
+            key,
+            &request,
+            &serde_json::json!({ "answered": key }),
+        )
+        .unwrap();
+}
+
+#[test]
+fn a_recorded_answer_is_replayed_inside_its_retention() {
+    let directory = temporary_directory("live");
+    let journal = SegmentJournal::open(&directory, Duration::from_secs(60)).unwrap();
+    let request = Identity::of_bytes(b"one");
+
+    put(&journal, "one");
+
+    assert_eq!(
+        journal.idempotency_get(SCOPE, "one", &request).unwrap(),
+        Some(serde_json::json!({ "answered": "one" })),
+    );
+    // The same key with different content is a caller error, not a miss.
+    assert!(
+        journal
+            .idempotency_get(SCOPE, "one", &Identity::of_bytes(b"other"))
+            .is_err()
+    );
+
+    drop(journal);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+/// The window's whole point, stated as a test: past it, the request is executed again
+/// rather than answered from a record Brain has stopped promising to keep.
+#[test]
+fn a_recorded_answer_stops_being_replayed_once_it_expires() {
+    let directory = temporary_directory("expired");
+    let journal = SegmentJournal::open(&directory, Duration::ZERO).unwrap();
+    let request = Identity::of_bytes(b"one");
+
+    put(&journal, "one");
+
+    assert_eq!(
+        journal.idempotency_get(SCOPE, "one", &request).unwrap(),
+        None
+    );
+    // And the key is free again, rather than permanently poisoned by its own record.
+    put(&journal, "one");
+
+    drop(journal);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+/// An expired record survives a restart in the log until its segment is reclaimed. It
+/// must not come back as an answer.
+#[test]
+fn an_expired_record_does_not_return_after_a_restart() {
+    let directory = temporary_directory("restart");
+    let journal = SegmentJournal::open(&directory, Duration::ZERO).unwrap();
+    put(&journal, "one");
+    drop(journal);
+
+    let journal = SegmentJournal::open(&directory, Duration::ZERO).unwrap();
+    assert_eq!(
+        journal
+            .idempotency_get(SCOPE, "one", &Identity::of_bytes(b"one"))
+            .unwrap(),
+        None
+    );
+
+    drop(journal);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+/// Codex's decisive case: delete a session that has one old idempotency record against
+/// it. That record used to sit at the reclamation floor forever. Which segments are
+/// unlinked is covered by `journal::segment::tests`; what this pins is that reclamation
+/// sweeps the record rather than carrying it.
+#[test]
+fn an_old_record_is_swept_when_reclamation_runs() {
+    let directory = temporary_directory("floor");
+    let journal = SegmentJournal::open(&directory, Duration::ZERO).unwrap();
+
+    put(&journal, "the-record-that-used-to-pin-everything");
+
+    let row = session(0);
+    journal
+        .create_session(
+            &row,
+            AppendRecord::new("session_created", serde_json::json!({})),
+        )
+        .unwrap();
+    journal
+        .append(
+            &row.session_id,
+            1,
+            &[AppendRecord::new("session_ended", serde_json::json!({}))],
+            SessionUpdate {
+                status: Some(SessionStatus::Ended),
+                context: None,
+                configuration: None,
+            },
+        )
+        .unwrap();
+
+    // Deleting the last session is what triggers reclamation.
+    journal.delete_ended(&row.session_id).unwrap();
+
+    // Nothing live is left, so nothing is left to answer either.
+    assert!(journal.session_summaries().unwrap().is_empty());
+    assert_eq!(
+        journal
+            .idempotency_get(
+                SCOPE,
+                "the-record-that-used-to-pin-everything",
+                &Identity::of_bytes(b"the-record-that-used-to-pin-everything")
+            )
+            .unwrap(),
+        None,
+        "an expired record must not survive the sweep that reclamation runs"
+    );
+
+    drop(journal);
+    fs::remove_dir_all(directory).unwrap();
+}
+
+/// A live record below the floor is written forward instead of holding its segment, so a
+/// long-lived record cannot pin a segment for its whole retention.
+#[test]
+fn a_live_record_is_written_forward_rather_than_holding_its_segment() {
+    let directory = temporary_directory("forward");
+    let journal = SegmentJournal::open(&directory, Duration::from_secs(3_600)).unwrap();
+
+    put(&journal, "still-live");
+
+    let row = session(0);
+    journal
+        .create_session(
+            &row,
+            AppendRecord::new("session_created", serde_json::json!({})),
+        )
+        .unwrap();
+    journal
+        .append(
+            &row.session_id,
+            1,
+            &[AppendRecord::new("session_ended", serde_json::json!({}))],
+            SessionUpdate {
+                status: Some(SessionStatus::Ended),
+                context: None,
+                configuration: None,
+            },
+        )
+        .unwrap();
+    journal.delete_ended(&row.session_id).unwrap();
+
+    // Still answerable: writing it forward moves where it lives, not whether it exists.
+    assert_eq!(
+        journal
+            .idempotency_get(SCOPE, "still-live", &Identity::of_bytes(b"still-live"))
+            .unwrap(),
+        Some(serde_json::json!({ "answered": "still-live" })),
+    );
+
+    drop(journal);
+    fs::remove_dir_all(directory).unwrap();
+}

--- a/crates/brain/tests/journal_growth.rs
+++ b/crates/brain/tests/journal_growth.rs
@@ -367,11 +367,9 @@ fn start(kernel: &Kernel, sealed: SealedSessionConfig) -> SessionHandle {
 /// bytes of journal for a 1 MiB context, 32.6x. The closed form predicts `(T+1)/2` =
 /// 32.5x, so what is being measured is the per-turn write and not overhead around it.
 ///
-/// IGNORED because it fails today and describes work that is not done. It is the
-/// acceptance test for that work: remove the `#[ignore]` when the per-turn context write
-/// goes away, and it will hold the fix in place. See `PERF-REVIEW.md` finding X0.
+/// Session state now lives in a file per session that is rewritten in place rather than
+/// appended, so the same run leaves 1,084,376 bytes — 1.0x, and flat in the turn count.
 #[tokio::test]
-#[ignore = "records a known defect: the journal grows with the square of the turn count"]
 async fn a_session_does_not_journal_one_context_copy_per_turn() {
     /// Turns in the measured session. Far below anything a real conversation reaches.
     const TURNS: usize = 64;

--- a/crates/brain/tests/journal_growth.rs
+++ b/crates/brain/tests/journal_growth.rs
@@ -228,7 +228,11 @@ async fn the_session_row_still_holds_the_final_context_after_the_turn() {
     // Moving the context write off the per-decision path must not leave the row stale:
     // the row is the only thing rehydration reads, and `Decision::Finish` historically
     // relied on the per-decision write having already persisted it.
-    let store = brain::SegmentJournal::open(&data_dir.join("journal")).unwrap();
+    let store = brain::SegmentJournal::open(
+        &data_dir.join("journal"),
+        brain::DEFAULT_IDEMPOTENCY_RETENTION,
+    )
+    .unwrap();
     let row = brain::JournalStore::session_row(&store, &session_id)
         .unwrap()
         .unwrap();

--- a/crates/brain/tests/journal_throughput.rs
+++ b/crates/brain/tests/journal_throughput.rs
@@ -33,7 +33,7 @@ fn reports_what_the_journal_costs() {
             .unwrap()
             .as_nanos()
     ));
-    let store = SegmentJournal::open(&directory).unwrap();
+    let store = SegmentJournal::open(&directory, brain::DEFAULT_IDEMPOTENCY_RETENTION).unwrap();
 
     let session_id = SessionId::new("ses_throughput");
     store
@@ -76,7 +76,7 @@ fn reports_what_the_journal_costs() {
     drop(store);
 
     let at = Instant::now();
-    let reopened = SegmentJournal::open(&directory).unwrap();
+    let reopened = SegmentJournal::open(&directory, brain::DEFAULT_IDEMPOTENCY_RETENTION).unwrap();
     let replay = at.elapsed().as_secs_f64() * 1e3;
     assert_eq!(
         reopened

--- a/crates/brain/tests/kernel.rs
+++ b/crates/brain/tests/kernel.rs
@@ -280,7 +280,11 @@ async fn restart_marks_an_inflight_turn_ambiguous_instead_of_guessing() {
     drop(kernel);
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-    let store = SegmentJournal::open(&data_dir.join("journal")).unwrap();
+    let store = SegmentJournal::open(
+        &data_dir.join("journal"),
+        brain::DEFAULT_IDEMPOTENCY_RETENTION,
+    )
+    .unwrap();
     let row = store.session_row(&session_id).unwrap().unwrap();
     store
         .append(

--- a/crates/brain/tests/session_listing.rs
+++ b/crates/brain/tests/session_listing.rs
@@ -63,7 +63,7 @@ const CONTEXT_BYTES: usize = 256 * 1024;
 const MAX_LISTING_BYTES: usize = CONTEXT_BYTES / 4;
 
 fn journal_with_sessions(directory: &Path) -> SegmentJournal {
-    let journal = SegmentJournal::open(directory).unwrap();
+    let journal = SegmentJournal::open(directory, brain::DEFAULT_IDEMPOTENCY_RETENTION).unwrap();
     let filler = serde_json::Value::String("x".repeat(CONTEXT_BYTES));
     for index in 0..SESSIONS {
         let row = SessionRow {


### PR DESCRIPTION
The four findings both performance reviews ranked above every micro-optimisation.
Each one has an acceptance test that was verified to fail on the previous behaviour.

## 1. The journal grew with the square of the turn count

`finish_turn` wrote a `$session` frame carrying the entire context at the end of every
turn, and the context grows across turns. A session running T turns adding C bytes each
wrote `C*T(T+1)/2` — the sum of every context it ever had — and read all of it back at
every restart. Nothing bounds T. Measured at 64 turns with a 16 KiB item per turn:
**34,199,242 bytes of journal for a 1 MiB context, 32.6x**, against a closed form of
32.5x.

Session state is not a record. It is rewritten every turn and only its latest value is
ever read, so it now lives in a file per session that the log rewrites in place, written
to a staging name and renamed over its predecessor. The same run leaves **1,084,376
bytes — 1.0x**, and flat in the turn count.

The log's writer handles both, so ordering is unchanged: a state reaches disk before the
segment buffer holding any record appended after it. A state superseded before it was
written is dropped, which removes the write entirely for turns that finish faster than
the disk. Two frame kinds go away with it: `$session` is the state, and `$deleted`
existed only to stop replay resurrecting a session whose state frame was still in the
log.

`a_session_does_not_journal_one_context_copy_per_turn` is no longer `#[ignore]`d.

## 2. Idempotency records never expired and pinned all disk reclamation

Every record stayed in memory and in the log for the life of the process, and the
reclamation floor included the oldest. One record — the one deleting a session writes —
held back every segment behind it: deleting a session with no record freed 2 of 3
segments, with one old record **0 of 3**. A million records held about 2 GiB of private
memory across a restart.

A record now carries an expiry, `DEFAULT_IDEMPOTENCY_RETENTION` (one day) from when it
was written. Past it the request is executed again rather than replayed from something
Brain has stopped promising to keep — that window is the contract, and it is stated
where the constant is defined. A TTL alone would still let a live record pin its segment
for a whole day, so reclamation also writes live records below the session floor forward
to the head. What sessions pin is inherent; a recorded answer is small and not
addressable, and has no business holding a segment down.

## 3. The writer queue was unbounded

Writing behind the caller turns disk latency into memory: with a deliberately slow
writer, producers queued 4,000 x 64 KiB frames in 218 ms and all **250 MiB** stayed on
the heap. Appends now reserve against a 64 MiB allowance and wait past it. A frame
larger than the whole allowance goes through once the queue is empty rather than waiting
for room that can never appear.

The writer also stopped swallowing its own failures. A segment it could not open or a
frame it could not write reported nothing, on the reasoning that there was no caller
left to tell — but there is always a next caller. The first failure is kept and every
later append reports it.

## 4. The concurrency ceiling was about three sessions

Three independent things made it so, and fixing any one changes nothing:

- `WorkerPool::activate` acquired a semaphore holding **three** permits, so a fourth was
  refused outright.
- It then held the process-global worker-state mutex across the whole activation, so
  even those three ran one at a time.
- The worker accepted one Unix connection, ran it to completion, and only then accepted
  the next.

Measured end to end at concurrency 64: **12 of 256 turns reached the model**, and a
throughput run against that counted the refusals as successes.

All three change here. The supervisor's lock now covers only what needs the worker's
identity and is released before the activation; its semaphore admits
`concurrent_activations + queued_activations` (18 by default) as an admission bound; and
the worker serves each connection on its own task, running the synchronous Wasmtime call
on a blocking thread. What runs at once stays explicitly bounded at sixteen per worker,
because each activation is a live Wasm instance and 48 at once measured 1.03 GiB.

The worker's request handling moved into `WorkerService`, off the socket it arrives on,
so it is type-checked and tested on every platform rather than only where it runs.

## Tests

`journal_growth` (turn axis, un-ignored), `idempotency_retention` (5 cases: replay
inside the window, expiry, expiry across a restart, the sweep at reclamation, and a live
record surviving being written forward), `journal::log::tests` (state replaced not
accumulated, half-written state discarded, hostile session id refused, the queue bound
holding under a slow writer, an oversized frame still written, a writer failure
surfacing), `journal::segment::tests` (the floor, the rewrite-forward, recovery from a
state file), and `service::tests` (requests answered without waiting for each other).

`concurrent_activations_all_reach_the_agentloop` runs twelve activations at once through
the real worker process. It needs Unix domain sockets and the built diagnostic package,
so it is verified by the `loophost` CI job rather than locally.

## Note

The one behaviour change worth calling out: an oversized activation output no longer
stops the worker. The frame carrying it was already bounded on the way in and the
instance that produced it is gone, so taking every other session's warm component down
for it is a far larger price than the violation.