### PR TITLE
release: prepare Brain 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,34 +162,34 @@ docker run --rm -p 8080:8080 -v brain-data:/var/lib/brain ghcr.io/aexhq/brain:la
 Drive a session from TypeScript:
 
 ```sh
-npm install @aexhq/brain @aexhq/brain-pi @aexhq/env-aws-microvm @aexhq/tools
+npm install @aexhq/brain @aexhq/brain-pi
 ```
 
 ```ts
 import { Brain } from "@aexhq/brain";
-import { awsMicroVm } from "@aexhq/env-aws-microvm";
 import { pi } from "@aexhq/brain-pi";
-import { bash, read, write } from "@aexhq/tools";
 
 const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });
-const workspace = awsMicroVm({ region: "eu-west-2" });
 
 const session = await brain.sessions.create({
   model: {
-    provider: "vercel-ai-gateway",
-    name: "openai/gpt-5-mini",
-    apiKey: process.env.VERCEL_AI_GATEWAY_API_KEY!,
+    provider: "openai",
+    name: "gpt-5-mini",
+    apiKey: process.env.OPENAI_API_KEY!,
   },
   brain: pi(),
-  tools: [read().useIn(workspace), write().useIn(workspace), bash().useIn(workspace)],
+  system: "Answer briefly and directly.",
 });
 
-await session.send("Read README.md and summarize it.");
+await session.send("Explain what a session kernel does, in one sentence.");
 for await (const event of session.events()) console.log(event);
+
+await session.end();
+await session.delete();
 ```
 
-Leave out `tools` and the model sees none. Brain listens on loopback and needs no token there; set
-`BRAIN_API_TOKEN` to listen anywhere else.
+No `tools` means the model sees none. Add them once you have somewhere to run them. Brain listens on
+loopback and needs no token there; set `BRAIN_API_TOKEN` to listen anywhere else.
 
 Four runnable scripts — a basic session, event history, the full lifecycle, and the same thing over
 raw HTTP with no SDK — are in [`examples/`](examples). Building from source and embedding the crate

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security
+
+Do not open a public issue for a suspected vulnerability. Report it through
+[GitHub private vulnerability reporting](https://github.com/aexhq/brain/security/advisories/new)
+with the affected version, reproduction, impact, and any known mitigation.
+
+Brain is under early development. Only the latest npm version and the matching immutable container
+image are supported; earlier builds do not receive compatibility or security fixes.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -35,9 +35,9 @@ const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });
 
 const session = await brain.sessions.create({
   model: {
-    provider: "vercel-ai-gateway",
-    name: "openai/gpt-5-mini",
-    apiKey: process.env.VERCEL_AI_GATEWAY_API_KEY!,
+    provider: "openai",
+    name: "gpt-5-mini",
+    apiKey: process.env.OPENAI_API_KEY!,
   },
   brain: pi(),
   system: "Answer briefly and directly.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## What

- version the provider-normalization contract as Brain 0.9.0
- make the first README session require only Brain, pi, Docker, and an OpenAI key
- align the quickstart with the direct OpenAI provider
- add a private vulnerability-reporting policy

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- npm ci
- npm test
- npm run package-smoke