### PR TITLE
events: stream records as they are appended

### DIFF
--- a/contracts/session/v1/openapi.yaml
+++ b/contracts/session/v1/openapi.yaml
@@ -143,7 +143,13 @@ paths:
           schema: { type: integer, minimum: 0 }
       responses:
         '200':
-          description: Finite event page or SSE stream according to Accept
+          description: >-
+            A finite event page for application/json, or a live SSE stream for
+            text/event-stream. The stream begins with the page `after` names and then
+            carries records as they are appended, so a client that opens it before
+            sending a message sees that turn. It ends if the subscriber falls too far
+            behind: reconnect with `after` set to the last id seen, and the journal
+            hands back exactly what was missed.
           content:
             application/json:
               schema: { $ref: './schemas.json#/$defs/EventPage' }

--- a/crates/brain-http/src/router.rs
+++ b/crates/brain-http/src/router.rs
@@ -13,6 +13,8 @@ use brain_protocol::{
     EnvironmentCallResult, EnvironmentId, MessageRequest, Session, SessionId, SessionList,
 };
 
+use futures_util::StreamExt as _;
+
 use crate::{BrainApi, HttpError};
 
 const MAX_REQUEST_BYTES: usize = 32 * 1024 * 1024;
@@ -204,10 +206,6 @@ async fn events<A: BrainApi>(
     Query(query): Query<EventsQuery>,
     headers: HeaderMap,
 ) -> Result<Response, HttpError> {
-    let page = api
-        .events(session_id, query.after)
-        .await
-        .map_err(HttpError)?;
     let wants_sse = headers
         .get(axum::http::header::ACCEPT)
         .and_then(|value| value.to_str().ok())
@@ -216,19 +214,71 @@ async fn events<A: BrainApi>(
                 .split(',')
                 .any(|media| media.trim().starts_with("text/event-stream"))
         });
-    if !wants_sse {
+
+    // Subscribed before the page is read, so a record appended between the two arrives on
+    // the subscription rather than falling into the gap. Only for a stream: a JSON reader
+    // asked for a page and gets one.
+    let live = wants_sse.then(|| api.subscribe());
+    let page = api
+        .events(session_id.clone(), query.after)
+        .await
+        .map_err(HttpError)?;
+    let Some(live) = live else {
         return Ok(Json(page).into_response());
+    };
+
+    // Where the page ended. Everything at or below it was already sent; everything above
+    // it is what this stream is for.
+    let sent_through = page.next_cursor;
+    // A session that has ended appends nothing more, so a stream that stayed open on one
+    // would wait for records that cannot arrive. The page is the whole story there.
+    let ended = page.events.iter().any(is_last);
+    let backlog = futures_util::stream::iter(page.events.into_iter().map(sse));
+    if ended {
+        return Ok(Sse::new(backlog).into_response());
     }
-    let events = page.events.into_iter().map(|event| {
-        let data = serde_json::to_string(&event.data).expect("JSON event payload is serializable");
-        Ok::<_, std::convert::Infallible>(
-            SseEvent::default()
-                .id(event.sequence.to_string())
-                .event(event.event_type)
-                .data(data),
-        )
-    });
-    Ok(Sse::new(futures_util::stream::iter(events)).into_response())
+    let following =
+        futures_util::stream::unfold(Some((live, sent_through, session_id)), |state| async move {
+            // `None` once the session has ended: nothing follows it, so holding the
+            // connection open would leave a client waiting on a promise the journal
+            // cannot keep.
+            let (mut live, mut sent_through, session_id) = state?;
+            loop {
+                match live.recv().await {
+                    Ok((session, event))
+                        if session == session_id && event.sequence > sent_through =>
+                    {
+                        sent_through = event.sequence;
+                        let carry = (!is_last(&event)).then_some((live, sent_through, session_id));
+                        return Some((event, carry));
+                    }
+                    Ok(_) => continue,
+                    // Lagged, or the kernel is gone. The stream ends rather than
+                    // silently skipping records: a client reconnects with the cursor it
+                    // last saw and the journal hands back exactly what it missed.
+                    Err(_) => return None,
+                }
+            }
+        })
+        .map(sse);
+
+    Ok(Sse::new(backlog.chain(following)).into_response())
+}
+
+/// Whether this record is the last a session can produce. A stream past it would wait
+/// on an append that cannot happen.
+fn is_last(event: &brain_protocol::Event) -> bool {
+    event.event_type == "session_ended"
+}
+
+/// One journal record as it goes out on the wire. The id is the sequence, so a client
+/// that reconnects with `Last-Event-ID` resumes from exactly what it saw.
+fn sse(event: brain_protocol::Event) -> Result<SseEvent, std::convert::Infallible> {
+    let data = serde_json::to_string(&event.data).expect("JSON event payload is serializable");
+    Ok(SseEvent::default()
+        .id(event.sequence.to_string())
+        .event(event.event_type)
+        .data(data))
 }
 
 fn invalid(message: impl Into<String>) -> HttpError {

--- a/crates/brain-http/src/service.rs
+++ b/crates/brain-http/src/service.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use brain_protocol::{
     AgentloopAdmission, AgentloopIdentity, ApiError, CreateSessionRequest, EnvironmentCallRequest,
-    EnvironmentCallResult, EnvironmentId, EventPage, MessageRequest, Session, SessionId,
+    EnvironmentCallResult, EnvironmentId, Event, EventPage, MessageRequest, Session, SessionId,
     SessionList,
 };
 
@@ -42,6 +42,13 @@ pub trait BrainApi: Clone + Send + Sync + 'static {
         session_id: SessionId,
         after: Option<u64>,
     ) -> Result<EventPage, ApiError>;
