### PR TITLE
docs: point the quickstart at the renamed agentloop packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ docker run --rm -p 8080:8080 -v brain-data:/var/lib/brain ghcr.io/aexhq/brain:la
 Drive a session from TypeScript:
 
 ```sh
-npm install @aexhq/brain @aexhq/brain-pi
+npm install @aexhq/brain @aexhq/agentloop-pi
 ```
 
 ```ts
 import { Brain } from "@aexhq/brain";
-import { pi } from "@aexhq/brain-pi";
+import { pi } from "@aexhq/agentloop-pi";
 
 const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -24,12 +24,12 @@ it refuses to start on a non-loopback address without one.
 ## Drive a session
 
 ```sh
-npm install @aexhq/brain @aexhq/brain-pi
+npm install @aexhq/brain @aexhq/agentloop-pi
 ```
 
 ```ts
 import { Brain } from "@aexhq/brain";
-import { pi } from "@aexhq/brain-pi";
+import { pi } from "@aexhq/agentloop-pi";
 
 const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });
 


### PR DESCRIPTION
The loop packages are being republished as `@aexhq/agentloop-pi` and `@aexhq/agentloop-codex` (loop vocabulary settled in #115); the README and quickstart install lines follow.