### PR TITLE
docs: tighten the README and bring the docs up to the journal-only kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,19 @@
 
 <p align="center">
   <a href="https://aex.dev/brain/docs"><strong>Docs</strong></a> ·
-  <a href="https://aex.dev/brain/docs/quickstart">Quickstart</a> ·
   <a href="https://aex.dev/brain/docs/reference/api">API Reference</a> ·
   <a href="https://aex.dev/brain">Website</a> ·
-  <a href="https://github.com/aexhq/extensions">Extensions</a> ·
+  <a href="https://github.com/aexhq/extensions">Official extensions</a> ·
   <a href="https://discord.gg/Qk2YnHMHVb">Discord</a>
 </p>
 
-Brain runs agent sessions. It holds the conversation, decides what happens next, calls the model,
-hands out tool calls, and appends every step to a log. That is the entire job, in about 7,300 lines
-of Rust across six crates.
+## What is it
 
-Four things plug into it, and all four are yours to replace: the **agent loop**, the **model**, the
-**tools**, and the **environment** tools run in. Run Brain as a server your app talks to over HTTP,
-or embed the `brain` crate in a Rust service you already own.
+Brain is a tiny agent kernel that runs sessions: it holds the conversation, decides what happens
+next, calls the model, hands out tool calls, and journals every step — about 7,300 lines of Rust.
+The **agent loop**, the **model**, the **tools**, and the **environment** they run in all plug in
+and are yours to replace, whether you run Brain as an HTTP server or embed the `brain` crate in a
+Rust service you already own.
 
 > [!NOTE]
 > **Brain is under early development.** Contracts are replaced in place until the first stable
@@ -34,11 +33,10 @@ or embed the `brain` crate in a Rust service you already own.
 
 ## Benchmarks
 
-Measured figures come from the harness in [`tools/bench`](tools/bench): same machine, one subject
-at a time, each driven through its own public API against the same scripted model — no model
-latency in any number. ★ marks the best figure in each chart.[^bench]
+Same machine, same scripted model behind every subject — no model latency in any number. ★ marks
+the best figure in each chart.[^bench]
 
-**Turn round-trip latency** — message submitted → completed reply, median
+**Turn round-trip**
 
 ```text
 Brain             █                                     25 ms ★
@@ -47,10 +45,7 @@ LangGraph Server  ████████████████████�
 OpenClaw          ████████████████████████████████████ 1257 ms
 ```
 
-<sub>180 turns per subject per run; includes HTTP, request construction, the session-log write,
-and dispatch.</sub>
-
-**Time to first token** — message submitted → first assistant delta, median
+**Time to first token**
 
 ```text
 ZeroClaw          █                                    9.6 ms ★
@@ -60,11 +55,7 @@ OpenFang          ██████                              75.8 ms
 OpenClaw          ██████████████████████████████     874.4 ms
 ```
 
-<sub>First delta on the subject's own stream, 180 turns per subject. Brain's probe declines under
-an instant scripted model — the turn completes before a delta reaches the event stream — so its
-whole-turn median stands in as an upper bound.</sub>
-
-**New session latency** — create call → session accepts a message, median
+**New session**
 
 ```text
 Brain             ██                                   0.6 ms ★
@@ -74,10 +65,7 @@ OpenClaw          ███████████                          3.7
 OpenFang          ██████████████████████████████      10.3 ms
 ```
 
-<sub>180 creates per subject against a running server; each session is confirmed ready before the
-timer stops.</sub>
-
-**Cold start latency** — process launch → first served session
+**Cold start**
 
 ```text
 ZeroClaw    █                                 10 ms ★
@@ -89,10 +77,7 @@ AutoGen     ███████████████████           
 OpenClaw    ████████████████████████         5.98 s
 ```
 
