### PR TITLE
sdk: host callback tools in the author's app

### DIFF
--- a/docs/concepts/tool.mdx
+++ b/docs/concepts/tool.mdx
@@ -51,6 +51,18 @@ process holding your sessions.
 That is also why a tool can be anything with an address: a sandbox VM, a browser tab, a service you
 already run, or a process on the user's own laptop.
 
+## Two hostings, one envelope
+
+The manifest's `hosting` axis says where the implementation lives; the invocation envelope does
+not change.
+
+- **Provisioned** (the default): the tool is a built artifact the environment executes.
+- **Callback**: the code stays in the author's own app — declared with
+  [`appTool`](/brain/docs/guides/app-tools) at create, registered with `appTools` in the app —
+  and the bound environment routes each invocation there: signed POSTs to a backend, or down
+  the outbound channel a browser page holds open. Secrets and app state never leave the app;
+  the trade is availability, which follows the app being up and connected.
+
 ## Splitting presentation from execution
 
 Because the two halves are independent, the same `read` the model sees can be bound to a MicroVM in

--- a/docs/guides/app-tools.mdx
+++ b/docs/guides/app-tools.mdx
@@ -1,0 +1,118 @@
+---
+title: Host a Tool in your app
+description: Callback tools run in your own process; the environment routes each call to them.
+---
+
+A provisioned tool ships its code to an environment. A callback tool does the opposite: the
+function stays in your app — closing over your state, your secrets, your database client — and
+the bound environment routes each invocation to it. Brain cannot tell the difference: both
+hostings answer `invoke {call_id, tool, input, deadline_ms}` with the same outcome —
+`ok | error | timeout | cancelled`.
+
+The registration shape is identical in both directions; only the transport differs.
+
+## Backend app: mount a handler
+
+A backend can listen, so the environment POSTs invocations to it, HMAC-signed with a key you
+share through the environment's configuration:
+
+```ts
+import { appTools } from "@aexhq/brain";
+import { z } from "zod";
+
+const tools = appTools({ signingKey: process.env.AEX_SIGNING_KEY });
+
+tools.register({
+  name: "create_invoice",
+  description: "Create an invoice in this app.",
+  input: z.object({ customer_id: z.string(), amount_cents: z.number().int() }),
+  output: z.object({ invoice_id: z.string() }),
+}, async (input) => billing.createInvoice(input));   // closes over app state + secrets
+
+export default tools.fetchHandler();                  // a WHATWG fetch handler; mount it anywhere
+```
+
+The handler verifies the signature over the raw body before anything else: an unsigned or
+tampered request is a 401 and a malformed one a 400, and neither ever reaches your function.
+A schema-invalid input, a thrown error, or a broken output contract each become an in-band
+error outcome. The handler races your function against `deadline_ms` and honors best-effort
+cancellation (`{cancel: call_id}` on the same endpoint) through the `signal` it hands you.
+
+## Browser or laptop: hold the channel outward
+
+A page cannot listen, so it connects out to the environment's channel endpoint and answers
+invocation frames over the socket. Registration is the same:
+
+```ts
+import { appTools } from "@aexhq/brain";
+import { z } from "zod";
+
+const tools = appTools.connect({ url: "wss://runtime.example/environments/app/channel", token });
+
+tools.register({
+  name: "highlight_row",
+  description: "Highlight a row in the visible grid.",
+  input: z.object({ row: z.number().int() }),
+}, async ({ row }) => grid.highlight(row));
+```
+
+The channel reconnects with backoff after a drop and is silent-safe: while it is down, the
+environment answers invocations immediately with a typed `app_disconnected` error — nothing
+hangs on either side. `tools.close()` ends it deliberately.
+
+## The environment side: `route.callbacks()`
+
+Whichever direction the transport runs, an environment declares that it routes callback
+invocations with one line:
+
+```ts
+export const app = environment({ options: z.object({ channelToken: z.string() }) }, (author) => {
+  const instance = author.open(async () => ({}));
+  instance.run(async () => undefined);
+  instance.close(async () => undefined);
+  author.route.callbacks();   // terminates the app's channel; token from options.channelToken
+  return {};
+});
+```
+
+Without a resolver the environment terminates the app's outbound WebSocket, authenticated by
+the `channelToken` option; its host server mounts the endpoint in one line:
+
+```ts
+server.on("upgrade", (request, socket, head) => handle.channel.upgrade(request, socket, head));
+```
+
+For a backend app, a resolver picks signed-POST mode from the environment's own options
+instead:
+
+```ts
+author.route.callbacks(({ options }) => ({ mode: "post", url: options.appUrl, signingKey: options.signingKey }));
+```
+
+Either way the environment enforces `deadline_ms` itself — an overdue call becomes a `timeout`
+outcome and a best-effort cancel travels down to the app — and an unreachable or disconnected
+app is a typed error outcome, never a hang.
+
+## Composing a session
+
+At create, a callback tool is schema only — `hosting: "callback"`, no payload, empty
+`requires`, so it binds to any environment:
+
+```ts
+import { appTool } from "@aexhq/brain";
+
+await brain.sessions.create({
+  model, agentloop: pi(),
+  tools: [
+    bash.useIn(vm),                                   // provisioned: code ships to the vm
+    appTool({
+      name: "create_invoice",
+      description: "Create an invoice in this app.",
+      input: z.object({ customer_id: z.string(), amount_cents: z.number().int() }),
+    }).useIn(app),                                    // callback: code stays home
+  ],
+});
+```
+
+The declared schema must match what the app registered — `tools.manifests()` returns the
+callback manifests so the two can share one source of truth.

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Guides",
-  "pages": ["write-a-loop", "write-a-tool", "write-an-environment", "embed"]
+  "pages": ["write-a-loop", "write-a-tool", "app-tools", "write-an-environment", "embed"]
 }

