### PR TITLE
release: fix staged contract probes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/packages/brain-sdk/test/client.test.mjs
+++ b/packages/brain-sdk/test/client.test.mjs
@@ -34,7 +34,7 @@ test("composes extensions through sessions, useIn, and object identity", async (
     fetch: async (input, init) => {
       const request = new Request(input, init);
       requests.push(request);
-      if (request.url.endsWith("/v1/agentloops")) return Response.json({ digest: "a".repeat(64), status: "admitted" });
+      if (request.url.endsWith("/v1/agentloops")) return Response.json({ identity: "a".repeat(64), status: "admitted" });
       if (request.url.includes("/calls/suspend")) return Response.json({ output: null });
       return Response.json({ session_id: "ses_12345678901234567890", journal_id: "jrn_test", status: "idle", through_sequence: 1, presentation_identity: "b".repeat(64) });
     },
@@ -52,6 +52,7 @@ test("composes extensions through sessions, useIn, and object identity", async (
   assert.match(requests[0].headers.get("idempotency-key"), /^brain-[0-9a-f]{64}$/u);
   const body = await requests[1].json();
   assert.deepEqual(body.brain_configuration, {});
+  assert.equal(body.agentloop_identity, "a".repeat(64));
   assert.equal(body.environments.length, 1);
   assert.equal(body.environments[0].environment_id, "env_1");
   assert.deepEqual(body.tool_bindings.map(({ name, environment_id }) => [name, environment_id]), [["read", "env_1"]]);

--- a/tests/release/http-contract.mjs
+++ b/tests/release/http-contract.mjs
@@ -66,11 +66,11 @@ const admitted = await call("POST", "/v1/agentloops", {
 });
 assert.equal(admitted.response.status, 200);
 assert.equal(admitted.result.status, "admitted");
-const admission = await call("GET", `/v1/agentloops/${admitted.result.digest}`);
+const admission = await call("GET", `/v1/agentloops/${admitted.result.identity}`);
 assert.deepEqual(admission.result, admitted.result);
 
 const createBody = {
-  agentloop_identity: admitted.result.digest,
+  agentloop_identity: admitted.result.identity,
   brain_configuration: {},
   model: { provider: "vercel-ai-gateway", name: "openai/gpt-5-mini", api_key: "release-smoke-key" },
   presentation: { system: "", tools: [] },

--- a/tests/release/http.mjs
+++ b/tests/release/http.mjs
@@ -38,7 +38,7 @@ const admission = await request(
 );
 assert.equal(admission.status, "admitted");
 const session = await request("POST", "/v1/sessions", {
-  agentloop_identity: admission.digest,
+  agentloop_identity: admission.identity,
   brain_configuration: {},
   model: {
     provider: "vercel-ai-gateway",

--- a/tests/release/sdk-events.mjs
+++ b/tests/release/sdk-events.mjs
@@ -31,7 +31,7 @@ const suffix = [];
 for await (const event of session.events(cursor)) suffix.push(event);
 assert.deepEqual(
   suffix.map(({ type }) => type),
-  ["turn_started", "activation_intent", "activation_result", "context_updated", "turn_finished"],
+  ["turn_started", "activation_intent", "activation_result", "turn_finished"],
 );
 assert.equal(suffix.at(-1)?.sequence, session.state.throughSequence);
 

--- a/tests/release/sdk-turns.mjs
+++ b/tests/release/sdk-turns.mjs
@@ -24,8 +24,8 @@ assert.equal(completed.status, "idle");
 const events = [];
 for await (const event of session.events()) events.push(event);
 assert.deepEqual(
-  events.slice(-5).map(({ type }) => type),
-  ["turn_started", "activation_intent", "activation_result", "context_updated", "turn_finished"],
+  events.slice(-4).map(({ type }) => type),
+  ["turn_started", "activation_intent", "activation_result", "turn_finished"],
 );
 assert.deepEqual(events.at(-1)?.data.result, { activations: 1, observation: "user_message" });
 assert.ok(events.every(({ recordedAt }) => recordedAt instanceof Date && !Number.isNaN(recordedAt.valueOf())));


### PR DESCRIPTION
Fix the release-only probes exposed by the 0.9.0 stage gate: consume the admission identity field, assert the current journal event sequence, and cover the SDK admission identity in unit tests. Bumps the immutable npm candidate to 0.9.1 because 0.9.0 is already staged. Local npm, package smoke, audit, fmt, clippy, and full Rust tests pass.