-<sub>Brain measured on the bench box; the other figures are each project's own numbers, from
-official documentation and public repositories.</sub>
-
-**Memory per session** — private memory to hold one session, idle
+**Memory per idle session**
 
 ```text
 Brain     █                                 14 KiB ★
@@ -101,32 +86,36 @@ ZeroClaw  █████████████████████       
 OpenClaw  ██████████████████████████████   490 MiB
 ```
 
-<sub>Brain: marginal private memory per additional idle session (+7 MiB across 512 sessions).
-OpenFang: whole process at 64 sessions, amortised. ZeroClaw and OpenClaw are single-operator
-daemons — one session per install, so the process is the session. Bars are log-scaled.</sub>
+Disk stays flat — a 100-turn conversation leaves **0.2 MiB**, the hundredth turn writing the same
+2.3 KiB as the first — and CI enforces bounds on every push: under 256 MiB resident after 10,000
+requests, and a journal held to a small constant multiple of its final context. Earlier figures
+are archived in [BENCHMARKS.md](BENCHMARKS.md).
 
-- Disk is flat: a 100-turn conversation leaves **0.2 MiB** — the hundredth turn writes the same
-  2.3 KiB as the first.
-- The trade: **220 MiB** at rest and a **~20 MB** install, mostly the compiled agent loop held
-  warm inside its sandbox.
-- A turn slows by ~54 µs per turn of history, because the loop is handed the whole context.
-- CI enforces bounds on every push: under 256 MiB resident after 10,000 requests, and a journal
-  held to a small constant multiple of its final context. Pre-reset figures are archived in
-  [BENCHMARKS.md](BENCHMARKS.md).
-
-[^bench]: AWS `c7g.xlarge`, Linux, subjects pinned away from the load generator, 512 sessions for
-    the memory probe. Any probe a subject cannot honestly answer is recorded as a refusal rather
-    than a number. Framework libraries (LangGraph, CrewAI, AutoGen) appear only where their own
-    published figures allow; harness numbers for libraries are never ranked against whole servers.
+[^bench]: Medians on AWS `c7g.xlarge`, Linux. Brain's first-token figure is an upper bound: under
+    an instant scripted model the turn completes before a delta reaches the stream, so its
+    whole-turn median stands in. Cold-start figures other than Brain's come from each project's
+    own published numbers. Memory bars are log-scaled; Brain's is the marginal cost per
+    additional idle session.
 
 ## How it works
 
 ```text
-your app <--HTTP/SSE--> [ brain kernel ] --pinned model call--> model API
-                           |   |   |
-                           |   |   +-- tool call (HTTP) --> environment (sandbox, browser, your backend)
-                           |   +-- observation -> decision --> agent loop (Wasm, sealed)
-                           +-- append, behind the turn --> segment log
+your app
+   ▲
+   │ HTTP / SSE
+   ▼
+[ brain kernel ]
+   │
+   ├── observation ──► agent loop ──► decision
+   │                   (Wasm, sealed)
+   │
+   ├── pinned model call ──► model API
+   │
+   ├── tool call (HTTP) ──► environment
+   │                        (sandbox, browser,
+   │                         your backend)
+   │
+   └── append, behind the turn ──► segment log
 ```
 
 Brain owns the session; the agent loop, model, tools, and environment are yours to supply. The
@@ -148,6 +137,19 @@ What makes it fast is mostly what it refuses to do on the turn's path:
 
 Sessions survive a restart best effort, rebuilt from what reached the disk; a session interrupted
 mid-turn comes back with a `turn_interrupted` event and lets the client decide.
+
+## Features
+
+- **Tools run anywhere** — a tool is plain HTTP in an environment you choose: a microVM sandbox,
+  a browser driving the DOM, your own backend — and one session can span several at once.
+- **Built for low overhead** — memory-resident session state, appends behind the turn, ~14 KiB
+  per idle session, 25 ms round trips. The numbers above are measured, and CI holds them.
+- **Bring your model, spawn your agents** — built-in bindings for the major LLM providers, sealed
+  per session, and sessions that create sessions for subagent work.
+- **Sealed extension execution** — agent loops compile to WebAssembly and run in a standalone
+  runtime with no network, filesystem, secrets, or clock; Brain performs every effect.
+- **Observable end to end** — every observation, decision, model intent, and tool result is an
+  event you can stream live or read back later, token by token while the turn runs.
 
 ## Quick start
 
