### PR TITLE
telemetry: batch bounded delivery

### DIFF
--- a/crates/brain-server/src/main.rs
+++ b/crates/brain-server/src/main.rs
@@ -185,20 +185,22 @@ struct LogSink;
 
 #[async_trait]
 impl TelemetrySink for LogSink {
-    async fn publish(
+    async fn publish_batch(
         &self,
-        record: &TelemetryRecord,
+        records: &[TelemetryRecord],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        tracing::info!(
-            telemetry_kind = ?record.kind,
-            telemetry_name = %record.name,
-            session_id = record.session_id.as_ref().map(ToString::to_string),
-            journal_id = record.journal_id.as_ref().map(ToString::to_string),
-            event_id = record.event_id.as_ref().map(ToString::to_string),
-            operation_id = record.operation_id.as_ref().map(ToString::to_string),
-            payload_bytes = record.payload.len(),
-            "Brain telemetry"
-        );
+        for record in records {
+            tracing::info!(
+                telemetry_kind = ?record.kind,
+                telemetry_name = %record.name,
+                session_id = record.session_id.as_ref().map(ToString::to_string),
+                journal_id = record.journal_id.as_ref().map(ToString::to_string),
+                event_id = record.event_id.as_ref().map(ToString::to_string),
+                operation_id = record.operation_id.as_ref().map(ToString::to_string),
+                payload_bytes = record.payload.len(),
+                "Brain telemetry"
+            );
+        }
         Ok(())
     }
 }

--- a/crates/brain-telemetry/src/metrics.rs
+++ b/crates/brain-telemetry/src/metrics.rs
@@ -31,12 +31,20 @@ impl TelemetryMetrics {
         self.inner.queued_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
 
-    pub(crate) fn removed(&self, bytes: usize) {
-        self.inner.queued_records.fetch_sub(1, Ordering::Relaxed);
+    pub(crate) fn removed(&self, records: usize, bytes: usize) {
+        self.inner
+            .queued_records
+            .fetch_sub(records, Ordering::Relaxed);
         self.inner.queued_bytes.fetch_sub(bytes, Ordering::Relaxed);
     }
 
     pub(crate) fn dropped(&self) {
         self.inner.dropped_records.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn dropped_by(&self, records: usize) {
+        self.inner
+            .dropped_records
+            .fetch_add(records as u64, Ordering::Relaxed);
     }
 }

--- a/crates/brain-telemetry/src/queue.rs
+++ b/crates/brain-telemetry/src/queue.rs
@@ -42,9 +42,8 @@ impl BoundedQueue {
         Some(bytes)
     }
 
-    pub fn pop(&mut self) -> Option<QueuedRecord> {
-        let queued = self.records.pop_front()?;
-        self.bytes -= queued.bytes;
-        Some(queued)
+    pub fn drain(&mut self) -> Vec<QueuedRecord> {
+        self.bytes = 0;
+        self.records.drain(..).collect()
     }
 }

--- a/crates/brain-telemetry/src/sink.rs
+++ b/crates/brain-telemetry/src/sink.rs
@@ -4,8 +4,10 @@ use crate::TelemetryRecord;
 
 #[async_trait]
 pub trait TelemetrySink: Send + Sync + 'static {
-    async fn publish(
+    /// Accept one ordered batch. Returning an error retries the whole batch, so sinks
+    /// must make duplicate delivery harmless.
+    async fn publish_batch(
         &self,
-        record: &TelemetryRecord,
+        records: &[TelemetryRecord],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/crates/brain-telemetry/src/worker.rs
+++ b/crates/brain-telemetry/src/worker.rs
@@ -36,13 +36,14 @@ impl TelemetryWorker {
                 self.queue
                     .lock()
                     .expect("telemetry queue mutex poisoned")
-                    .pop()
+                    .drain()
             };
-            let Some(queued) = queued else {
+            if queued.is_empty() {
                 self.notify.notified().await;
                 continue;
-            };
-            self.metrics.removed(queued.bytes);
+            }
+            self.metrics
+                .removed(queued.len(), queued.iter().map(|record| record.bytes).sum());
             self.deliver(&sink, queued, MAX_RETRY_AGE).await;
         }
     }
@@ -50,17 +51,28 @@ impl TelemetryWorker {
     async fn deliver(
         &self,
         sink: &Arc<dyn TelemetrySink>,
-        queued: QueuedRecord,
+        queued: Vec<QueuedRecord>,
         max_retry_age: Duration,
     ) {
+        let enqueued_at = queued
+            .first()
+            .expect("delivery batches are never empty")
+            .enqueued_at;
+        let records = queued
+            .iter()
+            .map(|queued| queued.record.clone())
+            .collect::<Vec<_>>();
         let mut attempt = 0;
         loop {
-            if sink.publish(&queued.record).await.is_ok() {
+            if sink.publish_batch(&records).await.is_ok() {
                 return;
             }
-            let Some(delay) = retry_delay(attempt, queued.enqueued_at, max_retry_age) else {
-                self.metrics.dropped();
-                if queued.record.name != DELIVERY_DROPPED_NAME {
+            let Some(delay) = retry_delay(attempt, enqueued_at, max_retry_age) else {
+                self.metrics.dropped_by(queued.len());
+                for queued in &queued {
+                    if queued.record.name == DELIVERY_DROPPED_NAME {
+                        continue;
+                    }
                     let accepted = self
                         .queue
                         .lock()
@@ -98,11 +110,16 @@ mod tests {
     struct FailingSink {
         failures: usize,
         attempts: AtomicUsize,
+        records: AtomicUsize,
     }
 
     #[async_trait]
     impl TelemetrySink for FailingSink {
-        async fn publish(&self, _: &TelemetryRecord) -> Result<(), Box<dyn Error + Send + Sync>> {
+        async fn publish_batch(
+            &self,
+            records: &[TelemetryRecord],
+        ) -> Result<(), Box<dyn Error + Send + Sync>> {
+            self.records.store(records.len(), Ordering::Relaxed);
             let attempt = self.attempts.fetch_add(1, Ordering::Relaxed);
             if attempt < self.failures {
                 Err("sink unavailable".into())
@@ -124,25 +141,28 @@ mod tests {
         }
     }
 
-    fn pop(worker: &TelemetryWorker) -> QueuedRecord {
+    fn drain(worker: &TelemetryWorker) -> Vec<QueuedRecord> {
         let queued = worker
             .queue
             .lock()
             .expect("telemetry queue mutex poisoned")
-            .pop()
-            .expect("test record is queued");
-        worker.metrics.removed(queued.bytes);
+            .drain();
+        worker
+            .metrics
+            .removed(queued.len(), queued.iter().map(|record| record.bytes).sum());
         queued
     }
 
     #[tokio::test]
-    async fn retries_a_transient_sink_failure() {
+    async fn batches_records_and_retries_a_transient_sink_failure() {
         let (publisher, worker) = telemetry_channel();
         assert!(publisher.try_publish(record()));
-        let queued = pop(&worker);
+        assert!(publisher.try_publish(record()));
+        let queued = drain(&worker);
         let sink = Arc::new(FailingSink {
             failures: 2,
             attempts: AtomicUsize::new(0),
+            records: AtomicUsize::new(0),
         });
         worker
             .deliver(
@@ -152,32 +172,37 @@ mod tests {
             )
             .await;
         assert_eq!(sink.attempts.load(Ordering::Relaxed), 3);
+        assert_eq!(sink.records.load(Ordering::Relaxed), 2);
         assert_eq!(publisher.metrics().dropped_records(), 0);
+        assert_eq!(publisher.metrics().queued_records(), 0);
     }
 
     #[tokio::test]
     async fn reports_retry_exhaustion_without_recursive_dead_letters() {
         let (publisher, worker) = telemetry_channel();
         assert!(publisher.try_publish(record()));
+        assert!(publisher.try_publish(record()));
         let sink: Arc<dyn TelemetrySink> = Arc::new(FailingSink {
             failures: usize::MAX,
             attempts: AtomicUsize::new(0),
+            records: AtomicUsize::new(0),
         });
-        worker.deliver(&sink, pop(&worker), Duration::ZERO).await;
-        assert_eq!(publisher.metrics().dropped_records(), 1);
-        let dead_letter = pop(&worker);
-        assert_eq!(dead_letter.record.name, DELIVERY_DROPPED_NAME);
-        assert_eq!(dead_letter.record.payload, b"turn_finished");
-
-        worker.deliver(&sink, dead_letter, Duration::ZERO).await;
+        worker.deliver(&sink, drain(&worker), Duration::ZERO).await;
         assert_eq!(publisher.metrics().dropped_records(), 2);
+        let dead_letters = drain(&worker);
+        assert_eq!(dead_letters.len(), 2);
+        assert_eq!(dead_letters[0].record.name, DELIVERY_DROPPED_NAME);
+        assert_eq!(dead_letters[0].record.payload, b"turn_finished");
+
+        worker.deliver(&sink, dead_letters, Duration::ZERO).await;
+        assert_eq!(publisher.metrics().dropped_records(), 4);
         assert!(
             worker
                 .queue
                 .lock()
                 .expect("telemetry queue mutex poisoned")
-                .pop()
-                .is_none()
+                .drain()
+                .is_empty()
         );
     }
 }

--- a/docs/guides/embed.mdx
+++ b/docs/guides/embed.mdx
@@ -48,3 +48,14 @@ is admitted, and both hold the request to the same contract the server's callers
 When a session is admitted, when it is resident, when it is recovered, when it is evicted. Where
 environments live and how they are found. Everything about product policy. The runtime has opinions
 about correctness, not about your architecture.
+
+## Telemetry delivery
+
+The telemetry channel is bounded and never holds up a turn. Its worker drains queued records into
+ordered batches and retries a rejected batch for up to 30 seconds. A sink may therefore receive a
+batch more than once and must make duplicates harmless. Exhausted deliveries are counted and
+reported through `telemetry_delivery_dropped` records when the queue still has room.
+
+Telemetry remains best effort. For resumable event forwarding, consume the session event endpoint,
+save its sequence cursor after the destination acknowledges a batch, and reconnect from that cursor.
+The journal, rather than the telemetry queue, is the durable record.


### PR DESCRIPTION
## Summary

- drain queued telemetry into ordered batches while disk persistence continues independently
- retry rejected batches under the existing bounded retry window and account for every dropped record
- require batch sinks to tolerate duplicate delivery and document journal-cursor forwarding for resumable events

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- npm ci
- npm test
- npm run package-smoke