--- a/packages/brain-sdk/src/app.ts
+++ b/packages/brain-sdk/src/app.ts
@@ -1,0 +1,262 @@
+import { z } from "zod";
+
+import { errorOutcome, parseCancelFrame, parseInvokeFrame, signatureHeader, verifySignature, type InvokeFrame, type Outcome } from "./callback-wire.js";
+import type { CapabilityName, Schema, SchemaOutput } from "./types.js";
+
+/** The contract of one app-hosted tool: what the model sees, declared where the
+ * function lives. The function itself never leaves the app's process. */
+export interface AppToolContract<InputSchema extends Schema = Schema, OutputSchema extends Schema | undefined = Schema | undefined> {
+  readonly name: string;
+  readonly description: string;
+  readonly input: InputSchema;
+  readonly output?: OutputSchema;
+}
+
+export interface AppToolCall {
+  readonly callId: string;
+  /** When the environment's budget for this call runs out. */
+  readonly deadline: Date;
+  /** Fires on best-effort cancellation and when the deadline passes. */
+  readonly signal: AbortSignal;
+}
+
+type AppToolHandler<Input, Output> = (input: Input, call: AppToolCall) => Output | Promise<Output>;
+
+/** The `contracts/tool/v1` manifest of a callback tool: `hosting: "callback"`, no
+ * payload — the code stays home. */
+export interface CallbackToolManifest {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: Readonly<Record<string, unknown>>;
+  readonly output_schema?: Readonly<Record<string, unknown>>;
+  readonly requires: readonly CapabilityName[];
+  readonly binding_names: readonly string[];
+  readonly hosting: "callback";
+}
+
+/** The one registration surface, identical in both transport directions. */
+export interface AppTools {
+  register<InputSchema extends Schema, OutputSchema extends Schema | undefined = undefined>(
+    contract: AppToolContract<InputSchema, OutputSchema>,
+    handler: AppToolHandler<SchemaOutput<InputSchema>, OutputSchema extends Schema ? SchemaOutput<OutputSchema> : unknown>,
+  ): this;
+  manifests(): readonly CallbackToolManifest[];
+}
+
+/** Backend direction: the app listens and the environment POSTs signed invocations. */
+export interface AppToolServer extends AppTools {
+  fetchHandler(): (request: Request) => Promise<Response>;
+}
+
+/** Browser/outbound direction: the app holds a channel out to the environment. */
+export interface AppToolChannel extends AppTools {
+  /** Resolves when the channel is connected; a new promise after every drop. */
+  ready(): Promise<void>;
+  close(): void;
+}
+
+interface RegisteredAppTool {
+  readonly contract: AppToolContract;
+  readonly handler: AppToolHandler<unknown, unknown>;
+}
+
+class AppToolRegistry {
+  private readonly tools = new Map<string, RegisteredAppTool>();
+  private readonly active = new Map<string, { readonly controller: AbortController; cancelled: boolean }>();
+
+  register(contract: AppToolContract, handler: AppToolHandler<unknown, unknown>): void {
+    if (typeof contract?.name !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(contract.name)) throw new TypeError("app tool name must be an identifier");
+    if (typeof contract.description !== "string" || contract.description.length === 0 || contract.description.length > 8_192) throw new TypeError("app tool description exceeds its contract bound");
+    if (typeof handler !== "function") throw new TypeError("app tool needs a handler function");
+    if (this.tools.has(contract.name)) throw new TypeError(`app tool ${contract.name} is already registered`);
+    this.tools.set(contract.name, { contract, handler });
+  }
+
+  manifests(): readonly CallbackToolManifest[] {
+    return [...this.tools.values()].map(({ contract }) => Object.freeze({
+      name: contract.name,
+      description: contract.description,
+      input_schema: Object.freeze(z.toJSONSchema(contract.input) as Record<string, unknown>),
+      ...(contract.output === undefined ? {} : { output_schema: Object.freeze(z.toJSONSchema(contract.output) as Record<string, unknown>) }),
+      requires: Object.freeze([]) as readonly CapabilityName[],
+      binding_names: Object.freeze([]) as readonly string[],
+      hosting: "callback" as const,
+    }));
+  }
+
+  cancel(callId: string): void {
+    const call = this.active.get(callId);
+    if (call === undefined) return;
+    call.cancelled = true;
+    call.controller.abort(new Error("call cancelled"));
+  }
+
+  async run(frame: InvokeFrame): Promise<Outcome> {
+    const registered = this.tools.get(frame.name);
+    if (registered === undefined) return errorOutcome("unknown_tool", `no app tool named ${frame.name} is registered`);
+    let input: unknown;
+    try {
+      input = registered.contract.input.parse(frame.arguments);
+    } catch (error) {
+      return errorOutcome("invalid_input", String(error instanceof Error ? error.message : error));
+    }
+    const call = { controller: new AbortController(), cancelled: false };
+    this.active.set(frame.call_id, call);
+    const timer = setTimeout(() => call.controller.abort(new Error("call deadline passed")), frame.deadline_ms);
+    const interrupted = new Promise<typeof interruption>((resolve) => call.controller.signal.addEventListener("abort", () => resolve(interruption), { once: true }));
+    try {
+      const value = await Promise.race([
+        Promise.resolve(registered.handler(input, { callId: frame.call_id, deadline: new Date(Date.now() + frame.deadline_ms), signal: call.controller.signal })),
+        interrupted,
+      ]);
+      if (value === interruption) return { status: call.cancelled ? "cancelled" : "timeout" };
+      if (registered.contract.output === undefined) return { status: "ok", value: value ?? null };
+      try {
+        return { status: "ok", value: registered.contract.output.parse(value) ?? null };
+      } catch (error) {
+        return errorOutcome("invalid_output", String(error instanceof Error ? error.message : error));
+      }
+    } catch (error) {
+      if (call.controller.signal.aborted) return { status: call.cancelled ? "cancelled" : "timeout" };
+      return errorOutcome("tool_error", String(error instanceof Error ? error.message : error));
+    } finally {
+      clearTimeout(timer);
+      this.active.delete(frame.call_id);
+    }
+  }
+}
+
+const interruption = Symbol("call interrupted");
+
+function requireOption(value: string | undefined, name: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError(`appTools needs a non-empty ${name}`);
+  return value;
+}
+
+/**
+ * Host callback tools in a backend app: mount the returned fetch handler and the
+ * environment POSTs HMAC-signed invocations to it. Unsigned or malformed requests are
+ * refused before any tool code runs; a handler that throws becomes an error outcome.
+ */
+export function appTools(options: { readonly signingKey: string | undefined }): AppToolServer {
+  const signingKey = requireOption(options?.signingKey, "signingKey");
+  const registry = new AppToolRegistry();
+  const server: AppToolServer = {
+    register(contract, handler) {
+      registry.register(contract, handler as AppToolHandler<unknown, unknown>);
+      return server;
+    },
+    manifests: () => registry.manifests(),
+    fetchHandler() {
+      return async (request: Request): Promise<Response> => {
+        if (request.method !== "POST") return failure(405, "method_not_allowed", "callback invocations are POSTed");
+        const body = await request.text();
+        const signature = request.headers.get(signatureHeader);
+        if (signature === null || !verifySignature(body, signature, signingKey)) return failure(401, "invalid_signature", "the request is not signed with this app's key");
+        let frame: unknown;
+        try {
+          frame = JSON.parse(body);
+        } catch {
+          return failure(400, "invalid_request", "the request body is not JSON");
+        }
+        const cancel = parseCancelFrame(frame);
+        if (cancel !== undefined) {
+          registry.cancel(cancel.cancel);
+          return Response.json({ status: "ok", value: null });
+        }
+        const invoke = parseInvokeFrame(frame);
+        if (invoke === undefined) return failure(400, "invalid_request", "the request is not an invocation frame");
+        return Response.json(await registry.run(invoke));
+      };
+    },
+  };
+  return Object.freeze(server);
+}
+
+function failure(status: number, code: string, message: string): Response {
+  return Response.json({ code, message, retryable: false }, { status });
+}
+
+/**
+ * Host callback tools from a process that cannot listen (a browser page, a laptop
+ * behind NAT): hold an outbound WebSocket to the environment's channel endpoint,
+ * answer invocation frames with outcomes, honor best-effort cancel, and reconnect
+ * with backoff. While the socket is down the environment answers invocations with a
+ * typed "app disconnected" error — nothing hangs here or there.
+ */
+appTools.connect = function connect(options: { readonly url: string | URL; readonly token: string | undefined }): AppToolChannel {
+  const token = requireOption(options?.token, "token");
+  const target = new URL(options.url);
+  target.searchParams.set("token", token);
+  const registry = new AppToolRegistry();
+  let socket: WebSocket | undefined;
+  let closed = false;
+  let attempt = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let readyResolvers: (() => void)[] = [];
+
+  const open = (): void => {
+    if (closed) return;
+    const ws = new WebSocket(target);
+    socket = ws;
+    ws.addEventListener("open", () => {
+      attempt = 0;
+      const resolvers = readyResolvers;
+      readyResolvers = [];
+      for (const resolve of resolvers) resolve();
+    });
+    ws.addEventListener("message", (event) => { void answer(ws, event.data); });
+    ws.addEventListener("error", () => {});
+    ws.addEventListener("close", () => {
+      if (socket !== ws) return;
+      socket = undefined;
+      if (closed) return;
+      timer = setTimeout(open, Math.min(10_000, 250 * 2 ** attempt));
+      attempt += 1;
+      (timer as { unref?(): void }).unref?.();
+    });
+  };
+
+  const answer = async (ws: WebSocket, data: unknown): Promise<void> => {
+    let frame: unknown;
+    try {
+      const text = typeof data === "string" ? data
+        : data instanceof Blob ? await data.text()
+        : new TextDecoder().decode(data as ArrayBuffer);
+      frame = JSON.parse(text);
+    } catch {
+      return;
+    }
+    const cancel = parseCancelFrame(frame);
+    if (cancel !== undefined) {
+      registry.cancel(cancel.cancel);
+      return;
+    }
+    const invoke = parseInvokeFrame(frame);
+    if (invoke === undefined) return;
+    const outcome = await registry.run(invoke);
+    if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ call_id: invoke.call_id, ...outcome }));
+  };
+
+  open();
+  const channel: AppToolChannel = {
+    register(contract, handler) {
+      registry.register(contract, handler as AppToolHandler<unknown, unknown>);
+      return channel;
+    },
+    manifests: () => registry.manifests(),
+    ready(): Promise<void> {
+      if (closed) return Promise.reject(new Error("the channel is closed"));
+      if (socket !== undefined && socket.readyState === WebSocket.OPEN) return Promise.resolve();
+      return new Promise((resolve) => readyResolvers.push(resolve));
+    },
+    close(): void {
+      closed = true;
+      if (timer !== undefined) clearTimeout(timer);
+      socket?.close();
+      socket = undefined;
+      readyResolvers = [];
+    },
+  };
+  return Object.freeze(channel);
+};

--- a/packages/brain-sdk/src/app.ts
+++ b/packages/brain-sdk/src/app.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { errorOutcome, parseCancelFrame, parseInvokeFrame, signatureHeader, verifySignature, type InvokeFrame, type Outcome } from "./callback-wire.js";
+import { errorOutcome, MAX_DEADLINE_MS, parseCancelFrame, parseInvokeFrame, signatureHeader, verifySignature, type InvokeFrame, type Outcome } from "./callback-wire.js";
 import type { CapabilityName, Schema, SchemaOutput } from "./types.js";
 
 /** The contract of one app-hosted tool: what the model sees, declared where the
@@ -102,11 +102,12 @@ class AppToolRegistry {
     }
     const call = { controller: new AbortController(), cancelled: false };
     this.active.set(frame.call_id, call);
-    const timer = setTimeout(() => call.controller.abort(new Error("call deadline passed")), frame.deadline_ms);
+    const deadlineMs = Math.min(frame.deadline_ms, MAX_DEADLINE_MS);
+    const timer = setTimeout(() => call.controller.abort(new Error("call deadline passed")), deadlineMs);
     const interrupted = new Promise<typeof interruption>((resolve) => call.controller.signal.addEventListener("abort", () => resolve(interruption), { once: true }));
     try {
       const value = await Promise.race([
-        Promise.resolve(registered.handler(input, { callId: frame.call_id, deadline: new Date(Date.now() + frame.deadline_ms), signal: call.controller.signal })),
+        Promise.resolve(registered.handler(input, { callId: frame.call_id, deadline: new Date(Date.now() + deadlineMs), signal: call.controller.signal })),
         interrupted,
       ]);
       if (value === interruption) return { status: call.cancelled ? "cancelled" : "timeout" };

--- a/packages/brain-sdk/src/app.ts
+++ b/packages/brain-sdk/src/app.ts
@@ -102,7 +102,7 @@ class AppToolRegistry {
     }
     const call = { controller: new AbortController(), cancelled: false };
     this.active.set(frame.call_id, call);
-    const deadlineMs = Math.min(frame.deadline_ms, MAX_DEADLINE_MS);
+    const deadlineMs = frame.deadline_ms > MAX_DEADLINE_MS ? MAX_DEADLINE_MS : frame.deadline_ms;
     const timer = setTimeout(() => call.controller.abort(new Error("call deadline passed")), deadlineMs);
     const interrupted = new Promise<typeof interruption>((resolve) => call.controller.signal.addEventListener("abort", () => resolve(interruption), { once: true }));
     try {

--- a/packages/brain-sdk/src/callback-wire.ts
+++ b/packages/brain-sdk/src/callback-wire.ts
@@ -1,0 +1,71 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/** The one envelope every callback invocation resolves to — the same Outcome Brain
+ * journals for every tool call, regardless of hosting. */
+export type Outcome =
+  | { readonly status: "ok"; readonly value: unknown }
+  | { readonly status: "error"; readonly error: { readonly code: string; readonly message: string; readonly details?: unknown } }
+  | { readonly status: "timeout" }
+  | { readonly status: "cancelled" };
+
+/** One invocation as it crosses the app boundary: MCP data shapes over plain HTTP,
+ * no framing ceremony. `deadline_ms` is the remaining budget, not an epoch. */
+export interface InvokeFrame {
+  readonly call_id: string;
+  readonly name: string;
+  readonly arguments: unknown;
+  readonly deadline_ms: number;
+}
+
+/** Best-effort cancellation travels down the same channel as the invocation. */
+export interface CancelFrame { readonly cancel: string }
+
+export const signatureHeader = "x-brain-signature";
+
+export function sign(body: string, signingKey: string): string {
+  return createHmac("sha256", signingKey).update(body, "utf8").digest("hex");
+}
+
+export function verifySignature(body: string, signature: string, signingKey: string): boolean {
+  if (!/^[0-9a-f]{64}$/u.test(signature)) return false;
+  return timingSafeEqual(Buffer.from(sign(body, signingKey), "hex"), Buffer.from(signature, "hex"));
+}
+
+export function errorOutcome(code: string, message: string): Outcome {
+  return { status: "error", error: { code, message: message.slice(0, 4096) } };
+}
+
+/** Accept only a well-formed Outcome from the other side of the wire; anything else
+ * becomes a typed error instead of leaking garbage into the receipt. */
+export function normalizeOutcome(value: unknown): Outcome {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    if (record.status === "ok" && "value" in record) return { status: "ok", value: record.value ?? null };
+    if (record.status === "timeout") return { status: "timeout" };
+    if (record.status === "cancelled") return { status: "cancelled" };
+    if (record.status === "error" && record.error !== null && typeof record.error === "object" && !Array.isArray(record.error)) {
+      const error = record.error as Record<string, unknown>;
+      if (typeof error.code === "string" && typeof error.message === "string") {
+        const code = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(error.code) ? error.code : "app_error";
+        return { status: "error", error: { code, message: error.message.slice(0, 4096), ...("details" in error ? { details: error.details } : {}) } };
+      }
+    }
+  }
+  return errorOutcome("invalid_outcome", "the app returned a malformed outcome");
+}
+
+export function parseInvokeFrame(value: unknown): InvokeFrame | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.call_id !== "string" || record.call_id.length === 0) return undefined;
+  if (typeof record.name !== "string" || record.name.length === 0) return undefined;
+  if (typeof record.deadline_ms !== "number" || !Number.isInteger(record.deadline_ms) || record.deadline_ms < 1) return undefined;
+  if (!("arguments" in record)) return undefined;
+  return { call_id: record.call_id, name: record.name, arguments: record.arguments, deadline_ms: record.deadline_ms };
+}
+
+export function parseCancelFrame(value: unknown): CancelFrame | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const cancel = (value as Record<string, unknown>).cancel;
+  return typeof cancel === "string" && cancel.length > 0 ? { cancel } : undefined;
+}