+    /// Every record appended from now on, for every session.
+    ///
+    /// Opened *before* the page a stream starts with, so a record appended between the
+    /// two arrives here instead of being lost in the gap; the caller drops what the page
+    /// already carried, by sequence. Falling behind loses records rather than holding up
+    /// a turn — the journal is the record, and `after` reads it back.
+    fn subscribe(&self) -> tokio::sync::broadcast::Receiver<(SessionId, Event)>;
     async fn cancel_session(
         &self,
         session_id: SessionId,

--- a/crates/brain-http/tests/routes.rs
+++ b/crates/brain-http/tests/routes.rs
@@ -11,8 +11,12 @@ use brain_protocol::{
 };
 use tower::ServiceExt;
 
-#[derive(Clone)]
-struct Api;
+#[derive(Clone, Default)]
+struct Api {
+    /// Held so a test can push a record after the page has been served, which is what a
+    /// turn does while a client is already streaming.
+    live: Option<tokio::sync::broadcast::Sender<(SessionId, Event)>>,
+}
 
 #[async_trait]
 impl BrainApi for Api {
@@ -56,6 +60,12 @@ impl BrainApi for Api {
         Ok(EnvironmentCallResult {
             output: request.input,
         })
+    }
+    fn subscribe(&self) -> tokio::sync::broadcast::Receiver<(SessionId, Event)> {
+        match &self.live {
+            Some(live) => live.subscribe(),
+            None => tokio::sync::broadcast::Sender::new(8).subscribe(),
+        }
     }
     async fn events(&self, _: SessionId, after: Option<u64>) -> Result<EventPage, ApiError> {
         Ok(EventPage {
@@ -134,7 +144,7 @@ async fn exposes_every_v1_route_with_its_contract_status() {
         request("GET", "/health/ready", None, None),
     ];
     for request in cases {
-        let response = router(Api).oneshot(request).await.unwrap();
+        let response = router(Api::default()).oneshot(request).await.unwrap();
         assert!(response.status().is_success(), "{}", response.status());
     }
 }
@@ -146,7 +156,7 @@ async fn mutating_routes_fail_fast_without_an_idempotency_key() {
         .uri("/v1/agentloops")
         .body(Body::from(vec![1]))
         .unwrap();
-    let response = router(Api).oneshot(request).await.unwrap();
+    let response = router(Api::default()).oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
@@ -162,7 +172,7 @@ async fn request_bodies_reject_unknown_fields() {
         "tool_bindings": [],
         "unknown": true
     });
-    let response = router(Api)
+    let response = router(Api::default())
         .oneshot(request(
             "POST",
             "/v1/sessions",
@@ -176,13 +186,13 @@ async fn request_bodies_reject_unknown_fields() {
 
 #[tokio::test]
 async fn bearer_auth_protects_api_routes_but_not_health() {
-    let unauthorized = router_with_bearer(Api, "secret".into())
+    let unauthorized = router_with_bearer(Api::default(), "secret".into())
         .oneshot(request("GET", "/v1/sessions", None, None))
         .await
         .unwrap();
     assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
 
-    let authorized = router_with_bearer(Api, "secret".into())
+    let authorized = router_with_bearer(Api::default(), "secret".into())
         .oneshot(
             Request::builder()
                 .uri("/v1/sessions")
@@ -194,16 +204,19 @@ async fn bearer_auth_protects_api_routes_but_not_health() {
         .unwrap();
     assert_eq!(authorized.status(), StatusCode::OK);
 
-    let health = router_with_bearer(Api, "secret".into())
+    let health = router_with_bearer(Api::default(), "secret".into())
         .oneshot(request("GET", "/health/ready", None, None))
         .await
         .unwrap();
     assert_eq!(health.status(), StatusCode::NO_CONTENT);
 }
 
+/// A stream still starts with the page `after` names, and still ends when there is
+/// nothing live behind it — a client reading history gets history and a close, not a
+/// connection held open forever.
 #[tokio::test]
-async fn event_route_negotiates_a_finite_sse_page() {
-    let response = router(Api)
+async fn the_event_stream_starts_with_the_page_the_cursor_names() {
+    let response = router(Api::default())
         .oneshot(
             Request::builder()
                 .uri("/v1/sessions/ses_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/events?after=7")
@@ -258,4 +271,70 @@ fn session() -> Session {
         through_sequence: 1,
         presentation_identity: brain_protocol::Identity::of(&"presentation").unwrap(),
     }
+}
+
+/// The event stream must carry what happens *after* it is opened.
+///
+/// It served one finite page of the journal and closed, so a client that opened it and
+/// then sent a message never saw the turn it was waiting for. Nothing pushed, which made
+/// a first-token measurement impossible to distinguish from a whole-turn one: the
+/// benchmark's `ttfb` probe could only ever return its `round_trip`.
+#[tokio::test]
+async fn the_event_stream_carries_records_appended_after_it_opened() {
+    let live = tokio::sync::broadcast::Sender::new(8);
+    let api = Api {
+        live: Some(live.clone()),
+    };
+
+    let request = Request::builder()
+        .uri("/v1/sessions/ses_test/events")
+        .header("accept", "text/event-stream")
+        .body(Body::empty())
+        .unwrap();
+    let response = router(api).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Appended after the page was served, the way a turn appends while a client streams.
+    live.send((
+        SessionId::new("ses_test"),
+        Event {
+            event_id: EventId::new("evt_live"),
+            sequence: 2,
+            recorded_at_ms: 1_787_846_400_001,
+            event_type: "assistant_delta".into(),
+            data: serde_json::json!({"delta": "hello"}),
+        },
+    ))
+    .unwrap();
+    // A record for another session must not reach this stream.
+    live.send((
+        SessionId::new("ses_other"),
+        Event {
+            event_id: EventId::new("evt_other"),
+            sequence: 3,
+            recorded_at_ms: 1_787_846_400_002,
+            event_type: "assistant_delta".into(),
+            data: serde_json::json!({"delta": "not yours"}),
+        },
+    ))
+    .unwrap();
+    drop(live);
+
+    let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body = String::from_utf8(body.to_vec()).unwrap();
+
+    assert!(
+        body.contains("test_event"),
+        "the page the stream starts with is missing: {body}"
+    );
+    assert!(
+        body.contains("assistant_delta") && body.contains("hello"),
+        "a record appended after the stream opened never arrived: {body}"
+    );
+    assert!(
+        !body.contains("not yours"),
+        "another session's record reached this stream: {body}"
+    );
 }

--- a/crates/brain-protocol/src/generated.rs
+++ b/crates/brain-protocol/src/generated.rs
@@ -14,4 +14,4 @@ pub const AGENTLOOP_WIT_DIGEST: &str =
     "153768b47ad95c717b34821c2204380764e15c6ab87eec0dda4b0b4d1cd32af1";
 pub const SESSION_OPENAPI: &str = include_str!("../../../contracts/session/v1/openapi.yaml");
 pub const SESSION_OPENAPI_DIGEST: &str =
-    "4a51b9571df5148e756004b44b6dab1dd582e431b3df0d7e2035793ff28ab815";
+    "cc1b6a8a3da1582dc0607f46808ed168185ebe9f6ae670d9c61af3ef14eaa992";

--- a/crates/brain-server/src/service.rs
+++ b/crates/brain-server/src/service.rs
@@ -402,6 +402,10 @@ impl BrainApi for ServerApi {
             .map_err(api_error)
     }
 
+    fn subscribe(&self) -> tokio::sync::broadcast::Receiver<(SessionId, brain_protocol::Event)> {
+        self.resources.kernel.subscribe()
+    }
+
     async fn cancel_session(
         &self,
         session_id: SessionId,

--- a/crates/brain/src/journal/observed.rs
+++ b/crates/brain/src/journal/observed.rs
@@ -1,24 +1,59 @@
 use std::sync::Arc;
 
-use brain_protocol::{Identity, Session, SessionId};
+use brain_protocol::{Event, Identity, Session, SessionId};
 use brain_telemetry::{TelemetryKind, TelemetryPublisher, TelemetryRecord};
+use tokio::sync::broadcast;
 
 use crate::{
     KernelError,
     journal::{AppendRecord, JournalRecord, JournalStore, SessionRow, SessionUpdate},
 };
 
+/// Records held for a subscriber that is not keeping up.
+///
+/// A live subscription must never be able to slow a turn down, so this is a bound on
+/// memory and not a promise of delivery: a subscriber further behind than this loses the
+/// records it missed and is told how many. Reading them back is what `after` is for — the
+/// journal is the record, and the stream is a notification that it moved.
+const LIVE_BACKLOG: usize = 1_024;
+
 pub(crate) struct ObservedJournal {
     inner: Arc<dyn JournalStore>,
     telemetry: TelemetryPublisher,
+    live: broadcast::Sender<(SessionId, Event)>,
 }
 
 impl ObservedJournal {
     pub(crate) fn new(inner: Arc<dyn JournalStore>, telemetry: TelemetryPublisher) -> Self {
-        Self { inner, telemetry }
+        Self {
+            inner,
+            telemetry,
+            live: broadcast::Sender::new(LIVE_BACKLOG),
+        }
+    }
+
+    /// Every record appended from now on, as it is appended.
+    ///
+    /// Subscribing before reading a page is what closes the gap between the two: a record
+    /// appended in between arrives on the subscription, and the reader drops what it has
+    /// already seen by sequence.
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<(SessionId, Event)> {
+        self.live.subscribe()
     }
 
     fn publish(&self, record: &JournalRecord) {
+        // Sent before telemetry, and never waited on: `send` returns immediately whether
+        // or not anyone is listening, and drops for a receiver that has fallen behind.
+        let _ = self.live.send((
+            record.session_id.clone(),
+            Event {
+                event_id: record.event_id(),
+                sequence: record.sequence,
+                recorded_at_ms: record.recorded_at_ms,
+                event_type: record.kind.clone(),
+                data: record.payload.clone(),
+            },
+        ));
         let _ = self.telemetry.try_publish(TelemetryRecord {
             kind: TelemetryKind::Event,
             name: record.kind.clone(),

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -37,7 +37,11 @@ pub struct Kernel {
 }
 
 struct KernelInner {
-    store: Arc<dyn JournalStore>,
+    /// Concrete rather than `dyn JournalStore`, because the live subscription is not part
+    /// of being a store: a journal an embedder brings has no reason to know about HTTP
+    /// subscribers, and the wrapper that observes every append is the only thing that
+    /// can serve them.
+    store: Arc<ObservedJournal>,
     config: KernelConfig,
     sessions: Mutex<HashMap<SessionId, SessionRuntime>>,
 }
@@ -151,6 +155,19 @@ impl Kernel {
             .session_row(session_id)?
             .ok_or_else(|| KernelError::InvalidState("session not found".into()))?;
         self.spawn(row)
+    }
+
+    /// Every record appended from now on, across every session.
+    ///
+    /// Subscribe before reading a page, then drop what the page already carried: a record
+    /// appended between the two arrives here rather than being lost in the gap. A
+    /// subscriber that falls further behind than the buffer loses records and is told so
+    /// by the channel — the journal is the record and `after` reads it back, while this is
+    /// a notification that it moved. A slow reader must never be able to hold up a turn.
+    pub fn subscribe(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<(SessionId, brain_protocol::Event)> {
+        self.inner.store.subscribe()
     }
 
     pub fn events(

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -40,6 +40,19 @@ bounded and best-effort: under sustained pressure it drops rather than blocking 
 without limit. If you need at-least-once delivery into your own systems, own the cursor and do the
 forwarding yourself — Brain is not a queue.
 
+The live stream is the same endpoint asked for a different media type:
+
+```
+GET /v1/sessions/{id}/events?after={cursor}
+Accept: text/event-stream
+```
+
+It begins with the page `after` names and then carries records as they are appended, so opening it
+*before* sending a message is how you see that turn's first output. It ends when the session ends,
+and it ends if you fall too far behind — reconnect with the last `id` you saw and the log hands
+back exactly what you missed. `Accept: application/json` returns one page and is what
+`session.events()` uses.
+
 ## Lifecycle
 
 `cancel` stops work in flight. `end` closes the session to new messages. `delete` removes it and its

--- a/packages/brain-sdk/src/generated/contracts.ts
+++ b/packages/brain-sdk/src/generated/contracts.ts
@@ -4,6 +4,6 @@ export const contractDigests = {
   agentloop_schema: "aae54716a97e28c71698cc92a25a2f448da8ffb0c4881b9fc9b933ff4c4e413d",
   agentloop_wit: "153768b47ad95c717b34821c2204380764e15c6ab87eec0dda4b0b4d1cd32af1",
   environment_schema: "dbf1481d0c6e7e70c7e949b3c1c4e0557b3dab5e02271bf4e3dc498062d96e4a",
-  session_openapi: "4a51b9571df5148e756004b44b6dab1dd582e431b3df0d7e2035793ff28ab815",
+  session_openapi: "cc1b6a8a3da1582dc0607f46808ed168185ebe9f6ae670d9c61af3ef14eaa992",
   session_schema: "8a7da2854841fc57181c3fdee62fa8c60f7b7b9be016afe59215b23ef0c4f65c",
 } as const;

--- a/packages/brain-sdk/src/generated/paths.ts
+++ b/packages/brain-sdk/src/generated/paths.ts
@@ -529,7 +529,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Finite event page or SSE stream according to Accept */
+            /** @description A finite event page for application/json, or a live SSE stream for text/event-stream. The stream begins with the page `after` names and then carries records as they are appended, so a client that opens it before sending a message sees that turn. It ends if the subscriber falls too far behind: reconnect with `after` set to the last id seen, and the journal hands back exactly what was missed. */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/tests/release/http-contract.mjs
+++ b/tests/release/http-contract.mjs
@@ -22,6 +22,26 @@ const call = async (method, path, { body, contentType = "application/json", key,
   return { response, result };
 };
 
+/// Reads an open SSE response only until `pattern` appears, then cancels it. Bounded, so
+/// a stream that never carries what was asked for fails the test instead of hanging it.
+const streamCarries = async (response, pattern, timeoutMs = 30_000) => {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const deadline = setTimeout(() => reader.cancel(), timeoutMs);
+  let seen = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return pattern.test(seen);
+      seen += decoder.decode(value, { stream: true });
+      if (pattern.test(seen)) return true;
+    }
+  } finally {
+    clearTimeout(deadline);
+    await reader.cancel().catch(() => {});
+  }
+};
+
 for (const path of ["/health/live", "/health/ready"]) {
   const { response } = await call("GET", path, { authorized: false });
   assert.equal(response.status, 204);
@@ -93,10 +113,15 @@ const page = await call("GET", `/v1/sessions/${sessionId}/events?after=0`);
 assert.equal(page.response.status, 200);
 assert.equal(page.result.next_cursor, message.result.through_sequence);
 assert.equal(page.result.events.at(-1).event_type, "turn_finished");
-const sse = await call("GET", `/v1/sessions/${sessionId}/events?after=0`, { accept: "text/event-stream" });
-assert.equal(sse.response.status, 200);
-assert.ok(sse.response.headers.get("content-type")?.startsWith("text/event-stream"));
-assert.match(sse.result, /event: turn_finished/u);
+// Read until the event we came for, not to the end of the body: the stream stays open
+// carrying records as they are appended, which is what makes a first-token measurement
+// possible. Reading it to EOF would wait for a close that only a session ending brings.
+const sse = await fetch(`${baseUrl}/v1/sessions/${sessionId}/events?after=0`, {
+  headers: { accept: "text/event-stream", authorization: `Bearer ${token}` },
+});
+assert.equal(sse.status, 200);
+assert.ok(sse.headers.get("content-type")?.startsWith("text/event-stream"));
+assert.ok(await streamCarries(sse, /event: turn_finished/u), "the stream never carried the finished turn");
 
 const cancelled = await call("POST", `/v1/sessions/${sessionId}/cancel`, { key: "http-contract-cancel" });
 assert.equal(cancelled.response.status, 204);


### PR DESCRIPTION
The first of the three things blocking a publishable benchmark, and the only one that
needed product code.

## The problem

`GET /v1/sessions/{id}/events` served a finite page of the journal and closed, whatever
the client asked for. A client that opened the stream and then sent a message never saw
that turn.

That made a first-token measurement impossible: the benchmark's `ttfb` probe opens the
stream, sends, and waits for the first assistant byte — but nothing was ever pushed, so
it could only return the same number as `round_trip`. Two probes, one measurement, and
no way to tell from the output.

## What changed

With `Accept: text/event-stream`, the response begins with the page `after` names and
then carries records as they are appended. `application/json` is unchanged and still
returns one page — the SDK pages that way and is untouched.

- **The subscription is opened before the page is read**, so a record appended between
  the two arrives on it rather than falling into the gap. Anything at or below the
  page's cursor is dropped by sequence.
- **The broadcast carries the session id**, so a stream only ever sees its own session.
- **A subscriber can never hold up a turn.** `send` returns whether or not anyone is
  listening; a subscriber more than 1,024 records behind loses them and the stream ends
  rather than silently skipping. The journal is the record, `after` reads it back, and
  this is a notification that it moved. That is the contract `docs/concepts/sessions.mdx`
  already described — the implementation now matches it.
- **The stream ends once the session has ended**, since nothing follows that.

`KernelInner::store` is now a concrete `ObservedJournal` rather than `dyn JournalStore`.
Serving subscribers is not part of being a store — a journal an embedder brings has no
reason to know about them — and the wrapper that already observes every append is the
only thing that can.

## A regression this would have shipped

`tests/release/http-contract.mjs` read the SSE body to EOF, which with a stream that
stays open never comes. It would have hung the `image-smoke` job until the 20-minute
timeout. It now reads until the event it came for, with its own timeout, so a stream
that never carries it fails the test instead of the job.

`examples/raw-http.mjs` and the SDK both send `Accept: application/json` and are
unaffected. The session contract digest moves because the endpoint's description did.

## Tests

- `the_event_stream_carries_records_appended_after_it_opened` — pushes a record after the
  page is served and asserts it arrives, and that another session's record does not.
- `the_event_stream_starts_with_the_page_the_cursor_names` — the old finite-page test,
  renamed for what it now pins: a stream with nothing live behind it still ends.