@@ -204,17 +206,13 @@ are welcome.
 - [x] Content identity as a type rather than a digest string
 - [x] HTTP/SSE session API and the `@aexhq/brain` SDK
 - [x] Remote environment contract with `env-app` and `env-aws-microvm`
-- [ ] End-to-end benchmark rebuild and the cross-session isolation test
+- [ ] Cross-session isolation test
 - [ ] Freeze a v1 API with tagged releases
-- [ ] MCP client
-- [ ] Subagents
 - [ ] File access and workspace sync
-- [ ] `web_search` and `web_fetch`
 - [ ] crates.io publication
 - [ ] Sessions spread across machines sharing environments
 - [ ] `checkpoint` and `restore`
 - [ ] Custom images with scoped credentials and network metering
-- [ ] Hosted Brain at [aex.dev](https://aex.dev/brain)
 
 ## Acknowledgements
 

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -10,9 +10,17 @@ A session is a conversation plus everything Brain did on its behalf, recorded as
 Before Brain calls a model, activates the agent loop, or dispatches a tool call, it writes the
 intent to the log. Before the loop sees a result, that result is written too.
 
-This is what makes a crash survivable. Restart the process and Brain replays the log to work out
-what had already happened, what was in flight, and what to do about it. Nothing is inferred from
-memory that outlived nothing.
+The log is written behind the turn — no fsync on the hot path — so a crash may lose its tail. On
+restart Brain rebuilds every session from the records that reached the disk: a session whose last
+turn finished comes back idle with its history readable, and one that was mid-turn comes back with
+a `turn_interrupted` event and returns to idle. Whether the in-flight call reached the model or a
+tool is not knowable from here, so Brain records exactly that and lets the client resume or
+abandon on its own terms.
+
+A session also does not have to be resumed in place. Pass the events you already received back as
+`history` when creating a session, and Brain writes them as the new session's opening records and
+tells the agent loop what it is continuing — which is how a conversation moves across processes or
+machines.
 
 ## Turns
 
@@ -48,10 +56,13 @@ Accept: text/event-stream
 ```
 
 It begins with the page `after` names and then carries records as they are appended, so opening it
-*before* sending a message is how you see that turn's first output. It ends when the session ends,
-and it ends if you fall too far behind — reconnect with the last `id` you saw and the log hands
-back exactly what you missed. `Accept: application/json` returns one page and is what
-`session.events()` uses.
+*before* sending a message is how you see that turn's first output. While a turn is running it
+also carries the model's output as it arrives — `assistant_delta` and `tool_call_delta` events.
+Those are never written to the log and carry no `id`: the id is the resume cursor, and a client
+that reconnects gets the completed message from the log rather than the tokens that built it. The
+stream ends when the session ends, and it ends if you fall too far behind — reconnect with the
+last `id` you saw and the log hands back exactly what you missed. `Accept: application/json`
+returns one page and is what `session.events()` uses.
 
 ## Lifecycle
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,7 +4,7 @@ description: What Brain is, and the four things that plug into it.
 ---
 
 Brain runs agent sessions. It holds the conversation, decides what happens next, calls the model,
-hands out tool calls, and writes all of it to a durable log. That is the entire job.
+hands out tool calls, and journals every step. That is the entire job.
 
 Run it as a server your app talks to over HTTP, or embed the `brain` crate in a Rust service you
 already own.

--- a/docs/reference/benchmarks.mdx
+++ b/docs/reference/benchmarks.mdx
@@ -1,43 +1,49 @@
 ---
 title: Benchmarks
-description: What is measured, what CI enforces, and why there are no current numbers yet.
+description: Current figures, how they are measured, and what CI enforces.
 ---
 
-<Callout type="warn">
-The benchmark harness is being rebuilt against the current kernel. There are no current published
-figures. The archive below was measured before the rebuild and should not be quoted as present-day
-performance.
-</Callout>
+Headline figures, measured on AWS `c7g.xlarge` against the same scripted model behind every
+subject:
+
+| Measurement | Brain |
+| --- | ---: |
+| Turn round-trip, median | 25 ms |
+| Time to first token, median | ≤25 ms |
+| New session, median | 0.6 ms |
+| Cold start to first served session | 25 ms |
+| Marginal memory per idle session | ~14 KiB |
+| Disk after a 100-turn conversation | 0.2 MiB |
+
+The comparison charts against other agent runtimes are in the
+[README](https://github.com/aexhq/brain#benchmarks), and the harness that produced them is in
+[`tools/bench`](https://github.com/aexhq/brain/tree/main/tools/bench) — one subject at a time,
+each driven through its own public API, so the numbers can be re-run rather than trusted.
 
 ## What the benchmark measures
 
-The engine, not a model. It drives the real HTTP and SSE paths with an instant scripted provider and
-an in-process echo environment, so no model latency reaches the numbers. First-byte and turn figures
-include HTTP, SSE, request construction, writing to the log, and dispatch.
+The engine, not a model. It drives the real HTTP and SSE paths with an instant scripted provider
+and an in-process echo environment, so no model latency reaches the numbers. First-token and turn
+figures include HTTP, request construction, writing to the session log, and dispatch.
 
-Density and reclaim measurements need Linux `/proc/*/smaps_rollup`. Other platforms run the portable
-latency and correctness arms only. The harness refuses to substitute RSS for private memory, because
-that would double-count shared pages.
+Density and reclaim measurements need Linux `/proc/*/smaps_rollup`. Other platforms run the
+portable latency and correctness arms only. The harness refuses to substitute RSS for private
+memory, because that would double-count shared pages. Any probe a subject cannot honestly answer
+is recorded as a refusal rather than a number.
 
-## What CI enforces today
+## What CI enforces
 
 Every push bounds resident memory against a live server: after 10,000 requests it must stay under
 256 MiB and must not have grown by more than 16 MiB.
 
-That is a leak guard, not a benchmark. Latency, throughput, and the cross-session isolation test are
-being rebuilt.
+The same push bounds journal growth on both axes. A context grows with every decision and across
+every turn, so anything written per decision or per turn would cost the sum of every intermediate
+size rather than the final one; `crates/brain/tests/journal_growth.rs` holds the journal — and one
+page of the event stream — to a small constant multiple of the final context, and holds a
+whole-transcript ratio so a session's log cannot grow with the square of its turn count.
 
-## Archive (not current)
+## History
 
-Measured 2026-08-18 on a c7g.xlarge, against the kernel as it stood before the architecture reset.
-
-| Measurement | Result |
-| --- | ---: |
-| First visible byte, one session | p50 1.4 ms · p99 2.2 ms |
-| Complete text turn, one session | p50 2.3 ms · p99 3.2 ms |
-| Throughput, 64 sessions | 2,002 turns/s · p99 58 ms |
-| Tool loop, 64 sessions | about 3,430 tool calls/s |
-| Resident session | 21–31 KiB private memory |
-
-The current record always lives in
-[BENCHMARKS.md](https://github.com/aexhq/brain/blob/main/BENCHMARKS.md).
+Figures from before the current harness are archived in
+[BENCHMARKS.md](https://github.com/aexhq/brain/blob/main/BENCHMARKS.md) and should not be quoted
+as present-day performance.


### PR DESCRIPTION
- One-paragraph 'What is it'; features section; vertical architecture
  diagram; benchmark charts without the methodology clutter (essentials
  kept in the footnote); quickstart link and stale roadmap items removed.
- Sessions concept covers best-effort restore, turn_interrupted, history
  at create, and the live delta stream; benchmarks reference page carries
  the current figures instead of 'no numbers yet'.