--- a/packages/brain-sdk/src/callback-wire.ts
+++ b/packages/brain-sdk/src/callback-wire.ts
@@ -22,6 +22,10 @@ export interface CancelFrame { readonly cancel: string }
 
 export const signatureHeader = "x-brain-signature";
 
+/** Ceiling on a wire-provided call deadline: generous next to the kernel's default
+ * tool deadline, small enough that a hostile frame cannot pin a timer for hours. */
+export const MAX_DEADLINE_MS = 600_000;
+
 export function sign(body: string, signingKey: string): string {
   return createHmac("sha256", signingKey).update(body, "utf8").digest("hex");
 }
@@ -61,7 +65,8 @@ export function parseInvokeFrame(value: unknown): InvokeFrame | undefined {
   if (typeof record.name !== "string" || record.name.length === 0) return undefined;
   if (typeof record.deadline_ms !== "number" || !Number.isInteger(record.deadline_ms) || record.deadline_ms < 1) return undefined;
   if (!("arguments" in record)) return undefined;
-  return { call_id: record.call_id, name: record.name, arguments: record.arguments, deadline_ms: record.deadline_ms };
+  // The deadline arms a timer, so a frame must not be able to demand an unbounded one.
+  return { call_id: record.call_id, name: record.name, arguments: record.arguments, deadline_ms: Math.min(record.deadline_ms, MAX_DEADLINE_MS) };
 }
 
 export function parseCancelFrame(value: unknown): CancelFrame | undefined {

--- a/packages/brain-sdk/src/callbacks.ts
+++ b/packages/brain-sdk/src/callbacks.ts
@@ -55,7 +55,7 @@ class PostRouter implements CallbackRouter {
     const body = JSON.stringify(frame);
     const controller = new AbortController();
     let interruption: "timeout" | "cancelled" | undefined;
-    const timer = setTimeout(() => { interruption = "timeout"; controller.abort(); }, Math.min(frame.deadline_ms, MAX_DEADLINE_MS));
+    const timer = setTimeout(() => { interruption = "timeout"; controller.abort(); }, frame.deadline_ms > MAX_DEADLINE_MS ? MAX_DEADLINE_MS : frame.deadline_ms);
     const onAbort = (): void => { interruption = "cancelled"; controller.abort(); };
     signal.addEventListener("abort", onAbort, { once: true });
     try {
@@ -128,7 +128,7 @@ class ChannelRouter implements CallbackRouter {
       timer = setTimeout(() => {
         connection.send({ cancel: frame.call_id });
         settle({ status: "timeout" });
-      }, Math.min(frame.deadline_ms, MAX_DEADLINE_MS));
+      }, frame.deadline_ms > MAX_DEADLINE_MS ? MAX_DEADLINE_MS : frame.deadline_ms);
       signal.addEventListener("abort", onAbort, { once: true });
       connection.send(frame);
     });

--- a/packages/brain-sdk/src/callbacks.ts
+++ b/packages/brain-sdk/src/callbacks.ts
@@ -2,7 +2,7 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 
-import { errorOutcome, normalizeOutcome, sign, signatureHeader, type InvokeFrame, type Outcome } from "./callback-wire.js";
+import { errorOutcome, MAX_DEADLINE_MS, normalizeOutcome, sign, signatureHeader, type InvokeFrame, type Outcome } from "./callback-wire.js";
 
 /**
  * Where an environment sends callback-tool invocations. `channel` terminates the
@@ -55,7 +55,7 @@ class PostRouter implements CallbackRouter {
     const body = JSON.stringify(frame);
     const controller = new AbortController();
     let interruption: "timeout" | "cancelled" | undefined;
-    const timer = setTimeout(() => { interruption = "timeout"; controller.abort(); }, frame.deadline_ms);
+    const timer = setTimeout(() => { interruption = "timeout"; controller.abort(); }, Math.min(frame.deadline_ms, MAX_DEADLINE_MS));
     const onAbort = (): void => { interruption = "cancelled"; controller.abort(); };
     signal.addEventListener("abort", onAbort, { once: true });
     try {
@@ -128,7 +128,7 @@ class ChannelRouter implements CallbackRouter {
       timer = setTimeout(() => {
         connection.send({ cancel: frame.call_id });
         settle({ status: "timeout" });
-      }, frame.deadline_ms);
+      }, Math.min(frame.deadline_ms, MAX_DEADLINE_MS));
       signal.addEventListener("abort", onAbort, { once: true });
       connection.send(frame);
     });

--- a/packages/brain-sdk/src/callbacks.ts
+++ b/packages/brain-sdk/src/callbacks.ts
@@ -1,0 +1,331 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+
+import { errorOutcome, normalizeOutcome, sign, signatureHeader, type InvokeFrame, type Outcome } from "./callback-wire.js";
+
+/**
+ * Where an environment sends callback-tool invocations. `channel` terminates the
+ * app's outbound WebSocket (a browser page, a process behind NAT, connecting with
+ * `appTools.connect`); `post` sends HMAC-signed POSTs to a backend app that mounted
+ * `appTools(...).fetchHandler()`.
+ */
+export type CallbackRoute =
+  | { readonly mode: "channel"; readonly token: string }
+  | { readonly mode: "post"; readonly url: string; readonly signingKey: string };
+
+export interface CallbackRouter {
+  invoke(frame: InvokeFrame, signal: AbortSignal): Promise<Outcome>;
+  /** Terminate an app's WebSocket upgrade on this router's channel. Returns false
+   * when this router routes over POST and terminates no channel. */
+  upgrade(request: IncomingMessage, socket: Duplex, head: Uint8Array): boolean;
+  close(): void;
+}
+
+export function resolveCallbackRoute(value: unknown): CallbackRoute {
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (record.mode === "channel" && typeof record.token === "string" && record.token.length > 0) return { mode: "channel", token: record.token };
+    if (record.mode === "post" && typeof record.url === "string" && /^https?:\/\//u.test(record.url) && typeof record.signingKey === "string" && record.signingKey.length > 0) {
+      return { mode: "post", url: record.url, signingKey: record.signingKey };
+    }
+  }
+  throw new TypeError("route.callbacks() needs { mode: \"channel\", token } or { mode: \"post\", url, signingKey }");
+}
+
+export function createCallbackRouter(route: CallbackRoute): CallbackRouter {
+  return route.mode === "post" ? new PostRouter(route) : new ChannelRouter(route);
+}
+
+/** Refuse a socket that arrived as an HTTP upgrade with a plain HTTP response. */
+export function refuseUpgrade(socket: Duplex, status: number, message: string): void {
+  const reason = status === 401 ? "Unauthorized" : status === 404 ? "Not Found" : "Bad Request";
+  try {
+    socket.write(`HTTP/1.1 ${status} ${reason}\r\nConnection: close\r\nContent-Type: text/plain\r\nContent-Length: ${Buffer.byteLength(message)}\r\n\r\n${message}`);
+  } catch {
+    // The refusal is best-effort; the destroy below is what matters.
+  }
+  socket.destroy();
+}
+
+class PostRouter implements CallbackRouter {
+  constructor(private readonly route: { readonly url: string; readonly signingKey: string }) {}
+
+  async invoke(frame: InvokeFrame, signal: AbortSignal): Promise<Outcome> {
+    const body = JSON.stringify(frame);
+    const controller = new AbortController();
+    let interruption: "timeout" | "cancelled" | undefined;
+    const timer = setTimeout(() => { interruption = "timeout"; controller.abort(); }, frame.deadline_ms);
+    const onAbort = (): void => { interruption = "cancelled"; controller.abort(); };
+    signal.addEventListener("abort", onAbort, { once: true });
+    try {
+      const response = await fetch(this.route.url, {
+        method: "POST",
+        headers: { "content-type": "application/json", [signatureHeader]: sign(body, this.route.signingKey) },
+        body,
+        signal: controller.signal,
+      });
+      const text = await response.text();
+      if (!response.ok) return errorOutcome("app_unreachable", `the app answered ${response.status}`);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        return errorOutcome("invalid_outcome", "the app answered with a non-JSON body");
+      }
+      return normalizeOutcome(parsed);
+    } catch (error) {
+      if (interruption !== undefined) {
+        this.cancelDownstream(frame.call_id);
+        return { status: interruption };
+      }
+      return errorOutcome("app_unreachable", String(error instanceof Error ? error.message : error));
+    } finally {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+
+  private cancelDownstream(callId: string): void {
+    const body = JSON.stringify({ cancel: callId });
+    void fetch(this.route.url, {
+      method: "POST",
+      headers: { "content-type": "application/json", [signatureHeader]: sign(body, this.route.signingKey) },
+      body,
+      signal: AbortSignal.timeout(5_000),
+    }).catch(() => {});
+  }
+
+  upgrade(): boolean { return false; }
+  close(): void {}
+}
+
+class ChannelRouter implements CallbackRouter {
+  private connection: ChannelConnection | undefined;
+  private readonly pending = new Map<string, (outcome: Outcome) => void>();
+  private closed = false;
+
+  constructor(private readonly route: { readonly token: string }) {}
+
+  invoke(frame: InvokeFrame, signal: AbortSignal): Promise<Outcome> {
+    const connection = this.connection;
+    if (connection === undefined) {
+      return Promise.resolve(errorOutcome("app_disconnected", "no app is connected to this environment's callback channel"));
+    }
+    return new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const settle = (outcome: Outcome): void => {
+        if (!this.pending.delete(frame.call_id)) return;
+        if (timer !== undefined) clearTimeout(timer);
+        signal.removeEventListener("abort", onAbort);
+        resolve(outcome);
+      };
+      const onAbort = (): void => {
+        connection.send({ cancel: frame.call_id });
+        settle({ status: "cancelled" });
+      };
+      this.pending.set(frame.call_id, settle);
+      timer = setTimeout(() => {
+        connection.send({ cancel: frame.call_id });
+        settle({ status: "timeout" });
+      }, frame.deadline_ms);
+      signal.addEventListener("abort", onAbort, { once: true });
+      connection.send(frame);
+    });
+  }
+
+  upgrade(request: IncomingMessage, socket: Duplex, head: Uint8Array): boolean {
+    if (this.closed) {
+      refuseUpgrade(socket, 404, "this callback channel is closed");
+      return true;
+    }
+    const key = request.headers["sec-websocket-key"];
+    if ((request.headers.upgrade ?? "").toLowerCase() !== "websocket" || typeof key !== "string" || request.headers["sec-websocket-version"] !== "13") {
+      refuseUpgrade(socket, 400, "expected a WebSocket upgrade");
+      return true;
+    }
+    if (!this.authorized(request)) {
+      refuseUpgrade(socket, 401, "invalid channel token");
+      return true;
+    }
+    const accept = createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+    socket.write(`HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`);
+    const connection: ChannelConnection = new ChannelConnection(socket, head, {
+      message: (text) => this.deliver(text),
+      close: () => {
+        if (this.connection === connection) this.connection = undefined;
+        // Calls in flight went down this socket; nothing will answer them now.
+        for (const settle of [...this.pending.values()]) settle(errorOutcome("app_disconnected", "the app disconnected before answering"));
+      },
+    });
+    // Last connection wins: a reconnecting app must displace its own half-dead socket.
+    this.connection?.close();
+    this.connection = connection;
+    return true;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.connection?.close();
+    this.connection = undefined;
+    for (const settle of [...this.pending.values()]) settle(errorOutcome("app_disconnected", "the callback channel is closed"));
+  }
+
+  private authorized(request: IncomingMessage): boolean {
+    const url = new URL(request.url ?? "/", "http://environment");
+    const bearer = /^Bearer (.+)$/u.exec(request.headers.authorization ?? "");
+    const presented = url.searchParams.get("token") ?? bearer?.[1];
+    if (typeof presented !== "string") return false;
+    const expected = Buffer.from(this.route.token);
+    const actual = Buffer.from(presented);
+    return expected.length === actual.length && timingSafeEqual(expected, actual);
+  }
+
+  private deliver(text: string): void {
+    let frame: unknown;
+    try {
+      frame = JSON.parse(text);
+    } catch {
+      return;
+    }
+    if (frame === null || typeof frame !== "object") return;
+    const callId = (frame as Record<string, unknown>).call_id;
+    if (typeof callId !== "string") return;
+    this.pending.get(callId)?.(normalizeOutcome(frame));
+  }
+}
+
+const maximumMessageBytes = 4 * 1024 * 1024;
+
+/**
+ * One terminated WebSocket connection: the minimal server half of RFC 6455 — the
+ * handshake happened in the router; this owns text frames, ping/pong, close, and
+ * continuation, with a hard message size bound. Small enough on purpose: the channel
+ * carries only this contract's JSON frames, so a dependency earns nothing.
+ */
+class ChannelConnection {
+  private buffer: Buffer = Buffer.alloc(0);
+  private fragments: Buffer[] = [];
+  private destroyed = false;
+
+  constructor(private readonly socket: Duplex, head: Uint8Array, private readonly events: { message(text: string): void; close(): void }) {
+    socket.on("data", (chunk: Buffer) => this.feed(chunk));
+    socket.on("error", () => socket.destroy());
+    socket.on("close", () => {
+      if (this.destroyed) return;
+      this.destroyed = true;
+      this.events.close();
+    });
+    if (head.byteLength > 0) this.feed(Buffer.from(head.buffer, head.byteOffset, head.byteLength));
+  }
+
+  send(value: unknown): void {
+    if (this.destroyed) return;
+    this.socket.write(encodeFrame(0x1, Buffer.from(JSON.stringify(value))));
+  }
+
+  close(): void {
+    if (this.destroyed) return;
+    try {
+      this.socket.write(encodeFrame(0x8, Buffer.alloc(0)));
+    } catch {
+      // Closing a broken socket is fine; destroy below is authoritative.
+    }
+    this.socket.destroy();
+  }
+
+  private feed(chunk: Buffer): void {
+    if (this.destroyed) return;
+    this.buffer = this.buffer.byteLength === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+    if (this.buffer.byteLength > maximumMessageBytes + 14) {
+      this.close();
+      return;
+    }
+    for (;;) {
+      const frame = decodeFrame(this.buffer);
+      if (frame === undefined) return;
+      if (frame === "invalid") {
+        this.close();
+        return;
+      }
+      this.buffer = this.buffer.subarray(frame.consumed);
+      switch (frame.opcode) {
+        case 0x0:
+        case 0x1:
+        case 0x2: {
+          if (frame.opcode !== 0x0) this.fragments = [];
+          this.fragments.push(frame.payload);
+          if (this.fragments.reduce((total, part) => total + part.byteLength, 0) > maximumMessageBytes) {
+            this.close();
+            return;
+          }
+          if (frame.fin) {
+            const text = Buffer.concat(this.fragments).toString("utf8");
+            this.fragments = [];
+            this.events.message(text);
+          }
+          break;
+        }
+        case 0x8:
+          this.close();
+          return;
+        case 0x9:
+          if (!this.destroyed) this.socket.write(encodeFrame(0xa, frame.payload));
+          break;
+        case 0xa:
+          break;
+        default:
+          this.close();
+          return;
+      }
+    }
+  }
+}
+
+function encodeFrame(opcode: number, payload: Buffer): Buffer {
+  let header: Buffer;
+  if (payload.byteLength < 126) {
+    header = Buffer.from([0x80 | opcode, payload.byteLength]);
+  } else if (payload.byteLength < 65_536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(payload.byteLength, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(payload.byteLength), 2);
+  }
+  return Buffer.concat([header, payload]);
+}
+
+function decodeFrame(buffer: Buffer): { readonly fin: boolean; readonly opcode: number; readonly payload: Buffer; readonly consumed: number } | "invalid" | undefined {
+  if (buffer.byteLength < 2) return undefined;
+  const fin = (buffer[0]! & 0x80) !== 0;
+  const opcode = buffer[0]! & 0x0f;
+  const masked = (buffer[1]! & 0x80) !== 0;
+  let length = buffer[1]! & 0x7f;
+  let offset = 2;
+  if (length === 126) {
+    if (buffer.byteLength < 4) return undefined;
+    length = buffer.readUInt16BE(2);
+    offset = 4;
+  } else if (length === 127) {
+    if (buffer.byteLength < 10) return undefined;
+    const wide = buffer.readBigUInt64BE(2);
+    if (wide > BigInt(maximumMessageBytes)) return "invalid";
+    length = Number(wide);
+    offset = 10;
+  }
+  if (length > maximumMessageBytes) return "invalid";
+  const mask = masked ? buffer.subarray(offset, offset + 4) : undefined;
+  if (masked) offset += 4;
+  if (buffer.byteLength < offset + length) return undefined;
+  const payload = Buffer.from(buffer.subarray(offset, offset + length));
+  if (mask !== undefined) {
+    if (mask.byteLength < 4) return undefined;
+    for (let index = 0; index < payload.byteLength; index += 1) payload[index] = payload[index]! ^ mask[index & 3]!;
+  }
+  return { fin, opcode, payload, consumed: offset + length };
+}

--- a/packages/brain-sdk/src/client.ts
+++ b/packages/brain-sdk/src/client.ts
@@ -176,6 +176,7 @@ function compileSession(options: CreateSessionOptions, agentloopIdentity: string
       ...(bound.definition.outputSchema === undefined ? {} : { output_schema: structuredClone(bound.definition.outputSchema) }),
       requires: [...bound.requires],
       binding_names: [...bound.bindingNames],
+      ...(bound.hosting === undefined ? {} : { hosting: bound.hosting }),
       environment_id: environmentId,
     });
   }

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { createCallbackRouter, refuseUpgrade, resolveCallbackRoute, type CallbackRoute, type CallbackRouter } from "./callbacks.js";
 import type { BoundTool, Agentloop, CapabilityName, Environment, ModelMessage, ModelResponse, Schema, SchemaInput, SchemaOutput, Tool, ToolDefinition, UserInput } from "./types.js";
 
 const capabilityNames: readonly CapabilityName[] = ["exec", "fs", "net", "js", "page"];
@@ -116,6 +117,13 @@ export interface EnvironmentInstanceAuthor<Instance> {
 export interface EnvironmentAuthor<Options> {
   readonly options: Options;
   open<Instance>(handler: (context: { readonly options: Options; readonly id: string; readonly signal: AbortSignal; readonly requestId: string }) => Instance | Promise<Instance>): EnvironmentInstanceAuthor<Instance>;
+  readonly route: {
+    /** Route callback-hosted tool invocations to the author's app. Without a resolver
+     * the environment terminates the app's outbound WebSocket channel and expects a
+     * `channelToken` string option; a resolver can pick channel or signed-POST mode
+     * from the environment's own options instead. */
+    callbacks(resolve?: (context: { readonly options: Options }) => CallbackRoute): void;
+  };
 }
 type PublicEnvironmentMembers<Members extends Record<string, EnvironmentMember>> = {
   [Name in keyof Members]: Members[Name] extends EnvironmentMethod<infer Input, infer Output>
@@ -134,11 +142,11 @@ interface EnvironmentRegistration {
   readonly cancel?: (context: unknown) => void | Promise<void>;
   readonly detach?: (context: unknown) => void | Promise<void>;
 }
-type EnvironmentSource = { readonly kind: "environment"; readonly options?: Schema; readonly setup: EnvironmentSetup<unknown, Record<string, EnvironmentMember>>; name?: string; runtimeName?: string; readonly members: Readonly<Record<string, EnvironmentMember>>; readonly registration: EnvironmentRegistration };
+type EnvironmentSource = { readonly kind: "environment"; readonly options?: Schema; readonly setup: EnvironmentSetup<unknown, Record<string, EnvironmentMember>>; name?: string; runtimeName?: string; readonly members: Readonly<Record<string, EnvironmentMember>>; readonly registration: EnvironmentRegistration; readonly callbacks?: (context: { readonly options: unknown }) => CallbackRoute };
 type ExtensionFactory = Function & { [extensionSource]?: AgentloopSource | ToolSource | EnvironmentSource };
 
 const agentloops = new WeakMap<object, { readonly artifact: URL | Uint8Array; readonly configuration: unknown }>();
-const tools = new WeakMap<object, { readonly definition: ToolDefinition; readonly implementationName: string; readonly configuration: unknown; readonly requires: readonly CapabilityName[]; readonly bindingNames: readonly string[] }>();
+const tools = new WeakMap<object, { readonly definition: ToolDefinition; readonly implementationName: string; readonly configuration: unknown; readonly requires: readonly CapabilityName[]; readonly bindingNames: readonly string[]; readonly hosting?: "callback" }>();
 const environments = new WeakMap<object, EnvironmentRuntime>();
 const bindings = new WeakMap<object, { readonly tool: Tool; readonly environment: Environment }>();
 const initializedTools = new WeakMap<ToolSource, Promise<void>>();
@@ -202,6 +210,36 @@ export function tool<OptionsSchema extends Schema | undefined, InputSchema exten
   return factory as never;
 }
 
+/**
+ * Declare a callback-hosted tool for session composition: the model sees an ordinary
+ * tool, but the implementation stays in the author's app — the bound environment
+ * routes each invocation there (see `appTools` and `route.callbacks`). The manifest
+ * carries `hosting: "callback"`, no payload, empty `requires`, so it binds anywhere.
+ */
+export function appTool<InputSchema extends Schema, OutputSchema extends Schema | undefined = undefined>(contract: {
+  readonly name: string;
+  readonly description: string;
+  readonly input: InputSchema;
+  readonly output?: OutputSchema;
+}): Tool<SchemaOutput<InputSchema>, OutputSchema extends Schema ? SchemaOutput<OutputSchema> : unknown> {
+  if (!validIdentifier(contract?.name)) throw new TypeError("appTool needs an identifier-shaped name");
+  if (typeof contract.description !== "string" || contract.description.length === 0 || contract.description.length > 8_192) throw new TypeError("appTool description exceeds its contract bound");
+  const definition: ToolDefinition = Object.freeze({
+    name: contract.name,
+    description: contract.description,
+    inputSchema: Object.freeze(z.toJSONSchema(contract.input) as Record<string, unknown>),
+    ...(contract.output === undefined ? {} : { outputSchema: Object.freeze(z.toJSONSchema(contract.output) as Record<string, unknown>) }),
+  });
+  const instance = { useIn(environment: Environment): BoundTool {
+    if (!environments.has(environment)) throw new TypeError("useIn requires an Environment extension");
+    const bound = Object.freeze({});
+    bindings.set(bound, { tool: instance as Tool, environment });
+    return bound as BoundTool;
+  } } as Tool;
+  tools.set(instance, { definition, implementationName: contract.name, configuration: Object.freeze({}), requires: Object.freeze([]), bindingNames: Object.freeze([]), hosting: "callback" });
+  return Object.freeze(instance) as never;
+}
+
 function collectTool(setup: ToolSetup<unknown, unknown, unknown>): Pick<ToolSource, "initialize" | "run"> {
   let initialize: ToolSource["initialize"];
   let run: ToolSource["run"] | undefined;
@@ -246,12 +284,27 @@ export async function executeTool(factory: unknown, options: unknown, input: unk
   return source.contract.output === undefined ? result : source.contract.output.parse(result);
 }
 
-export function createEnvironmentHandler(factory: unknown): (command: unknown) => Promise<unknown> {
+/** The channel side of a generated environment handler: mount it on the host HTTP
+ * server's `upgrade` event so apps can hold their callback channel to it. */
+export interface EnvironmentChannel {
+  upgrade(request: import("node:http").IncomingMessage, socket: import("node:stream").Duplex, head?: Uint8Array): void;
+}
+export type EnvironmentHandler = ((command: unknown) => Promise<unknown>) & { readonly channel: EnvironmentChannel };
+
+interface EnvironmentInstanceState {
+  readonly value: unknown;
+  readonly options: unknown;
+  readonly attachments: Map<string, string>;
+  readonly provisioned: Set<string>;
+  readonly router?: CallbackRouter;
+}
+
+export function createEnvironmentHandler(factory: unknown): EnvironmentHandler {
   const source = sourceOf(factory as ExtensionFactory, "environment") as EnvironmentSource;
-  const instances = new Map<string, { readonly value: unknown; readonly options: unknown; readonly attachments: Map<string, string> }>();
+  const instances = new Map<string, EnvironmentInstanceState>();
   const receipts = new Map<string, { readonly identity: string; readonly response: unknown }>();
   const active = new Map<string, AbortController>();
-  return async (raw: unknown) => {
+  const handler = async (raw: unknown) => {
     const command = environmentCommand(raw);
     const operation = command.operation;
     const prior = receipts.get(operation.operation_id);
@@ -272,7 +325,8 @@ export function createEnvironmentHandler(factory: unknown): (command: unknown) =
           let instance = instances.get(operation.environment_id);
           if (instance === undefined) {
             const value = await source.registration.open({ ...context, id: operation.environment_id, options });
-            instance = { value, options, attachments: new Map() };
+            const router = source.callbacks === undefined ? undefined : createCallbackRouter(resolveCallbackRoute(source.callbacks({ options })));
+            instance = { value, options, attachments: new Map(), provisioned: new Set(), ...(router === undefined ? {} : { router }) };
             instances.set(operation.environment_id, instance);
           }
           receipt = { type: "accepted" };
@@ -282,6 +336,11 @@ export function createEnvironmentHandler(factory: unknown): (command: unknown) =
           const instance = requiredEnvironmentInstance(instances, operation.environment_id);
           if (operation.attachment_id === undefined) throw new TypeError("attach requires an attachment identity");
           if (!plainObject(operation.request.grants) || !Array.isArray(operation.request.provisions) || !plainObject(operation.request.bindings)) throw new TypeError("attach requires grants, provisions, and bindings");
+          // Only provisioned tools arrive as provisions; anything else invoked here is
+          // callback-hosted and belongs to the router, when one is registered.
+          for (const provision of operation.request.provisions) {
+            if (plainObject(provision) && plainObject(provision.manifest) && typeof provision.manifest.name === "string") instance.provisioned.add(provision.manifest.name);
+          }
           instance.attachments.set(operation.attachment_id, operation.session_id);
           await source.registration.attach?.({ ...context, instance: instance.value, sessionId: operation.session_id });
           // Generated environments implement no capability providers yet, so they
@@ -292,6 +351,16 @@ export function createEnvironmentHandler(factory: unknown): (command: unknown) =
         case "invoke": {
           const instance = authorizedEnvironmentInstance(instances, operation);
           if (typeof operation.request.call_id !== "string" || typeof operation.request.tool !== "string") throw new TypeError("Environment Tool invocation is invalid");
+          if (instance.router !== undefined && !instance.provisioned.has(operation.request.tool)) {
+            const deadline = operation.request.deadline_ms;
+            if (typeof deadline !== "number" || !Number.isInteger(deadline) || deadline < 1) throw new TypeError("Environment Tool invocation needs a deadline");
+            const outcome = await instance.router.invoke(
+              { call_id: operation.request.call_id, name: operation.request.tool, arguments: operation.request.input, deadline_ms: deadline },
+              controller.signal,
+            );
+            receipt = { type: "outcome", outcome };
+            break;
+          }
           // A tool that ran and failed is an in-band error outcome; the outer catch
           // stays for operations that never reached the tool.
           try {
@@ -337,6 +406,7 @@ export function createEnvironmentHandler(factory: unknown): (command: unknown) =
         case "teardown": {
           const instance = requiredEnvironmentInstance(instances, operation.environment_id);
           if (instance.attachments.size > 0) throw new Error("cannot close an Environment with active attachments");
+          instance.router?.close();
           await source.registration.close({ ...context, instance: instance.value });
           instances.delete(operation.environment_id);
           receipt = { type: "accepted" };
@@ -353,6 +423,15 @@ export function createEnvironmentHandler(factory: unknown): (command: unknown) =
     receipts.set(operation.operation_id, { identity: operation.request_identity, response });
     return response;
   };
+  const channel: EnvironmentChannel = {
+    upgrade(request, socket, head = new Uint8Array(0)) {
+      const pathname = new URL(request.url ?? "/", "http://environment").pathname;
+      const candidates = [...instances.entries()].filter(([, instance]) => instance.router !== undefined);
+      const match = candidates.find(([id]) => pathname.endsWith(`/environments/${id}/channel`)) ?? (candidates.length === 1 ? candidates[0] : undefined);
+      if (match === undefined || match[1].router?.upgrade(request, socket, head) !== true) refuseUpgrade(socket, 404, "no callback channel here");
+    },
+  };
+  return Object.assign(handler, { channel });
 }
 
 interface RuntimeEnvironmentOperation {
@@ -372,13 +451,13 @@ function environmentCommand(raw: unknown): { readonly operation: RuntimeEnvironm
   return { operation: operation as unknown as RuntimeEnvironmentOperation };
 }
 
-function requiredEnvironmentInstance(instances: Map<string, { readonly value: unknown; readonly options: unknown; readonly attachments: Map<string, string> }>, id: string) {
+function requiredEnvironmentInstance(instances: Map<string, EnvironmentInstanceState>, id: string) {
   const instance = instances.get(id);
   if (instance === undefined) throw new Error(`Environment ${id} is not open`);
   return instance;
 }
 
-function authorizedEnvironmentInstance(instances: Map<string, { readonly value: unknown; readonly options: unknown; readonly attachments: Map<string, string> }>, operation: RuntimeEnvironmentOperation) {
+function authorizedEnvironmentInstance(instances: Map<string, EnvironmentInstanceState>, operation: RuntimeEnvironmentOperation) {
   const instance = requiredEnvironmentInstance(instances, operation.environment_id);
   if (operation.attachment_id === undefined || instance.attachments.get(operation.attachment_id) !== operation.session_id) throw new Error("Environment attachment does not authorize this session");
   return instance;
@@ -431,19 +510,30 @@ export function environment<OptionsSchema extends Schema, Members extends Record
     environments.set(instance, runtime);
     return Object.freeze(instance);
   }) as ExtensionFactory;
-  defineSource(factory, { kind: "environment", ...(optionsSchema === undefined ? {} : { options: optionsSchema }), setup: setup as EnvironmentSetup<unknown, Record<string, EnvironmentMember>>, members, registration: collected.registration });
+  defineSource(factory, { kind: "environment", ...(optionsSchema === undefined ? {} : { options: optionsSchema }), setup: setup as EnvironmentSetup<unknown, Record<string, EnvironmentMember>>, members, registration: collected.registration, ...(collected.callbacks === undefined ? {} : { callbacks: collected.callbacks }) });
   return factory as never;
 }
 
-function collectEnvironment(setup: EnvironmentSetup<unknown, Record<string, EnvironmentMember>>): { readonly members: Readonly<Record<string, EnvironmentMember>>; readonly registration: EnvironmentRegistration } {
+function collectEnvironment(setup: EnvironmentSetup<unknown, Record<string, EnvironmentMember>>): { readonly members: Readonly<Record<string, EnvironmentMember>>; readonly registration: EnvironmentRegistration; readonly callbacks?: (context: { readonly options: unknown }) => CallbackRoute } {
   let open: EnvironmentRegistration["open"] | undefined;
   let run: EnvironmentRegistration["run"] | undefined;
   let close: EnvironmentRegistration["close"] | undefined;
   let attach: EnvironmentRegistration["attach"];
   let cancel: EnvironmentRegistration["cancel"];
   let detach: EnvironmentRegistration["detach"];
+  let callbacks: ((context: { readonly options: unknown }) => CallbackRoute) | undefined;
   const author: EnvironmentAuthor<unknown> = {
     options: Object.freeze({}),
+    route: {
+      callbacks(resolve) {
+        if (callbacks !== undefined) throw new TypeError("environment may register route.callbacks only once");
+        callbacks = resolve ?? (({ options }) => {
+          const token = plainObject(options) ? options.channelToken : undefined;
+          if (typeof token !== "string" || token.length === 0) throw new TypeError("route.callbacks() without a resolver needs a channelToken string option");
+          return { mode: "channel", token };
+        });
+      },
+    },
     open<Instance>(handler: (context: { readonly options: unknown; readonly id: string; readonly signal: AbortSignal; readonly requestId: string }) => Instance | Promise<Instance>) {
       if (open !== undefined) throw new TypeError("environment may register open only once");
       open = handler as EnvironmentRegistration["open"];
@@ -474,7 +564,7 @@ function collectEnvironment(setup: EnvironmentSetup<unknown, Record<string, Envi
   for (const [name, member] of Object.entries(members)) {
     if (!validIdentifier(name) || !plainObject(member) || (member.kind !== "method" && member.kind !== "stream")) throw new TypeError(`Environment member ${name} must be created with method or stream`);
   }
-  return { members: Object.freeze({ ...members }), registration: { open, run, close, ...(attach === undefined ? {} : { attach }), ...(cancel === undefined ? {} : { cancel }), ...(detach === undefined ? {} : { detach }) } };
+  return { members: Object.freeze({ ...members }), registration: { open, run, close, ...(attach === undefined ? {} : { attach }), ...(cancel === undefined ? {} : { cancel }), ...(detach === undefined ? {} : { detach }) }, ...(callbacks === undefined ? {} : { callbacks }) };
 }
 
 export function installExtensionIdentity(factory: unknown, name: string, artifact?: URL | Uint8Array, runtimeName?: string): void {
@@ -496,7 +586,7 @@ export function inspectAgentloop(value: Agentloop): { readonly artifact: URL | U
   return metadata;
 }
 
-export function inspectBoundTool(value: BoundTool): { readonly definition: ToolDefinition; readonly implementationName: string; readonly configuration: unknown; readonly requires: readonly CapabilityName[]; readonly bindingNames: readonly string[]; readonly environment: Environment } {
+export function inspectBoundTool(value: BoundTool): { readonly definition: ToolDefinition; readonly implementationName: string; readonly configuration: unknown; readonly requires: readonly CapabilityName[]; readonly bindingNames: readonly string[]; readonly hosting?: "callback"; readonly environment: Environment } {
   const binding = bindings.get(value);
   const metadata = binding === undefined ? undefined : tools.get(binding.tool);
   if (binding === undefined || metadata === undefined) throw new TypeError("tools must be configured with useIn");

--- a/packages/brain-sdk/src/index.ts
+++ b/packages/brain-sdk/src/index.ts
@@ -1,12 +1,14 @@
 export { BrainClient as Brain, BrainClient, SessionHandle, Sessions } from "./client.js";
 export type { BrainOptions } from "./client.js";
-export { activateAgentloop, agentloop, createEnvironmentHandler, environment, executeTool, installExtensionIdentity, tool } from "./extensions.js";
+export { activateAgentloop, agentloop, appTool, createEnvironmentHandler, environment, executeTool, installExtensionIdentity, tool } from "./extensions.js";
 export type {
   AgentloopAction,
   AgentloopAuthor,
   AgentloopInput,
   AgentloopTurn,
   EnvironmentAuthor,
+  EnvironmentChannel,
+  EnvironmentHandler,
   EnvironmentInstanceAuthor,
   EnvironmentMethod,
   EnvironmentStream,
@@ -15,6 +17,10 @@ export type {
   ToolCall,
   ToolContract,
 } from "./extensions.js";
+export { appTools } from "./app.js";
+export type { AppToolCall, AppToolChannel, AppToolContract, AppToolServer, AppTools, CallbackToolManifest } from "./app.js";
+export type { CallbackRoute } from "./callbacks.js";
+export type { Outcome } from "./callback-wire.js";
 export { BrainError } from "./errors.js";
 export type {
   Agentloop,

--- a/packages/brain-sdk/test/app.test.mjs
+++ b/packages/brain-sdk/test/app.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import test from "node:test";
+
+import { z } from "zod";
+import { Brain, appTool, appTools, environment, installExtensionIdentity } from "../dist/index.js";
+
+const signingKey = "app-secret";
+const sign = (body) => createHmac("sha256", signingKey).update(body).digest("hex");
+const post = (handler, frame, options = {}) => {
+  const body = typeof frame === "string" ? frame : JSON.stringify(frame);
+  const headers = { "content-type": "application/json" };
+  if (options.signature !== null) headers["x-brain-signature"] = options.signature ?? sign(body);
+  return handler(new Request("https://app.example/tools", { method: "POST", body, headers }));
+};
+
+function invoiceTools() {
+  return appTools({ signingKey }).register({
+    name: "create_invoice",
+    description: "Create an invoice in this app.",
+    input: z.object({ customer_id: z.string(), amount_cents: z.number().int() }),
+    output: z.object({ invoice_id: z.string() }),
+  }, async ({ customer_id }) => ({ invoice_id: `inv_${customer_id}` }));
+}
+
+test("answers a signed invocation with an ok outcome", async () => {
+  const handler = invoiceTools().fetchHandler();
+  const response = await post(handler, { call_id: "call_1", name: "create_invoice", arguments: { customer_id: "c9", amount_cents: 100 }, deadline_ms: 5_000 });
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { status: "ok", value: { invoice_id: "inv_c9" } });
+});
+
+test("refuses unsigned and garbage requests without invoking anything", async () => {
+  let invoked = false;
+  const handler = appTools({ signingKey }).register(
+    { name: "observe", description: "Record that the handler ran.", input: z.object({}) },
+    () => { invoked = true; return null; },
+  ).fetchHandler();
+  const frame = { call_id: "call_1", name: "observe", arguments: {}, deadline_ms: 5_000 };
+  assert.equal((await post(handler, frame, { signature: null })).status, 401);
+  assert.equal((await post(handler, frame, { signature: "f".repeat(64) })).status, 401);
+  assert.equal((await post(handler, frame, { signature: "not-hex" })).status, 401);
+  assert.equal((await post(handler, "not json")).status, 400);
+  assert.equal((await post(handler, { call_id: "call_1" })).status, 400);
+  assert.equal((await handler(new Request("https://app.example/tools", { method: "GET" }))).status, 405);
+  assert.equal(invoked, false);
+});
+
+test("maps schema violations and thrown errors into error outcomes", async () => {
+  const handler = appTools({ signingKey })
+    .register({ name: "typed", description: "Validate input.", input: z.object({ count: z.number() }), output: z.object({ doubled: z.number() }) }, ({ count }) => ({ doubled: count * 2 }))
+    .register({ name: "broken", description: "Always throws.", input: z.object({}) }, () => { throw new Error("kaboom"); })
+    .register({ name: "malformed", description: "Breaks its output contract.", input: z.object({}), output: z.object({ ok: z.boolean() }) }, () => ({ ok: "yes" }))
+    .fetchHandler();
+  const outcomeOf = async (name, args) => (await post(handler, { call_id: "call_1", name, arguments: args, deadline_ms: 5_000 })).json();
+  assert.equal((await outcomeOf("typed", { count: "three" })).error.code, "invalid_input");
+  const broken = await outcomeOf("broken", {});
+  assert.equal(broken.error.code, "tool_error");
+  assert.match(broken.error.message, /kaboom/u);
+  assert.equal((await outcomeOf("malformed", {})).error.code, "invalid_output");
+  assert.equal((await outcomeOf("missing", {})).error.code, "unknown_tool");
+});
+
+test("honors the deadline and best-effort cancel", async () => {
+  const handler = appTools({ signingKey }).register(
+    { name: "wait", description: "Wait for the signal.", input: z.object({}) },
+    (_input, call) => new Promise(() => { void call; }),
+  ).fetchHandler();
+  const timedOut = await (await post(handler, { call_id: "slow_1", name: "wait", arguments: {}, deadline_ms: 50 })).json();
+  assert.deepEqual(timedOut, { status: "timeout" });
+  const pending = post(handler, { call_id: "slow_2", name: "wait", arguments: {}, deadline_ms: 60_000 });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal((await post(handler, { cancel: "slow_2" })).status, 200);
+  assert.deepEqual(await (await pending).json(), { status: "cancelled" });
+});
+
+test("publishes callback manifests with no payload and no requirements", () => {
+  const manifests = invoiceTools().manifests();
+  assert.equal(manifests.length, 1);
+  const manifest = manifests[0];
+  assert.equal(manifest.name, "create_invoice");
+  assert.equal(manifest.hosting, "callback");
+  assert.deepEqual(manifest.requires, []);
+  assert.deepEqual(manifest.binding_names, []);
+  assert.equal("payload" in manifest, false);
+  assert.equal(manifest.input_schema.type, "object");
+  assert.equal(manifest.output_schema.type, "object");
+});
+
+test("rejects a missing signing key and duplicate registrations", () => {
+  assert.throws(() => appTools({ signingKey: undefined }), /signingKey/u);
+  assert.throws(() => appTools({ signingKey }).register({ name: "twin", description: "d", input: z.object({}) }, () => null).register({ name: "twin", description: "d", input: z.object({}) }, () => null), /already registered/u);
+});
+
+test("composes appTool bindings into a callback-shaped create request", async () => {
+  const app = environment((author) => {
+    const instance = author.open(async () => ({}));
+    instance.run(async () => undefined);
+    instance.close(async () => undefined);
+    author.route.callbacks();
+    return {};
+  });
+  installExtensionIdentity(app, "app");
+  const requests = [];
+  const client = new Brain({
+    baseUrl: "https://brain.example",
+    fetch: async (input, init) => {
+      const request = new Request(input, init);
+      requests.push(request);
+      if (request.url.endsWith("/v1/agentloops")) return Response.json({ identity: "a".repeat(64), status: "admitted" });
+      return Response.json({ session_id: "ses_12345678901234567890", journal_id: "jrn_test", status: "idle", last_sequence: 1, config_hash: "b".repeat(64) });
+    },
+  });
+  const { agentloop } = await import("../dist/index.js");
+  const loop = agentloop((author) => { author.on.message((_message, turn) => turn.done()); });
+  installExtensionIdentity(loop, "loop", new Uint8Array([1]));
+  await client.sessions.create({
+    model: { provider: "anthropic", name: "claude-sonnet-4-5", apiKey: "k" },
+    agentloop: loop(),
+    tools: [appTool({ name: "create_invoice", description: "Create an invoice.", input: z.object({ customer_id: z.string() }) }).useIn(app())],
+  });
+  const body = await requests[1].json();
+  assert.equal(body.tools.length, 1);
+  const tool = body.tools[0];
+  assert.equal(tool.name, "create_invoice");
+  assert.equal(tool.hosting, "callback");
+  assert.deepEqual(tool.requires, []);
+  assert.deepEqual(tool.binding_names, []);
+  assert.equal("payload" in tool, false);
+  assert.equal(tool.environment_id, "env_1");
+});

--- a/packages/brain-sdk/test/callbacks.test.mjs
+++ b/packages/brain-sdk/test/callbacks.test.mjs
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import { z } from "zod";
+import { appTools, createEnvironmentHandler, environment, installExtensionIdentity } from "../dist/index.js";
+
+const channelToken = "sesame";
+
+function makeChannelEnvironment(name) {
+  const definition = environment({ options: z.object({ channelToken: z.string() }) }, (author) => {
+    const instance = author.open(async () => ({}));
+    instance.run(async () => "provisioned ran");
+    instance.close(async () => undefined);
+    author.route.callbacks();
+    return {};
+  });
+  installExtensionIdentity(definition, name, undefined, name);
+  return definition;
+}
+
+const command = (id, request, attachmentId) => ({
+  contract: "environment/v2",
+  binding: {},
+  operation: {
+    operation_id: id,
+    request_identity: id.padEnd(64, "a"),
+    environment_id: "env_1",
+    session_id: "ses_test",
+    ...(attachmentId === undefined ? {} : { attachment_id: attachmentId }),
+    request,
+  },
+});
+
+async function openEnvironment(handle, configuration) {
+  assert.equal((await handle(command("setup", { type: "setup", configuration }))).receipt.type, "accepted");
+  const attached = await handle(command("attach", { type: "attach", grants: {}, provisions: [], bindings: {} }, "att_1"));
+  assert.equal(attached.receipt.type, "accepted");
+  assert.deepEqual(attached.receipt.provides, []);
+}
+
+function listen(handle) {
+  const server = createServer((request, response) => {
+    response.statusCode = 426;
+    response.end();
+  });
+  const sockets = new Set();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  server.on("upgrade", (request, socket, head) => handle.channel.upgrade(request, socket, head));
+  return new Promise((resolve) => server.listen(0, "127.0.0.1", () => resolve({ server, sockets, port: server.address().port })));
+}
+
+const outcomeOf = async (handle, id, tool, input, deadlineMs) => {
+  const response = await handle(command(id, { type: "invoke", call_id: id, tool, input, deadline_ms: deadlineMs }, "att_1"));
+  assert.equal(response.receipt.type, "outcome");
+  return response.receipt.outcome;
+};
+
+const until = async (probe) => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const value = await probe();
+    if (value !== undefined) return value;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.fail("condition never held");
+};
+
+test("routes invocations down the app's channel and back", async () => {
+  const handle = createEnvironmentHandler(makeChannelEnvironment("chanRoundtrip"));
+  const { server, port } = await listen(handle);
+  await openEnvironment(handle, { driver: "chanRoundtrip", channelToken });
+  let cancelSeen = false;
+  let hangStarted = false;
+  const app = appTools.connect({ url: `ws://127.0.0.1:${port}/environments/env_1/channel`, token: channelToken })
+    .register({ name: "highlight_row", description: "Highlight a row.", input: z.object({ row: z.number().int() }) }, ({ row }) => ({ highlighted: row }))
+    .register({ name: "hang", description: "Wait until cancelled.", input: z.object({}) }, (_input, call) => {
+      hangStarted = true;
+      return new Promise((resolve) => call.signal.addEventListener("abort", () => { cancelSeen = true; resolve(null); }, { once: true }));
+    });
+  try {
+    await app.ready();
+
+    // Invoke → result.
+    assert.deepEqual(await outcomeOf(handle, "inv_ok", "highlight_row", { row: 7 }, 5_000), { status: "ok", value: { highlighted: 7 } });
+
+    // Schema violations stay in-band.
+    const invalid = await outcomeOf(handle, "inv_bad", "highlight_row", { row: "seven" }, 5_000);
+    assert.equal(invalid.status, "error");
+    assert.equal(invalid.error.code, "invalid_input");
+
+    // Deadline → timeout outcome, and the cancel reaches the app.
+    assert.deepEqual(await outcomeOf(handle, "inv_slow", "hang", {}, 200), { status: "timeout" });
+    await until(() => (cancelSeen ? true : undefined));
+
+    // Brain-side cancel → cancelled outcome.
+    cancelSeen = false;
+    hangStarted = false;
+    const pending = outcomeOf(handle, "inv_cancel", "hang", {}, 60_000);
+    await until(() => (hangStarted ? true : undefined));
+    await handle(command("cancel_1", { type: "cancel", target_operation_id: "inv_cancel" }, "att_1"));
+    assert.deepEqual(await pending, { status: "cancelled" });
+    await until(() => (cancelSeen ? true : undefined));
+  } finally {
+    app.close();
+    server.close();
+  }
+});
+
+test("fails fast while the app is disconnected and recovers when it reconnects", async () => {
+  const handle = createEnvironmentHandler(makeChannelEnvironment("chanReconnect"));
+  const { server, sockets, port } = await listen(handle);
+  await openEnvironment(handle, { driver: "chanReconnect", channelToken });
+
+  // No app yet: a typed error, not a hang.
+  const unrouted = await outcomeOf(handle, "inv_none", "echo", {}, 1_000);
+  assert.equal(unrouted.status, "error");
+  assert.equal(unrouted.error.code, "app_disconnected");
+
+  const app = appTools.connect({ url: `ws://127.0.0.1:${port}/environments/env_1/channel`, token: channelToken })
+    .register({ name: "echo", description: "Echo.", input: z.object({}) }, () => "here");
+  try {
+    await app.ready();
+    assert.deepEqual(await outcomeOf(handle, "inv_first", "echo", {}, 5_000), { status: "ok", value: "here" });
+
+    // Drop the transport out from under the app; it reconnects with backoff.
+    let sequence = 0;
+    for (const socket of sockets) socket.destroy();
+    const recovered = await until(async () => {
+      const outcome = await outcomeOf(handle, `inv_retry_${sequence += 1}`, "echo", {}, 1_000);
+      return outcome.status === "ok" ? outcome : undefined;
+    });
+    assert.deepEqual(recovered, { status: "ok", value: "here" });
+
+    // A deliberate close is terminal: calls fail app-disconnected again.
+    app.close();
+    const closed = await until(async () => {
+      const outcome = await outcomeOf(handle, `inv_gone_${sequence += 1}`, "echo", {}, 1_000);
+      return outcome.status === "error" ? outcome : undefined;
+    });
+    assert.equal(closed.error.code, "app_disconnected");
+  } finally {
+    app.close();
+    server.close();
+  }
+});
+
+test("refuses a channel upgrade with a bad token", async () => {
+  const handle = createEnvironmentHandler(makeChannelEnvironment("chanAuth"));
+  const { server, port } = await listen(handle);
+  await openEnvironment(handle, { driver: "chanAuth", channelToken });
+  try {
+    const socket = new WebSocket(`ws://127.0.0.1:${port}/environments/env_1/channel?token=wrong`);
+    const outcome = await new Promise((resolve) => {
+      socket.addEventListener("open", () => resolve("open"));
+      socket.addEventListener("error", () => resolve("refused"));
+    });
+    assert.equal(outcome, "refused");
+  } finally {
+    server.close();
+  }
+});
+
+test("routes invocations to a backend app over signed POSTs", async () => {
+  const signingKey = "post-secret";
+  const app = appTools({ signingKey })
+    .register({ name: "create_invoice", description: "Create an invoice.", input: z.object({ customer_id: z.string() }) }, ({ customer_id }) => ({ invoice_id: `inv_${customer_id}` }))
+    .register({ name: "hang", description: "Wait forever.", input: z.object({}) }, () => new Promise(() => {}));
+  const fetchHandler = app.fetchHandler();
+  const appServer = createServer(async (request, response) => {
+    let body = "";
+    for await (const chunk of request) body += chunk;
+    const answered = await fetchHandler(new Request(`http://app.local${request.url}`, { method: request.method, headers: { "x-brain-signature": request.headers["x-brain-signature"] ?? "" }, body }));
+    response.statusCode = answered.status;
+    response.setHeader("content-type", "application/json");
+    response.end(await answered.text());
+  });
+  const port = await new Promise((resolve) => appServer.listen(0, "127.0.0.1", () => resolve(appServer.address().port)));
+
+  const definition = environment({ options: z.object({ url: z.string(), key: z.string() }) }, (author) => {
+    const instance = author.open(async () => ({}));
+    instance.run(async () => undefined);
+    instance.close(async () => undefined);
+    author.route.callbacks(({ options }) => ({ mode: "post", url: options.url, signingKey: options.key }));
+    return {};
+  });
+  installExtensionIdentity(definition, "postEnv", undefined, "postEnv");
+  const handle = createEnvironmentHandler(definition);
+  await openEnvironment(handle, { driver: "postEnv", url: `http://127.0.0.1:${port}/tools`, key: signingKey });
+  try {
+    assert.deepEqual(await outcomeOf(handle, "inv_ok", "create_invoice", { customer_id: "c1" }, 5_000), { status: "ok", value: { invoice_id: "inv_c1" } });
+    assert.deepEqual(await outcomeOf(handle, "inv_slow", "hang", {}, 200), { status: "timeout" });
+  } finally {
+    appServer.close();
+  }
+
+  // An unreachable app is a typed error, not a hang.
+  const unreachable = environment({ options: z.object({ url: z.string(), key: z.string() }) }, (author) => {
+    const instance = author.open(async () => ({}));
+    instance.run(async () => undefined);
+    instance.close(async () => undefined);
+    author.route.callbacks(({ options }) => ({ mode: "post", url: options.url, signingKey: options.key }));
+    return {};
+  });
+  installExtensionIdentity(unreachable, "postGone", undefined, "postGone");
+  const gone = createEnvironmentHandler(unreachable);
+  await openEnvironment(gone, { driver: "postGone", url: `http://127.0.0.1:${port}/tools`, key: signingKey });
+  const outcome = await outcomeOf(gone, "inv_gone", "create_invoice", { customer_id: "c2" }, 2_000);
+  assert.equal(outcome.status, "error");
+  assert.equal(outcome.error.code, "app_unreachable");
+});
+
+test("keeps provisioned invocations on the environment's own run handler", async () => {
+  const handle = createEnvironmentHandler(makeChannelEnvironment("chanMixed"));
+  assert.equal((await handle(command("setup", { type: "setup", configuration: { driver: "chanMixed", channelToken } }))).receipt.type, "accepted");
+  const provision = { manifest: { name: "local_tool", description: "Provisioned here.", input_schema: {}, requires: [], binding_names: [], hosting: "provisioned", payload: { kind: "esm", identity: "c".repeat(64) } }, payload_identity: "c".repeat(64) };
+  assert.equal((await handle(command("attach", { type: "attach", grants: {}, provisions: [provision], bindings: {} }, "att_1"))).receipt.type, "accepted");
+  const provisioned = await outcomeOf(handle, "inv_local", "local_tool", {}, 1_000);
+  assert.deepEqual(provisioned, { status: "ok", value: "provisioned ran" });
+  const routed = await outcomeOf(handle, "inv_remote", "remote_tool", {}, 1_000);
+  assert.equal(routed.error.code, "app_disconnected");
+});


### PR DESCRIPTION
Implements the callback third of the capability contract (#119): tools whose implementation stays in the author's app, invoked through the bound environment with the same `invoke → Outcome` envelope as provisioned tools. MCP data shapes over plain HTTP, no JSON-RPC framing: `{call_id, name, arguments, deadline_ms}` per call, the shared Outcome back, best-effort `{cancel: call_id}` down the same channel.

## App side — `appTools` (new `src/app.ts`)

One `register({name, description, input, output?}, fn)` shape in both transport directions:

- **Backend (`appTools({signingKey})`)**: `.fetchHandler()` returns a WHATWG fetch handler. HMAC-SHA256 over the raw body (`x-brain-signature`) is verified before anything else — unsigned/tampered → 401, malformed → 400, and the tool function is never reached. Schema-invalid input, a thrown handler, or a broken output contract are in-band error outcomes; `deadline_ms` is raced app-side too and cancel aborts the in-flight call's `signal`.
- **Browser/outbound (`appTools.connect({url, token})`)**: holds an outbound WebSocket (Node ≥22 / browser built-in client; token in the URL query since the standard client cannot set headers), answers invoke frames with `{call_id, ...outcome}`, honors `{cancel}`, reconnects with backoff (250ms → 10s), and is silent-safe when down.
- `.manifests()` returns the `tool/v1` callback manifests (`hosting: "callback"`, no payload, empty `requires`/`binding_names`) for composition.

## Environment side — `author.route.callbacks()` (new `src/callbacks.ts`)

- Bare `route.callbacks()` terminates the app's outbound WebSocket channel, token-authenticated from the environment's `channelToken` option; the generated handler now exposes `handle.channel.upgrade(request, socket, head)` for the host server's `upgrade` event. The server half of RFC 6455 is ~120 lines in-tree (handshake, masking, continuation, ping/pong, close, 4 MiB bound) — no dependency, not even a dev one: the end-to-end tests run Node's built-in client against it.
- `route.callbacks(({options}) => ({mode: "post", url, signingKey}))` POSTs HMAC-signed invocations to a backend app instead.
- On `invoke`, tools that arrived as attach `provisions` keep the environment's own `run` path; everything else routes to the app. The environment enforces `deadline_ms` itself (timeout outcome + best-effort cancel downstream), maps Brain-side cancellation to a cancelled outcome, and answers a down/unreachable app with typed `app_disconnected` / `app_unreachable` errors — never a hang.
- Attach receipts keep `provides` capability-empty: the contract has no field for callback tool names, and callback tools have empty `requires`, so they bind. **No contract schema changes were needed.**

## Composition — `appTool(...)`

`appTool({name, description, input, output?}).useIn(appEnv)` produces a bindable tool whose wire manifest is callback-shaped (`hosting: "callback"`, no payload); the client now sends `hosting` when set.

## Tests

`fetchHandler` roundtrips (signed ok / 401 / 400 / error outcomes / deadline / cancel), connect-mode end-to-end through the generated environment handler over a real HTTP upgrade (invoke → result, deadline → timeout with cancel observed app-side, Brain-side cancel → cancelled, disconnected → typed error, transport-drop → reconnect → recovery), signed-POST mode end-to-end incl. unreachable app, bad channel token refused, provisioned/callback routing split. All existing SDK and Rust tests untouched and green.

## Docs

New guide `docs/guides/app-tools.mdx` covering both directions and `route.callbacks()`; `docs/concepts/tool.mdx` gains the two-hostings section.