### PR TITLE
sdk: author provisioned tools against typed capabilities

### DIFF
--- a/docs/concepts/environment.mdx
+++ b/docs/concepts/environment.mdx
@@ -27,6 +27,13 @@ The setup and attach receipts report `provides: [...]`, and Brain checks every b
 create-time rejection naming the capability, the tool, and the environment, not a runtime
 mystery. Growth of the set is a contract release, not an author convention.
 
+An environment authored with the SDK registers providers with `provide.exec(...)`,
+`provide.fs(...)`, and so on; the registered set is exactly what its receipts report. It
+can also host provisioned tools with `host.esm()` — the SDK owns the host runtime, wiring
+each hosted tool's handles to the environment's own providers in-process, so a capability
+call from a hosted tool never crosses a wire. See
+[Write an environment](/brain/docs/guides/write-an-environment).
+
 ## Attach carries the typed policy
 
 `attach` carries three typed fields, replacing the untyped grant and adapter blobs of v1:

--- a/docs/concepts/tool.mdx
+++ b/docs/concepts/tool.mdx
@@ -32,12 +32,30 @@ export const bash = tool({
   input: z.object({ command: z.string() }),
   requires: ["exec"],
   bindings: { API_BASE: z.string() },
-}, (author) => { /* ... */ });
+}, (author) => {
+  author.run(async (input, context) => {
+    // context.exec is typed from `requires`; context.fs would not compile.
+    return context.exec.run(input.command);
+  });
+});
 ```
+
+The declaration is checked at both ends: the run context type is derived from `requires`,
+so using an undeclared capability does not type-check, and `brain build` warns when a
+declared capability's handle never appears in the authored code. See
+[Write a tool](/brain/docs/guides/write-a-tool).
 
 Binding *values* never appear in a manifest or in Brain's journal — they are supplied at
 session create and sealed the way model credentials are; the environment injects them at
 runtime.
+
+## One artifact, provisioned at attach
+
+`brain build` packages each tool as a `tool/v1` artifact: the manifest above plus a
+self-contained single-file ESM bundle, named by the bundle's sha-256 (`payload.identity`).
+The environment provisions the artifact at attach — executing the bundle once, so a broken
+tool fails the attach receipt instead of the first model call — and re-provisioning by the
+same identity is idempotent.
 
 ## Brain does not run tool code
 

--- a/docs/guides/write-a-tool.mdx
+++ b/docs/guides/write-a-tool.mdx
@@ -1,53 +1,85 @@
 ---
 title: Write a Tool extension
-description: Bundle an async function and its npm dependencies for an Environment.
+description: Declare what you need, receive typed handles, ship one artifact.
 ---
+
+A provisioned tool is a typed async function plus a declaration of what it needs. The run
+context is derived from that declaration: handles for exactly the capabilities in
+`requires`, values for exactly the names in `bindings`, and nothing else.
 
 ```ts
 import { tool } from "@aexhq/brain";
-import Client from "@vendor/orders";
 import { z } from "zod";
 
-const options = z.object({ endpoint: z.url() });
-const input = z.object({ orderId: z.string() });
-const output = z.object({ status: z.string() });
-
-export const lookupOrder = tool(
+export const bash = tool(
   {
-    description: "Look up an order.",
-    options,
-    input,
-    output,
-    // Capabilities this tool needs from its environment. Brain checks the
-    // declaration against what the bound environment provides at session
-    // create; omit it (or leave it empty) and the tool binds anywhere.
-    requires: [],
-    // Named runtime values by shape. Values are supplied at session create and
-    // injected by the environment; only the names enter the manifest.
-    bindings: {},
+    description: "Run a shell command in the session workspace.",
+    input: z.object({ command: z.string(), timeout_ms: z.number().int().optional() }),
+    output: z.object({ exit_code: z.number(), stdout: z.string(), stderr: z.string() }),
+    // Capabilities this tool needs from its environment. The context type below
+    // is derived from this list, so using an undeclared capability is a compile
+    // error — and Brain rejects a bind to an environment that does not provide
+    // them at session create. Omit it (or leave it empty) to bind anywhere.
+    requires: ["exec"],
+    // Named runtime values by shape. Only the names enter the manifest; values
+    // are supplied at session create and injected by the environment.
+    bindings: { API_BASE: z.string() },
   },
   (author) => {
-    let client: Client;
-
-    author.setup(async ({ options, signal }) => {
-      client = new Client({ endpoint: options.endpoint });
-      await client.ready({ signal });
+    author.run(async (input, context) => {
+      // context: { exec: ExecHandle; bindings: { API_BASE: string };
+      //            signal: AbortSignal; deadline: Date; callId: string; ... }
+      const result = await context.exec.run(input.command, { timeoutMs: input.timeout_ms });
+      return { exit_code: result.exitCode, stdout: result.stdout, stderr: result.stderr };
     });
-
-    author.run(async ({ orderId }, call) => client.lookup(orderId, { signal: call.signal }));
   },
 );
 ```
 
-Run `npx brain build`. The export name becomes the model-visible name, input and output cross the
-trust boundary through the Zod schemas, and reachable JavaScript dependencies are bundled into the
-Environment-side runtime. Native addons and install-time files are not portable and fail the build.
+Handles throw typed `CapabilityError`s; timeouts and cancellation arrive through the
+tool's own `signal` and `deadline`, not per-handle knobs. Grant clamping — the fs root,
+exec bounds, the net allowlist — happens behind the handle: a tool cannot observe or
+bypass policy, only hit it as an error.
+
+`requires` is declared, not inferred from the handler body, and the duplication is
+checked twice: at compile time the context type comes from the declaration (hard), and
+at build time `brain build` warns when a declared capability's handle never appears in
+your code (a warning, not an error — passing the context into a helper can hide a real
+use, and over-declaring only makes the bind-time check stricter).
+
+## The artifact
+
+Run `npx brain build`. For each exported tool it emits `<name>.tool.json`: a `tool/v1`
+manifest plus a self-contained single-file ESM bundle, named by the bundle's sha-256.
+
+```jsonc
+{
+  "manifest": {
+    "name": "bash",
+    "description": "Run a shell command in the session workspace.",
+    "input_schema": { /* from zod */ },
+    "output_schema": { /* from zod */ },
+    "requires": ["exec"],
+    "binding_names": ["API_BASE"],
+    "hosting": "provisioned",
+    "payload": { "kind": "esm", "identity": "<sha-256 of the bundle>" }
+  },
+  "payload": "/* the bundle */"
+}
+```
+
+Dependencies are baked into the bundle; binding *values* are structurally impossible in
+it — they do not exist at build time. Provisioning executes the bundle once at attach,
+so a broken tool fails the attach receipt, never the first model call. Native addons and
+install-time files are not portable and fail the build.
 
 Application code chooses placement explicitly:
 
 ```ts
-lookupOrder({ endpoint }).useIn(environment)
+bash().useIn(environment)
 ```
 
-Tool handlers are async. Cancellation aborts `call.signal`; `call.deadline`, `call.requestId`,
-`call.workspace`, and `call.progress()` are available when the selected Environment supports them.
+Legacy notes: the export name becomes the model-visible name, and handlers stay async.
+`call.workspace` and `call.progress()` remain available on environments that support the
+pre-capability runtime; new tools should declare `requires: ["fs"]` instead of reaching
+for a workspace path.

--- a/docs/guides/write-an-environment.mdx
+++ b/docs/guides/write-an-environment.mdx
@@ -1,13 +1,15 @@
 ---
 title: Write an Environment extension
-description: Own a Tool runtime and expose provider-specific methods with one authoring shape.
+description: Provide capabilities, host provisioned tools, and expose provider-specific methods.
 ---
 
-An Environment owns somewhere Tools run. `open`, `run`, and `close` may be async and may use normal
-runtime libraries:
+An Environment owns somewhere Tools run. It implements capability *providers* against its
+open instance, and may opt in to hosting provisioned tools with one line — the SDK owns
+the host runtime (payload cache, attach-time validation, handle wiring, the outcome
+envelope), so environment authors never write it:
 
 ```ts
-import { environment } from "@aexhq/brain";
+import { clamp, environment } from "@aexhq/brain";
 import { z } from "zod";
 import Provider from "@vendor/cloud-sdk";
 
@@ -19,6 +21,21 @@ export const cloudVm = environment({ options }, (author) => {
     return provider.getOrCreate({ id });
   });
 
+  // Capability providers: the factory sees the open instance and the
+  // attachment's grants. Enforcement is yours — the shared clamp helper
+  // covers exec bounds and fs-root confinement.
+  vm.provide.exec(({ instance, grants }) => ({
+    run: (command, opts) => instance.exec(command, clamp(opts, grants.exec)),
+  }));
+  vm.provide.fs(({ instance, grants }) => ({
+    read: (path) => instance.readFile(clamp.path(grants.fs.root, path)),
+    write: (path, data) => instance.writeFile(clamp.path(grants.fs.root, path), data),
+    list: (path) => instance.listDir(clamp.path(grants.fs.root, path)),
+  }));
+
+  // Host provisioned ESM tools, wired in-process to the providers above.
+  vm.host.esm({ artifacts: myBuiltArtifacts });
+
   vm.run(async (request, context) => context.instance.execute(request, { signal: context.signal }));
   vm.close(async ({ instance }) => instance.close());
 
@@ -28,8 +45,33 @@ export const cloudVm = environment({ options }, (author) => {
 });
 ```
 
-Build it with `npx brain build`. The generated application object implements Brain's Environment
-interface and keeps its own methods:
+What the environment `provide`s becomes the `provides` list on its setup and attach
+receipts — the other half of Brain's `requires ⊆ provides` check at session create.
+Anything ugly a capability needs — quoting `sh -c`, enforcing a timeout by kill,
+bridging fs over exec — lives inside the provider, never in a tool.
+
+## Hosting provisioned tools
+
+`host.esm()` opts in. An attach carries each tool's manifest and the content identity of
+its payload; the bundle bytes themselves travel out of band and are registered through
+`host.esm({ artifacts })` (`brain build` output, one `<name>.tool.json` per tool). At
+attach the SDK host imports each bundle once per identity, resolves its run function, and
+checks that `requires` are provided and binding values are present — so a broken or
+mis-bound tool fails the attach receipt, never the first model call. At invoke it
+validates input against the tool's schema, wires handles to your providers in-process,
+injects binding values, and maps the result — return value, thrown error, deadline,
+cancellation — onto the one outcome envelope.
+
+An environment that does not call `host.esm()` still accepts provisions: their
+invocations stay on the environment's own `run` handler (the legacy runtime path), and a
+callback router never captures a provisioned name. See
+[App tools](/brain/docs/guides/app-tools) for the callback hosting an environment routes
+with `route.callbacks()`.
+
+## The application object
+
+Build it with `npx brain build`. The generated application object implements Brain's
+Environment interface and keeps its own methods:
 
 ```ts
 const vm = cloudVm({ region: "eu-west-2" });

--- a/packages/brain-sdk/src/build.ts
+++ b/packages/brain-sdk/src/build.ts
@@ -13,7 +13,7 @@ import { extensionSource } from "./extensions.js";
 export const BUILDER_TOOLCHAIN = "brain-build-1 componentize-js-0.19.3";
 
 export interface BuildOptions { readonly entry?: string; readonly out?: string }
-export interface BuiltExtension { readonly name: string; readonly kind: "agentloop" | "tool" | "environment"; readonly artifact?: string; readonly identity?: string; readonly bytes?: number }
+export interface BuiltExtension { readonly name: string; readonly kind: "agentloop" | "tool" | "environment"; readonly artifact?: string; readonly identity?: string; readonly bytes?: number; readonly warnings?: readonly string[] }
 
 export async function build(options: BuildOptions = {}): Promise<readonly BuiltExtension[]> {
   const entry = resolve(options.entry ?? "src/index.ts");
@@ -30,6 +30,7 @@ export async function build(options: BuildOptions = {}): Promise<readonly BuiltE
   const built: BuiltExtension[] = [];
   const toolRegistry: Record<string, { readonly contract_digest: string; readonly filename: string }> = {};
   const environmentRuntimeNames = new Map<string, string>();
+  let authoredCheckSource: string | undefined;
   for (const [name, definition] of definitions) {
     if (!validIdentifier(name)) throw new Error(`extension export ${JSON.stringify(name)} is not a stable identifier`);
     const kind = definition[extensionSource].kind;
@@ -38,7 +39,7 @@ export async function build(options: BuildOptions = {}): Promise<readonly BuiltE
       const packageValue = await buildAgentloop(entry, name, join(out, artifact));
       built.push({ name, kind, artifact, identity: packageValue.manifest.component_identity, bytes: packageValue.manifest.component_bytes });
     } else if (kind === "tool") {
-      const source = definition[extensionSource] as unknown as { contract: { description: string; input: z.ZodType; output?: z.ZodType } };
+      const source = definition[extensionSource] as unknown as { contract: { description: string; input: z.ZodType; output?: z.ZodType; requires?: readonly string[]; bindings?: Readonly<Record<string, z.ZodType>> } };
       const contract = {
         name,
         description: source.contract.description,
@@ -48,7 +49,26 @@ export async function build(options: BuildOptions = {}): Promise<readonly BuiltE
       const contractDigest = createHash("sha256").update(canonical(contract)).digest("hex");
       await buildTool(entry, name, join(out, "runtime", `${name}.mjs`), contractDigest);
       toolRegistry[name] = { contract_digest: contractDigest, filename: `${name}.mjs` };
-      built.push({ name, kind });
+      // The provisioned artifact: a self-contained single-file ESM bundle plus
+      // the tool/v1 manifest naming it by content identity. Binding values are
+      // structurally impossible here — only the names enter the manifest.
+      const payload = await buildProvisionedPayload(entry, name);
+      const identity = createHash("sha256").update(payload).digest("hex");
+      const manifest = {
+        name,
+        description: contract.description,
+        input_schema: contract.input_schema,
+        ...(source.contract.output === undefined ? {} : { output_schema: z.toJSONSchema(source.contract.output) }),
+        requires: [...(source.contract.requires ?? [])],
+        binding_names: Object.keys(source.contract.bindings ?? {}),
+        hosting: "provisioned",
+        payload: { kind: "esm", identity },
+      };
+      const artifact = `${name}.tool.json`;
+      await writeFile(join(out, artifact), `${JSON.stringify({ manifest, payload })}\n`);
+      authoredCheckSource ??= await authoredSource(entry);
+      const warnings = unusedRequiresWarnings(name, manifest.requires, authoredCheckSource);
+      built.push({ name, kind, artifact, identity, bytes: Buffer.byteLength(payload), ...(warnings.length === 0 ? {} : { warnings }) });
     } else {
       environmentRuntimeNames.set(name, await packageRuntimeName(entry));
       await buildEnvironment(entry, name, join(out, "runtime", `${name}.mjs`));
@@ -126,6 +146,42 @@ export default {
     },
     bundle: true, format: "esm", platform: "node", target: "node22", outfile: out, legalComments: "none",
   });
+}
+
+async function buildProvisionedPayload(entry: string, name: string): Promise<string> {
+  const compiled = await bundle({
+    stdin: {
+      contents: `
+import { provisionedToolRuntime } from "@aexhq/brain";
+import { ${name} as definition } from ${JSON.stringify(entry.replaceAll("\\", "/"))};
+export default provisionedToolRuntime(definition);
+`,
+      resolveDir: dirname(entry), sourcefile: `${name}.provisioned-entry.js`, loader: "js",
+    },
+    bundle: true, format: "esm", platform: "node", target: "node22", write: false, legalComments: "none",
+  });
+  const output = compiled.outputFiles[0];
+  if (output === undefined) throw new Error(`esbuild produced no provisioned payload for tool ${name}`);
+  return output.text;
+}
+
+/** The authored code alone (dependencies stay external), so the unused-requires
+ * heuristic below is not defeated by capability names appearing inside the SDK
+ * or third-party packages that would be bundled into the payload. */
+async function authoredSource(entry: string): Promise<string> {
+  const compiled = await bundle({ entryPoints: [entry], bundle: true, format: "esm", platform: "node", target: "node22", write: false, legalComments: "none", packages: "external" });
+  return compiled.outputFiles[0]?.text ?? "";
+}
+
+/** Warn on a declared capability whose handle never appears in the authored
+ * code as a property access or destructured key. Aliasing — a context passed
+ * whole into a helper or library — can false-alarm, which is why this is a
+ * warning, not an error: over-declaring is conservative and only makes the
+ * bind-time check stricter. */
+export function unusedRequiresWarnings(name: string, requires: readonly string[], authored: string): readonly string[] {
+  return requires
+    .filter((capability) => !new RegExp(`[.{,(]\\s*${capability}\\b`, "u").test(authored))
+    .map((capability) => `tool ${name} declares capability "${capability}" but its handle never appears in the bundle`);
 }
 
 async function buildAgentloop(entry: string, name: string, out: string): Promise<AgentloopPackage> {

--- a/packages/brain-sdk/src/callback-wire.ts
+++ b/packages/brain-sdk/src/callback-wire.ts
@@ -1,12 +1,10 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+import type { Outcome } from "./types.js";
+
 /** The one envelope every callback invocation resolves to — the same Outcome Brain
- * journals for every tool call, regardless of hosting. */
-export type Outcome =
-  | { readonly status: "ok"; readonly value: unknown }
-  | { readonly status: "error"; readonly error: { readonly code: string; readonly message: string; readonly details?: unknown } }
-  | { readonly status: "timeout" }
-  | { readonly status: "cancelled" };
+ * journals for every tool call, regardless of hosting (defined in types.ts). */
+export type { Outcome };
 
 /** One invocation as it crosses the app boundary: MCP data shapes over plain HTTP,
  * no framing ceremony. `deadline_ms` is the remaining budget, not an epoch. */

--- a/packages/brain-sdk/src/capabilities.ts
+++ b/packages/brain-sdk/src/capabilities.ts
@@ -1,0 +1,139 @@
+import type { CapabilityName } from "./types.js";
+
+/**
+ * The tool-facing half of the capability contract: typed handles a provisioned
+ * tool receives for exactly the capabilities it declares in `requires`, and the
+ * environment-facing grant shapes providers enforce behind them.
+ *
+ * Handles surface failures as `CapabilityError`s. Timeouts and cancellation
+ * arrive through the tool's own `signal`/`deadline`, not per-handle knobs, and
+ * grant policy is enforced behind the handle — a tool cannot observe or bypass
+ * it, only hit it as an error.
+ */
+
+/** A typed failure thrown by a capability handle. `code` is an identifier the
+ * invoke outcome carries verbatim (for example `path_escape`). */
+export class CapabilityError extends Error {
+  override readonly name = "CapabilityError";
+  constructor(
+    public readonly capability: CapabilityName,
+    public readonly code: string,
+    message: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+export interface ExecOptions {
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly stdin?: string;
+  readonly timeoutMs?: number;
+}
+export interface ExecResult { readonly exitCode: number; readonly stdout: string; readonly stderr: string }
+export interface ExecHandle { run(command: string, opts?: ExecOptions): Promise<ExecResult> }
+
+export interface FsEntry { readonly name: string; readonly kind: "file" | "dir" }
+export interface FsHandle {
+  read(path: string): Promise<Uint8Array>;
+  write(path: string, data: Uint8Array | string): Promise<void>;
+  list(path: string): Promise<readonly FsEntry[]>;
+}
+
+export interface NetFetchRequest {
+  readonly url: string;
+  readonly method?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly body?: string;
+}
+export interface NetFetchResponse { readonly status: number; readonly headers: Readonly<Record<string, string>>; readonly body: string }
+export interface NetHandle { fetch(input: NetFetchRequest): Promise<NetFetchResponse> }
+
+export interface JsHandle { evaluate(source: string, args?: readonly unknown[]): Promise<unknown> }
+
+/** The contract leaves the trusted-input action shape open in v1; ref-based
+ * `act()` is a reserved later interface addition. */
+export type PageInput = unknown;
+export interface ConsoleEntry { readonly level: string; readonly text: string }
+export interface PageHandle {
+  navigate(url: string, wait?: "none" | "interaction" | "complete"): Promise<void>;
+  screenshot(): Promise<Uint8Array>;
+  input(action: PageInput): Promise<void>;
+  consoleSince(cursor: number): Promise<{ readonly entries: readonly ConsoleEntry[]; readonly cursor: number }>;
+}
+
+/** Every capability's tool-facing handle, keyed by its contract name. A tool's
+ * run context picks from this by its declared `requires`. */
+export interface CapabilityHandles {
+  readonly exec: ExecHandle;
+  readonly fs: FsHandle;
+  readonly net: NetHandle;
+  readonly js: JsHandle;
+  readonly page: PageHandle;
+}
+
+/** Per-capability policy carried on attach (`environment/v2` GrantSet, wire
+ * field names). Providers enforce it; tools never see it. */
+export interface ExecGrant { readonly timeout_ms_max?: number; readonly output_bytes_max?: number }
+export interface FsGrant { readonly root: string }
+export interface NetGrant { readonly allow: readonly string[] }
+export interface GrantSet {
+  readonly exec?: ExecGrant;
+  readonly fs?: FsGrant;
+  readonly net?: NetGrant;
+  readonly js?: Record<string, never>;
+  readonly page?: Record<string, never>;
+}
+
+/** What an environment registers per capability: given its open instance and
+ * the attachment's grants, return the provider — the same interface the tool's
+ * handle projects, so the two sides cannot drift. */
+export type CapabilityProviderFactory<Instance, Name extends CapabilityName> = (
+  context: { readonly instance: Instance; readonly grants: GrantSet },
+) => CapabilityHandles[Name];
+
+function clampExec(opts: ExecOptions | undefined, grant: ExecGrant | undefined): ExecOptions {
+  const maximum = grant?.timeout_ms_max;
+  if (maximum === undefined) return opts ?? {};
+  const requested = opts?.timeoutMs;
+  return { ...opts, timeoutMs: requested === undefined ? maximum : Math.min(requested, maximum) };
+}
+
+/** Pure posix-style normalization (no filesystem, no cwd): resolves `.`/`..`
+ * segments so escapes are judged on the resolved path, not its spelling. */
+function normalizedPath(path: string): { readonly absolute: boolean; readonly value: string } {
+  const absolute = path.startsWith("/");
+  const parts: string[] = [];
+  for (const part of path.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (parts.length > 0 && parts[parts.length - 1] !== "..") parts.pop();
+      else if (!absolute) parts.push("..");
+    } else {
+      parts.push(part);
+    }
+  }
+  return { absolute, value: `${absolute ? "/" : ""}${parts.join("/")}` };
+}
+
+function clampPath(root: string, path: string): string {
+  const normalizedRoot = normalizedPath(root.replaceAll("\\", "/")).value;
+  const requested = path.replaceAll("\\", "/");
+  const candidate = normalizedPath(requested.startsWith("/") ? requested : `${normalizedRoot}/${requested}`).value;
+  const prefix = normalizedRoot === "/" ? "/" : `${normalizedRoot}/`;
+  if (candidate !== normalizedRoot && !candidate.startsWith(prefix)) {
+    throw new CapabilityError("fs", "path_escape", `path ${path} escapes the granted root ${root}`);
+  }
+  return candidate;
+}
+
+/**
+ * The shared grant-clamping helper for providers. Calling `clamp(opts,
+ * grants.exec)` bounds exec options (a requested timeout never exceeds the
+ * granted maximum; an absent request gets the maximum); `clamp.path(root,
+ * path)` confines an fs path to the granted root, returning the resolved path
+ * or throwing a `path_escape` CapabilityError for anything that resolves
+ * outside it.
+ */
+export const clamp = Object.assign(clampExec, { path: clampPath });

--- a/packages/brain-sdk/src/cli.ts
+++ b/packages/brain-sdk/src/cli.ts
@@ -54,7 +54,10 @@ if (watching) {
 
 async function runBuild(): Promise<void> {
   const built = await build(options);
-  for (const extension of built) process.stderr.write(`${extension.name} (${extension.kind})${extension.identity === undefined ? "" : ` -> ${extension.identity} (${extension.bytes} bytes)`}\n`);
+  for (const extension of built) {
+    process.stderr.write(`${extension.name} (${extension.kind})${extension.identity === undefined ? "" : ` -> ${extension.identity} (${extension.bytes} bytes)`}\n`);
+    for (const warning of extension.warnings ?? []) process.stderr.write(`warning: ${warning}\n`);
+  }
 }
 
 function usage(): never {

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 import { createCallbackRouter, refuseUpgrade, resolveCallbackRoute, type CallbackRoute, type CallbackRouter } from "./callbacks.js";
+import type { CapabilityHandles, CapabilityProviderFactory, GrantSet } from "./capabilities.js";
+import { EsmToolHost, capabilityHandles, invokeProvisioned, type ProvisionedToolArtifact, type ProvisionedToolModule } from "./host.js";
 import type { BoundTool, Agentloop, CapabilityName, Environment, ModelMessage, ModelResponse, Schema, SchemaInput, SchemaOutput, Tool, ToolDefinition, UserInput } from "./types.js";
 
 const capabilityNames: readonly CapabilityName[] = ["exec", "fs", "net", "js", "page"];
@@ -63,24 +65,46 @@ export interface AgentloopAuthor<Options> {
 type AgentloopSetup<Options> = (author: AgentloopAuthor<Options>) => void;
 type AgentloopSource = { readonly kind: "agentloop"; readonly options?: Schema; readonly setup: AgentloopSetup<unknown>; artifact?: URL | Uint8Array; name?: string };
 
-export interface ToolContract<OptionsSchema extends Schema | undefined, InputSchema extends Schema, OutputSchema extends Schema | undefined> {
+type BindingSchemas = Readonly<Record<string, Schema>>;
+export interface ToolContract<
+  OptionsSchema extends Schema | undefined,
+  InputSchema extends Schema,
+  OutputSchema extends Schema | undefined,
+  Requires extends readonly CapabilityName[] = readonly CapabilityName[],
+  Bindings extends BindingSchemas = BindingSchemas,
+> {
   readonly description: string;
   readonly options?: OptionsSchema;
   readonly input: InputSchema;
   readonly output?: OutputSchema;
   /** Capabilities the tool needs from its environment. The whole declaration:
-   * Brain rejects a bind to an environment that does not provide them, and an empty
-   * (or absent) list binds anywhere. */
-  readonly requires?: readonly CapabilityName[];
+   * the run context is typed from it (an undeclared capability does not
+   * type-check), Brain rejects a bind to an environment that does not provide
+   * them, and an empty (or absent) list binds anywhere. */
+  readonly requires?: Requires;
   /** Binding names plus value shapes. Only the names enter the manifest; values are
    * supplied at session create and injected by the environment at runtime. */
-  readonly bindings?: Readonly<Record<string, Schema>>;
+  readonly bindings?: Bindings;
 }
-export interface ToolAuthor<Options, Input, Output> {
+/** The context a tool's run handler receives: typed handles for exactly the
+ * declared `requires`, typed `bindings` values, and the invocation plumbing. */
+export type ToolRunContext<Options, Requires extends readonly CapabilityName[] = readonly [], Bindings extends BindingSchemas = Record<never, Schema>> =
+  Pick<CapabilityHandles, Requires[number]> & {
+    readonly bindings: { readonly [Name in keyof Bindings]: SchemaOutput<Bindings[Name]> };
+    readonly options: Options;
+    readonly signal: AbortSignal;
+    readonly deadline: Date;
+    /** The invocation's call id (`requestId` remains as its historic alias). */
+    readonly callId: string;
+    readonly requestId: string;
+    readonly workspace?: string;
+    progress(value: unknown): void;
+  };
+export interface ToolAuthor<Options, Input, Output, RunContext = ToolRunContext<Options>> {
   setup(handler: (context: { readonly options: Options; readonly signal: AbortSignal; readonly requestId: string; readonly workspace?: string }) => void | Promise<void>): void;
-  run(handler: (input: Input, context: { readonly options: Options; readonly signal: AbortSignal; readonly deadline: Date; readonly requestId: string; readonly workspace?: string; progress(value: unknown): void }) => Output | Promise<Output>): void;
+  run(handler: (input: Input, context: RunContext) => Output | Promise<Output>): void;
 }
-type ToolSetup<Options, Input, Output> = (author: ToolAuthor<Options, Input, Output>) => void;
+type ToolSetup<Options, Input, Output, RunContext = ToolRunContext<Options>> = (author: ToolAuthor<Options, Input, Output, RunContext>) => void;
 type ToolSource = {
   readonly kind: "tool";
   readonly contract: ToolContract<Schema | undefined, Schema, Schema | undefined>;
@@ -105,6 +129,17 @@ type EnvironmentMember = EnvironmentMethod<never, unknown> | EnvironmentStream<n
 export interface EnvironmentInstanceAuthor<Instance> {
   run(handler: (request: unknown, context: { readonly instance: Instance; readonly signal: AbortSignal; readonly requestId: string }) => unknown | Promise<unknown>): void;
   close(handler: (context: { readonly instance: Instance; readonly signal: AbortSignal; readonly requestId: string }) => void | Promise<void>): void;
+  /** Register a capability provider. What the environment provides becomes the
+   * `provides` list on its setup and attach receipts — the other half of
+   * Brain's `requires ⊆ provides` bind check — and hosted tools' handles wire
+   * to these providers in-process. Grant clamping is the provider's job; the
+   * shared `clamp` helper covers exec bounds and fs-root confinement. */
+  readonly provide: { readonly [Name in CapabilityName]: (factory: CapabilityProviderFactory<Instance, Name>) => void };
+  /** Opt in to hosting provisioned tools. `esm()` accepts the artifacts this
+   * process can serve (`brain build` output); attach provisions name payloads
+   * by content identity, so the bytes travel out of band — registered here —
+   * and a provision naming an unregistered identity fails the attach. */
+  readonly host: { esm(options?: { readonly artifacts?: readonly ProvisionedToolArtifact[] }): void };
   readonly on: {
     attach(handler: (context: { readonly instance: Instance; readonly sessionId: string; readonly signal: AbortSignal; readonly requestId: string }) => void | Promise<void>): void;
     cancel(handler: (context: { readonly instance: Instance; readonly signal: AbortSignal; readonly requestId: string }) => void | Promise<void>): void;
@@ -142,7 +177,8 @@ interface EnvironmentRegistration {
   readonly cancel?: (context: unknown) => void | Promise<void>;
   readonly detach?: (context: unknown) => void | Promise<void>;
 }
-type EnvironmentSource = { readonly kind: "environment"; readonly options?: Schema; readonly setup: EnvironmentSetup<unknown, Record<string, EnvironmentMember>>; name?: string; runtimeName?: string; readonly members: Readonly<Record<string, EnvironmentMember>>; readonly registration: EnvironmentRegistration; readonly callbacks?: (context: { readonly options: unknown }) => CallbackRoute };
+type ProviderFactories = Readonly<Partial<Record<CapabilityName, (context: { readonly instance: unknown; readonly grants: GrantSet }) => unknown>>>;
+type EnvironmentSource = { readonly kind: "environment"; readonly options?: Schema; readonly setup: EnvironmentSetup<unknown, Record<string, EnvironmentMember>>; name?: string; runtimeName?: string; readonly members: Readonly<Record<string, EnvironmentMember>>; readonly registration: EnvironmentRegistration; readonly callbacks?: (context: { readonly options: unknown }) => CallbackRoute; readonly providers: ProviderFactories; readonly esmHost?: EsmToolHost };
 type ExtensionFactory = Function & { [extensionSource]?: AgentloopSource | ToolSource | EnvironmentSource };
 
 const agentloops = new WeakMap<object, { readonly artifact: URL | Uint8Array; readonly configuration: unknown }>();
@@ -176,9 +212,20 @@ export function agentloop<OptionsSchema extends Schema>(contractOrSetup: { reado
   return factory;
 }
 
-export function tool<OptionsSchema extends Schema | undefined, InputSchema extends Schema, OutputSchema extends Schema | undefined = undefined>(
-  contract: ToolContract<OptionsSchema, InputSchema, OutputSchema>,
-  setup: ToolSetup<OptionsSchema extends Schema ? SchemaOutput<OptionsSchema> : Record<string, never>, SchemaOutput<InputSchema>, OutputSchema extends Schema ? SchemaOutput<OutputSchema> : unknown>,
+export function tool<
+  OptionsSchema extends Schema | undefined,
+  InputSchema extends Schema,
+  OutputSchema extends Schema | undefined = undefined,
+  const Requires extends readonly CapabilityName[] = readonly [],
+  Bindings extends BindingSchemas = Record<never, Schema>,
+>(
+  contract: ToolContract<OptionsSchema, InputSchema, OutputSchema, Requires, Bindings>,
+  setup: ToolSetup<
+    OptionsSchema extends Schema ? SchemaOutput<OptionsSchema> : Record<string, never>,
+    SchemaOutput<InputSchema>,
+    OutputSchema extends Schema ? SchemaOutput<OutputSchema> : unknown,
+    ToolRunContext<OptionsSchema extends Schema ? SchemaOutput<OptionsSchema> : Record<string, never>, Requires, Bindings>
+  >,
 ): (options?: OptionsSchema extends Schema ? SchemaInput<OptionsSchema> : undefined) => Tool<SchemaOutput<InputSchema>, OutputSchema extends Schema ? SchemaOutput<OutputSchema> : unknown> {
   if (typeof contract.description !== "string" || contract.description.length > 8_192) throw new TypeError("Tool description exceeds its contract bound");
   if (typeof setup !== "function") throw new TypeError("tool requires a setup function");
@@ -277,7 +324,9 @@ export async function executeTool(factory: unknown, options: unknown, input: unk
     options: parsedOptions,
     signal: context.signal,
     deadline: new Date(context.deadlineMs),
+    callId: context.requestId ?? "call",
     requestId: context.requestId ?? "call",
+    bindings: Object.freeze({}),
     ...(context.workspace === undefined ? {} : { workspace: context.workspace }),
     progress: context.progress ?? (() => {}),
   });
@@ -291,16 +340,48 @@ export interface EnvironmentChannel {
 }
 export type EnvironmentHandler = ((command: unknown) => Promise<unknown>) & { readonly channel: EnvironmentChannel };
 
+interface HostedTool {
+  readonly manifest: { readonly name: string; readonly requires: readonly CapabilityName[]; readonly binding_names: readonly string[] };
+  readonly module: ProvisionedToolModule;
+  readonly handles: Readonly<Partial<CapabilityHandles>>;
+}
+interface EnvironmentAttachment {
+  readonly sessionId: string;
+  readonly bindings: Readonly<Record<string, string>>;
+  readonly hosted: ReadonlyMap<string, HostedTool>;
+}
 interface EnvironmentInstanceState {
   readonly value: unknown;
   readonly options: unknown;
-  readonly attachments: Map<string, string>;
+  readonly attachments: Map<string, EnvironmentAttachment>;
   readonly provisioned: Set<string>;
   readonly router?: CallbackRouter;
 }
 
+/** What a provisioned ESM bundle default-exports: `brain build` wraps the tool
+ * definition with this, so the host can validate input against the tool's own
+ * schema (the manifest was generated from it), resolve run once at provision,
+ * and execute with the context it wires. Binding values replace options for
+ * provisioned tools; an options schema is parsed empty, so only defaults apply. */
+export function provisionedToolRuntime(factory: unknown): ProvisionedToolModule {
+  const source = sourceOf(factory as ExtensionFactory, "tool") as ToolSource;
+  const options = source.contract.options === undefined ? Object.freeze({}) : source.contract.options.parse({});
+  return Object.freeze({
+    kind: "brain.provisioned-tool/v1" as const,
+    ...(source.initialize === undefined ? {} : {
+      initialize: (context: { readonly signal: AbortSignal; readonly requestId: string }) => source.initialize?.({ options, ...context }),
+    }),
+    parseInput: (input: unknown) => source.contract.input.parse(input),
+    run: async (input: unknown, context: object) => {
+      const result = await source.run(input, { options, ...context });
+      return source.contract.output === undefined ? result ?? null : source.contract.output.parse(result);
+    },
+  });
+}
+
 export function createEnvironmentHandler(factory: unknown): EnvironmentHandler {
   const source = sourceOf(factory as ExtensionFactory, "environment") as EnvironmentSource;
+  const provides = capabilityNames.filter((name) => source.providers[name] !== undefined);
   const instances = new Map<string, EnvironmentInstanceState>();
   const receipts = new Map<string, { readonly identity: string; readonly response: unknown }>();
   const active = new Map<string, AbortController>();
@@ -329,7 +410,7 @@ export function createEnvironmentHandler(factory: unknown): EnvironmentHandler {
             instance = { value, options, attachments: new Map(), provisioned: new Set(), ...(router === undefined ? {} : { router }) };
             instances.set(operation.environment_id, instance);
           }
-          receipt = { type: "accepted" };
+          receipt = { type: "accepted", provides };
           break;
         }
         case "attach": {
@@ -337,20 +418,44 @@ export function createEnvironmentHandler(factory: unknown): EnvironmentHandler {
           if (operation.attachment_id === undefined) throw new TypeError("attach requires an attachment identity");
           if (!plainObject(operation.request.grants) || !Array.isArray(operation.request.provisions) || !plainObject(operation.request.bindings)) throw new TypeError("attach requires grants, provisions, and bindings");
           // Only provisioned tools arrive as provisions; anything else invoked here is
-          // callback-hosted and belongs to the router, when one is registered.
+          // callback-hosted and belongs to the router, when one is registered. With
+          // host.esm the SDK hosts the provisions itself; without it they stay on the
+          // environment's own run handler (the legacy runtime path).
           for (const provision of operation.request.provisions) {
             if (plainObject(provision) && plainObject(provision.manifest) && typeof provision.manifest.name === "string") instance.provisioned.add(provision.manifest.name);
           }
-          instance.attachments.set(operation.attachment_id, operation.session_id);
+          const hosted = source.esmHost === undefined
+            ? new Map<string, HostedTool>()
+            : await provisionTools(source, instance.value, operation.request as unknown as { grants: GrantSet; provisions: unknown[]; bindings: Record<string, unknown> }, context);
+          instance.attachments.set(operation.attachment_id, {
+            sessionId: operation.session_id,
+            bindings: Object.freeze({ ...(operation.request.bindings as Record<string, string>) }),
+            hosted,
+          });
           await source.registration.attach?.({ ...context, instance: instance.value, sessionId: operation.session_id });
-          // Generated environments implement no capability providers yet, so they
-          // report an empty `provides`: only tools with empty `requires` bind here.
-          receipt = { type: "accepted", provides: [] };
+          receipt = { type: "accepted", provides };
           break;
         }
         case "invoke": {
-          const instance = authorizedEnvironmentInstance(instances, operation);
+          const { instance, attachment } = authorizedEnvironmentInstance(instances, operation);
           if (typeof operation.request.call_id !== "string" || typeof operation.request.tool !== "string") throw new TypeError("Environment Tool invocation is invalid");
+          // Dispatch order: a tool the SDK hosts in-process, then the callback
+          // router for anything not provisioned here, then the environment's own
+          // run handler as the legacy floor.
+          const hostedTool = attachment.hosted.get(operation.request.tool);
+          if (hostedTool !== undefined) {
+            const deadline = operation.request.deadline_ms;
+            if (typeof deadline !== "number" || !Number.isInteger(deadline) || deadline < 1) throw new TypeError("Environment Tool invocation needs a deadline");
+            receipt = { type: "outcome", outcome: await invokeProvisioned(hostedTool.module, {
+              callId: operation.request.call_id,
+              input: operation.request.input,
+              deadlineMs: deadline,
+              signal: controller.signal,
+              handles: hostedTool.handles,
+              bindings: pickBindings(hostedTool.manifest.binding_names, attachment.bindings),
+            }) };
+            break;
+          }
           if (instance.router !== undefined && !instance.provisioned.has(operation.request.tool)) {
             const deadline = operation.request.deadline_ms;
             if (typeof deadline !== "number" || !Number.isInteger(deadline) || deadline < 1) throw new TypeError("Environment Tool invocation needs a deadline");
@@ -372,7 +477,7 @@ export function createEnvironmentHandler(factory: unknown): EnvironmentHandler {
           break;
         }
         case "call": {
-          const instance = authorizedEnvironmentInstance(instances, operation);
+          const { instance } = authorizedEnvironmentInstance(instances, operation);
           if (typeof operation.request.name !== "string") throw new TypeError("Environment method name is invalid");
           const member = source.members[operation.request.name];
           if (member === undefined) throw new TypeError(`unknown Environment method ${operation.request.name}`);
@@ -459,8 +564,49 @@ function requiredEnvironmentInstance(instances: Map<string, EnvironmentInstanceS
 
 function authorizedEnvironmentInstance(instances: Map<string, EnvironmentInstanceState>, operation: RuntimeEnvironmentOperation) {
   const instance = requiredEnvironmentInstance(instances, operation.environment_id);
-  if (operation.attachment_id === undefined || instance.attachments.get(operation.attachment_id) !== operation.session_id) throw new Error("Environment attachment does not authorize this session");
-  return instance;
+  const attachment = operation.attachment_id === undefined ? undefined : instance.attachments.get(operation.attachment_id);
+  if (attachment === undefined || attachment.sessionId !== operation.session_id) throw new Error("Environment attachment does not authorize this session");
+  return { instance, attachment };
+}
+
+/** Resolve an attach's provisions to loaded, initialized modules with their
+ * handles wired to this environment's providers. Any failure here fails the
+ * attach receipt — a broken tool never reaches its first model call. */
+async function provisionTools(
+  source: EnvironmentSource,
+  instanceValue: unknown,
+  request: { readonly grants: GrantSet; readonly provisions: readonly unknown[]; readonly bindings: Readonly<Record<string, unknown>> },
+  context: { readonly signal: AbortSignal; readonly requestId: string },
+): Promise<ReadonlyMap<string, HostedTool>> {
+  const hosted = new Map<string, HostedTool>();
+  if (request.provisions.length === 0) return hosted;
+  if (source.esmHost === undefined) throw new Error("this environment does not host provisioned tools");
+  // One provider instance per capability per attachment: the factory sees the
+  // open instance and this attachment's grants, and clamps against them.
+  const providers: Partial<Record<CapabilityName, unknown>> = {};
+  for (const name of capabilityNames) {
+    const factory = source.providers[name];
+    if (factory !== undefined) providers[name] = factory({ instance: instanceValue, grants: request.grants });
+  }
+  for (const provision of request.provisions) {
+    if (!plainObject(provision) || !plainObject(provision.manifest) || typeof provision.payload_identity !== "string") throw new TypeError("attach provision is invalid");
+    const manifest = provision.manifest as unknown as HostedTool["manifest"] & { readonly hosting?: string; readonly payload?: { readonly kind?: string } };
+    if (typeof manifest.name !== "string" || !Array.isArray(manifest.requires) || !Array.isArray(manifest.binding_names)) throw new TypeError("attach provision manifest is invalid");
+    if (manifest.payload?.kind !== "esm") throw new Error(`tool ${manifest.name} does not carry an esm payload; only esm payloads are hosted`);
+    const missingCapability = manifest.requires.find((name: CapabilityName) => providers[name] === undefined);
+    if (missingCapability !== undefined) throw new Error(`tool ${manifest.name} requires ${missingCapability}, which this environment does not provide`);
+    const missingBinding = manifest.binding_names.find((name) => typeof request.bindings[name] !== "string");
+    if (missingBinding !== undefined) throw new Error(`tool ${manifest.name} needs a value for binding ${missingBinding}`);
+    const module = await source.esmHost.provision(provision.payload_identity, context);
+    hosted.set(manifest.name, { manifest, module, handles: capabilityHandles(manifest.requires, providers as Readonly<Partial<CapabilityHandles>>) });
+  }
+  return hosted;
+}
+
+function pickBindings(names: readonly string[], values: Readonly<Record<string, string>>): Readonly<Record<string, string>> {
+  const picked: Record<string, string> = {};
+  for (const name of names) picked[name] = values[name] as string;
+  return picked;
 }
 
 function environmentResponse(operation: RuntimeEnvironmentOperation, receipt: unknown) {
@@ -510,11 +656,11 @@ export function environment<OptionsSchema extends Schema, Members extends Record
     environments.set(instance, runtime);
     return Object.freeze(instance);
   }) as ExtensionFactory;
-  defineSource(factory, { kind: "environment", ...(optionsSchema === undefined ? {} : { options: optionsSchema }), setup: setup as EnvironmentSetup<unknown, Record<string, EnvironmentMember>>, members, registration: collected.registration, ...(collected.callbacks === undefined ? {} : { callbacks: collected.callbacks }) });
+  defineSource(factory, { kind: "environment", ...(optionsSchema === undefined ? {} : { options: optionsSchema }), setup: setup as EnvironmentSetup<unknown, Record<string, EnvironmentMember>>, members, registration: collected.registration, ...(collected.callbacks === undefined ? {} : { callbacks: collected.callbacks }), providers: collected.providers, ...(collected.esmHost === undefined ? {} : { esmHost: collected.esmHost }) });
   return factory as never;
 }
 
-function collectEnvironment(setup: EnvironmentSetup<unknown, Record<string, EnvironmentMember>>): { readonly members: Readonly<Record<string, EnvironmentMember>>; readonly registration: EnvironmentRegistration; readonly callbacks?: (context: { readonly options: unknown }) => CallbackRoute } {
+function collectEnvironment(setup: EnvironmentSetup<unknown, Record<string, EnvironmentMember>>): { readonly members: Readonly<Record<string, EnvironmentMember>>; readonly registration: EnvironmentRegistration; readonly callbacks?: (context: { readonly options: unknown }) => CallbackRoute; readonly providers: ProviderFactories; readonly esmHost?: EsmToolHost } {
   let open: EnvironmentRegistration["open"] | undefined;
   let run: EnvironmentRegistration["run"] | undefined;
   let close: EnvironmentRegistration["close"] | undefined;
@@ -522,6 +668,13 @@ function collectEnvironment(setup: EnvironmentSetup<unknown, Record<string, Envi
   let cancel: EnvironmentRegistration["cancel"];
   let detach: EnvironmentRegistration["detach"];
   let callbacks: ((context: { readonly options: unknown }) => CallbackRoute) | undefined;
+  const providers: Partial<Record<CapabilityName, (context: { readonly instance: unknown; readonly grants: GrantSet }) => unknown>> = {};
+  let esmHost: EsmToolHost | undefined;
+  const provideOne = (name: CapabilityName) => (factory: (context: { readonly instance: never; readonly grants: GrantSet }) => unknown) => {
+    if (providers[name] !== undefined) throw new TypeError(`environment may provide ${name} only once`);
+    if (typeof factory !== "function") throw new TypeError(`provide.${name} requires a provider factory`);
+    providers[name] = factory as (context: { readonly instance: unknown; readonly grants: GrantSet }) => unknown;
+  };
   const author: EnvironmentAuthor<unknown> = {
     options: Object.freeze({}),
     route: {
@@ -540,6 +693,14 @@ function collectEnvironment(setup: EnvironmentSetup<unknown, Record<string, Envi
       const instance: EnvironmentInstanceAuthor<Instance> = {
         run(handler) { if (run !== undefined) throw new TypeError("environment may register run only once"); run = handler as EnvironmentRegistration["run"]; },
         close(handler) { if (close !== undefined) throw new TypeError("environment may register close only once"); close = handler as EnvironmentRegistration["close"]; },
+        provide: { exec: provideOne("exec"), fs: provideOne("fs"), net: provideOne("net"), js: provideOne("js"), page: provideOne("page") },
+        host: {
+          esm(options) {
+            if (esmHost !== undefined) throw new TypeError("environment may register host.esm only once");
+            esmHost = new EsmToolHost();
+            for (const artifact of options?.artifacts ?? []) esmHost.register(artifact);
+          },
+        },
         on: {
           attach(handler) { if (attach !== undefined) throw new TypeError("environment may register attach only once"); attach = handler as EnvironmentRegistration["attach"]; },
           cancel(handler) { if (cancel !== undefined) throw new TypeError("environment may register cancel only once"); cancel = handler as EnvironmentRegistration["cancel"]; },
@@ -564,7 +725,13 @@ function collectEnvironment(setup: EnvironmentSetup<unknown, Record<string, Envi
   for (const [name, member] of Object.entries(members)) {
     if (!validIdentifier(name) || !plainObject(member) || (member.kind !== "method" && member.kind !== "stream")) throw new TypeError(`Environment member ${name} must be created with method or stream`);
   }
-  return { members: Object.freeze({ ...members }), registration: { open, run, close, ...(attach === undefined ? {} : { attach }), ...(cancel === undefined ? {} : { cancel }), ...(detach === undefined ? {} : { detach }) }, ...(callbacks === undefined ? {} : { callbacks }) };
+  return {
+    members: Object.freeze({ ...members }),
+    registration: { open, run, close, ...(attach === undefined ? {} : { attach }), ...(cancel === undefined ? {} : { cancel }), ...(detach === undefined ? {} : { detach }) },
+    ...(callbacks === undefined ? {} : { callbacks }),
+    providers: Object.freeze({ ...providers }),
+    ...(esmHost === undefined ? {} : { esmHost }),
+  };
 }
 
 export function installExtensionIdentity(factory: unknown, name: string, artifact?: URL | Uint8Array, runtimeName?: string): void {

--- a/packages/brain-sdk/src/host.ts
+++ b/packages/brain-sdk/src/host.ts
@@ -1,0 +1,189 @@
+import { CapabilityError, type CapabilityHandles, type GrantSet } from "./capabilities.js";
+import type { CapabilityName, Outcome } from "./types.js";
+
+/**
+ * The SDK-owned host runtime for provisioned ESM tools. An environment opts in
+ * with one line (`host.esm()`); this module owns the dirty work — the payload
+ * cache, provision-time validation, handle wiring, and mapping every result to
+ * the one Outcome envelope — so environment authors never write it.
+ */
+
+/** A `tool/v1` manifest as `brain build` emits it — the only thing the host
+ * (and Brain) reads about a tool. */
+export interface ProvisionedToolManifest {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: Readonly<Record<string, unknown>>;
+  readonly output_schema?: Readonly<Record<string, unknown>>;
+  readonly requires: readonly CapabilityName[];
+  readonly binding_names: readonly string[];
+  readonly hosting?: "provisioned" | "callback";
+  readonly payload?: { readonly kind: "esm" | "component"; readonly identity: string };
+}
+
+/** The build artifact: manifest plus the self-contained single-file ESM bundle
+ * whose sha-256 is the manifest's payload identity. */
+export interface ProvisionedToolArtifact {
+  readonly manifest: ProvisionedToolManifest;
+  readonly payload: string;
+}
+
+/** What a provisioned ESM bundle default-exports (`provisionedToolRuntime`
+ * builds it). `parseInput` validates against the tool's own schema — the same
+ * schema the manifest was generated from; `run` executes with the typed
+ * context the host wires. */
+export interface ProvisionedToolModule {
+  readonly kind: "brain.provisioned-tool/v1";
+  initialize?(context: { readonly signal: AbortSignal; readonly requestId: string }): void | Promise<void>;
+  parseInput(input: unknown): unknown;
+  run(input: unknown, context: object): unknown | Promise<unknown>;
+}
+
+export async function payloadIdentity(payload: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(payload));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/** Caches provisioned payloads by content identity: each payload is imported
+ * and validated once per process, so a broken bundle fails the provision
+ * receipt at attach, never the first model call. */
+export class EsmToolHost {
+  private readonly artifacts = new Map<string, ProvisionedToolArtifact>();
+  private readonly provisioned = new Map<string, Promise<ProvisionedToolModule>>();
+
+  register(artifact: ProvisionedToolArtifact): void {
+    const identity = artifact?.manifest?.payload?.identity;
+    if (typeof artifact?.payload !== "string" || typeof identity !== "string" || !/^[0-9a-f]{64}$/u.test(identity)) {
+      throw new TypeError("an ESM tool artifact needs a payload and its manifest's payload identity");
+    }
+    if (artifact.manifest.payload?.kind !== "esm") throw new TypeError("only esm payloads can be hosted by host.esm");
+    this.artifacts.set(identity, artifact);
+  }
+
+  /** Resolve one attach provision to its loaded module, importing and
+   * initializing the bundle on first use. A rejection is forgotten so a later
+   * attach may retry. */
+  async provision(identity: string, context: { readonly signal: AbortSignal; readonly requestId: string }): Promise<ProvisionedToolModule> {
+    const artifact = this.artifacts.get(identity);
+    if (artifact === undefined) throw new Error(`no ESM payload is registered for identity ${identity}`);
+    let pending = this.provisioned.get(identity);
+    if (pending === undefined) {
+      pending = this.load(artifact, identity, context);
+      this.provisioned.set(identity, pending);
+      pending.catch(() => this.provisioned.delete(identity));
+    }
+    return pending;
+  }
+
+  private async load(artifact: ProvisionedToolArtifact, identity: string, context: { readonly signal: AbortSignal; readonly requestId: string }): Promise<ProvisionedToolModule> {
+    if ((await payloadIdentity(artifact.payload)) !== identity) throw new Error(`payload for ${artifact.manifest.name} does not match its declared identity`);
+    // Trusted-artifact assumption, v1: the bundle is imported into the
+    // environment server's own process. Payload identity is checked above and
+    // the kernel admits artifacts, but there is no worker/vm confinement yet —
+    // handles are direct in-process closures over the environment's providers,
+    // and an RPC layer to carry them across a worker boundary is not worth its
+    // weight until an untrusted-tool story needs it.
+    const loaded = (await import(`data:text/javascript;charset=utf-8,${encodeURIComponent(artifact.payload)}`)) as { readonly default?: unknown };
+    const module = loaded.default as ProvisionedToolModule | undefined;
+    if (module?.kind !== "brain.provisioned-tool/v1" || typeof module.parseInput !== "function" || typeof module.run !== "function") {
+      throw new Error(`payload for ${artifact.manifest.name} is not a provisioned tool bundle`);
+    }
+    await module.initialize?.(context);
+    return module;
+  }
+}
+
+/** Wrap providers into the handles a tool receives: same interface, with every
+ * thrown failure surfaced as a typed CapabilityError. */
+export function capabilityHandles(requires: readonly CapabilityName[], providers: Readonly<Partial<CapabilityHandles>>): Readonly<Partial<CapabilityHandles>> {
+  const handles: Record<string, unknown> = {};
+  for (const capability of requires) {
+    const provider = providers[capability] as Readonly<Record<string, unknown>> | undefined;
+    if (provider === undefined) throw new Error(`this environment does not provide the ${capability} capability`);
+    const handle: Record<string, unknown> = {};
+    for (const [name, member] of Object.entries(provider)) {
+      if (typeof member !== "function") continue;
+      handle[name] = async (...args: readonly unknown[]) => {
+        try {
+          return await (member as (...values: readonly unknown[]) => unknown).apply(provider, [...args]);
+        } catch (error) {
+          if (error instanceof CapabilityError) throw error;
+          throw new CapabilityError(capability, "capability_error", String(error instanceof Error ? error.message : error).slice(0, 4096));
+        }
+      };
+    }
+    handles[capability] = Object.freeze(handle);
+  }
+  return Object.freeze(handles) as Readonly<Partial<CapabilityHandles>>;
+}
+
+export interface HostedInvocation {
+  readonly callId: string;
+  readonly input: unknown;
+  readonly deadlineMs: number;
+  readonly signal: AbortSignal;
+  readonly handles: Readonly<Partial<CapabilityHandles>>;
+  readonly bindings: Readonly<Record<string, string>>;
+}
+
+/** Run one hosted invocation and resolve to exactly one Outcome: input that
+ * fails the tool's schema is an `invalid_input` error, a thrown error keeps an
+ * identifier-shaped `code` (CapabilityErrors included), the caller-owned
+ * deadline maps to `timeout`, and a cancelled operation maps to `cancelled`. */
+export async function invokeProvisioned(module: ProvisionedToolModule, invocation: HostedInvocation): Promise<Outcome> {
+  let input: unknown;
+  try {
+    input = module.parseInput(invocation.input);
+  } catch (error) {
+    return { status: "error", error: { code: "invalid_input", message: messageOf(error) } };
+  }
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort(new Error("tool deadline exceeded"));
+  }, invocation.deadlineMs);
+  const onCancel = () => controller.abort(invocation.signal.reason);
+  invocation.signal.addEventListener("abort", onCancel, { once: true });
+  if (invocation.signal.aborted) onCancel();
+  const context = Object.freeze({
+    ...invocation.handles,
+    bindings: Object.freeze({ ...invocation.bindings }),
+    signal: controller.signal,
+    deadline: new Date(Date.now() + invocation.deadlineMs),
+    callId: invocation.callId,
+    requestId: invocation.callId,
+    progress: () => {},
+  });
+  try {
+    const value = await Promise.race([Promise.resolve(module.run(input, context)), rejectOnAbort(controller.signal)]);
+    return { status: "ok", value: value ?? null };
+  } catch (error) {
+    if (timedOut) return { status: "timeout" };
+    if (invocation.signal.aborted) return { status: "cancelled" };
+    return { status: "error", error: { code: codeOf(error), message: messageOf(error) } };
+  } finally {
+    clearTimeout(timer);
+    invocation.signal.removeEventListener("abort", onCancel);
+  }
+}
+
+/** Resolves never, rejects on abort — so a tool that ignores its signal still
+ * yields the invoke slot at the deadline (it keeps running in the background;
+ * see the trusted-artifact note above). */
+function rejectOnAbort(signal: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal.aborted) reject(reasonOf(signal));
+    else signal.addEventListener("abort", () => reject(reasonOf(signal)), { once: true });
+  });
+}
+function reasonOf(signal: AbortSignal): unknown {
+  return signal.reason instanceof Error ? signal.reason : new Error(String(signal.reason ?? "aborted"));
+}
+function codeOf(error: unknown): string {
+  const code = (error as { readonly code?: unknown } | null)?.code;
+  return typeof code === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(code) ? code : "tool_error";
+}
+function messageOf(error: unknown): string {
+  return String(error instanceof Error ? error.message : error).slice(0, 4096);
+}

--- a/packages/brain-sdk/src/index.ts
+++ b/packages/brain-sdk/src/index.ts
@@ -1,6 +1,6 @@
 export { BrainClient as Brain, BrainClient, SessionHandle, Sessions } from "./client.js";
 export type { BrainOptions } from "./client.js";
-export { activateAgentloop, agentloop, appTool, createEnvironmentHandler, environment, executeTool, installExtensionIdentity, tool } from "./extensions.js";
+export { activateAgentloop, agentloop, appTool, createEnvironmentHandler, environment, executeTool, installExtensionIdentity, provisionedToolRuntime, tool } from "./extensions.js";
 export type {
   AgentloopAction,
   AgentloopAuthor,
@@ -16,11 +16,33 @@ export type {
   ToolAuthor,
   ToolCall,
   ToolContract,
+  ToolRunContext,
 } from "./extensions.js";
 export { appTools } from "./app.js";
 export type { AppToolCall, AppToolChannel, AppToolContract, AppToolServer, AppTools, CallbackToolManifest } from "./app.js";
 export type { CallbackRoute } from "./callbacks.js";
-export type { Outcome } from "./callback-wire.js";
+export { CapabilityError, clamp } from "./capabilities.js";
+export type {
+  CapabilityHandles,
+  CapabilityProviderFactory,
+  ConsoleEntry,
+  ExecGrant,
+  ExecHandle,
+  ExecOptions,
+  ExecResult,
+  FsEntry,
+  FsGrant,
+  FsHandle,
+  GrantSet,
+  JsHandle,
+  NetFetchRequest,
+  NetFetchResponse,
+  NetGrant,
+  NetHandle,
+  PageHandle,
+  PageInput,
+} from "./capabilities.js";
+export type { ProvisionedToolArtifact, ProvisionedToolManifest, ProvisionedToolModule } from "./host.js";
 export { BrainError } from "./errors.js";
 export type {
   Agentloop,
@@ -38,6 +60,7 @@ export type {
   ModelStopReason,
   ModelUsage,
   OperationOptions,
+  Outcome,
   Schema,
   SchemaInput,
   SchemaOutput,

--- a/packages/brain-sdk/src/types.ts
+++ b/packages/brain-sdk/src/types.ts
@@ -30,6 +30,15 @@ export interface ToolDefinition {
  * Growth is a contract release, not an author convention. */
 export type CapabilityName = "exec" | "fs" | "net" | "js" | "page";
 
+/** The one envelope every capability call and tool invocation resolves to.
+ * `timeout` is the caller-owned deadline firing — distinguished, never an exit
+ * code. */
+export type Outcome<Value = unknown> =
+  | { readonly status: "ok"; readonly value: Value }
+  | { readonly status: "error"; readonly error: { readonly code: string; readonly message: string; readonly details?: unknown } }
+  | { readonly status: "timeout" }
+  | { readonly status: "cancelled" };
+
 export type { KnownProviderId } from "./generated/providers.js";
 import type { KnownProviderId } from "./generated/providers.js";
 

--- a/packages/brain-sdk/test/capability.test.mjs
+++ b/packages/brain-sdk/test/capability.test.mjs
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { z } from "zod";
+import { CapabilityError, clamp, createEnvironmentHandler, environment } from "../dist/index.js";
+import { build, unusedRequiresWarnings } from "../dist/build.js";
+
+const identityOf = (payload) => createHash("sha256").update(payload).digest("hex");
+const artifactOf = (name, payload, { requires = [], binding_names = [] } = {}) => ({
+  manifest: {
+    name,
+    description: "test tool",
+    input_schema: { type: "object" },
+    requires,
+    binding_names,
+    hosting: "provisioned",
+    payload: { kind: "esm", identity: identityOf(payload) },
+  },
+  payload,
+});
+const toolPayload = (members) => `export default { kind: "brain.provisioned-tool/v1", ${members} };`;
+
+let sequence = 0;
+const command = (request, attachment_id) => {
+  sequence += 1;
+  const id = `op_${sequence}`;
+  return {
+    contract: "environment/v2",
+    binding: {},
+    operation: { operation_id: id, request_identity: id.padEnd(64, "a"), environment_id: "env_1", session_id: "ses_test", ...(attachment_id === undefined ? {} : { attachment_id }), request },
+  };
+};
+const attachRequest = (provisions, overrides = {}) => ({
+  type: "attach",
+  grants: { exec: { timeout_ms_max: 1_000 }, fs: { root: "/workspace" } },
+  provisions,
+  bindings: { API_BASE: "https://api.internal" },
+  ...overrides,
+});
+const invokeRequest = (tool, input, deadline_ms = 5_000) => ({ type: "invoke", call_id: `call_${sequence}`, tool, input, deadline_ms });
+
+function hostingEnvironment(artifacts) {
+  const definition = environment((author) => {
+    const box = author.open(async () => ({}));
+    box.run(async () => undefined);
+    box.close(async () => undefined);
+    box.provide.exec(({ grants }) => ({
+      run: async (cmd, opts) => ({ exitCode: 0, stdout: JSON.stringify(clamp(opts, grants.exec)), stderr: cmd }),
+    }));
+    box.provide.fs(({ grants }) => ({
+      read: async (path) => new TextEncoder().encode(clamp.path(grants.fs.root, path)),
+      write: async (path) => void clamp.path(grants.fs.root, path),
+      list: async () => [],
+    }));
+    box.host.esm({ artifacts });
+    return {};
+  });
+  return createEnvironmentHandler(definition);
+}
+
+test("clamp bounds exec options against the grant", () => {
+  assert.deepEqual(clamp({ timeoutMs: 999_999 }, { timeout_ms_max: 1_000 }), { timeoutMs: 1_000 });
+  assert.deepEqual(clamp({ timeoutMs: 5 }, { timeout_ms_max: 1_000 }), { timeoutMs: 5 });
+  assert.deepEqual(clamp(undefined, { timeout_ms_max: 1_000 }), { timeoutMs: 1_000 });
+  assert.deepEqual(clamp({ cwd: "/x" }, undefined), { cwd: "/x" });
+});
+
+test("clamp.path confines resolved paths to the granted root", () => {
+  assert.equal(clamp.path("/workspace", "a/b.txt"), "/workspace/a/b.txt");
+  assert.equal(clamp.path("/workspace", "a/../b.txt"), "/workspace/b.txt");
+  assert.equal(clamp.path("/workspace", "/workspace/a"), "/workspace/a");
+  assert.equal(clamp.path("/workspace/", "."), "/workspace");
+  for (const escape of ["../secret", "a/../../secret", "/etc/passwd", "/workspacefake/a"]) {
+    assert.throws(() => clamp.path("/workspace", escape), (error) => error instanceof CapabilityError && error.capability === "fs" && error.code === "path_escape");
+  }
+});
+
+test("setup and attach receipts report what the environment provides", async () => {
+  const handle = hostingEnvironment([]);
+  const setup = await handle(command({ type: "setup", configuration: {} }));
+  assert.equal(setup.receipt.type, "accepted");
+  assert.deepEqual(setup.receipt.provides, ["exec", "fs"]);
+  const attached = await handle(command(attachRequest([]), "att_1"));
+  assert.equal(attached.receipt.type, "accepted");
+  assert.deepEqual(attached.receipt.provides, ["exec", "fs"]);
+});
+
+test("hosts a provisioned tool: happy path with clamped grants and injected bindings", async () => {
+  const payload = toolPayload(`
+    parseInput(input) { if (typeof input.command !== "string") throw new Error("command must be a string"); return input; },
+    async run(input, context) {
+      const result = await context.exec.run(input.command, { timeoutMs: 999_999_999 });
+      return { exit: result.exitCode, opts: JSON.parse(result.stdout), base: context.bindings.API_BASE, callId: context.callId };
+    }`);
+  const artifact = artifactOf("echo", payload, { requires: ["exec"], binding_names: ["API_BASE"] });
+  const handle = hostingEnvironment([artifact]);
+  await handle(command({ type: "setup", configuration: {} }));
+  const attached = await handle(command(attachRequest([{ manifest: artifact.manifest, payload_identity: artifact.manifest.payload.identity }]), "att_1"));
+  assert.equal(attached.receipt.type, "accepted");
+  const invoked = await handle(command(invokeRequest("echo", { command: "run it" }), "att_1"));
+  assert.equal(invoked.receipt.type, "outcome");
+  assert.equal(invoked.receipt.outcome.status, "ok");
+  assert.deepEqual(invoked.receipt.outcome.value.opts, { timeoutMs: 1_000 }, "the provider clamps the requested timeout to the grant");
+  assert.equal(invoked.receipt.outcome.value.base, "https://api.internal");
+  assert.equal(invoked.receipt.outcome.value.exit, 0);
+
+  const invalid = await handle(command(invokeRequest("echo", { command: 7 }), "att_1"));
+  assert.equal(invalid.receipt.outcome.status, "error");
+  assert.equal(invalid.receipt.outcome.error.code, "invalid_input");
+});
+
+test("maps thrown errors, deadlines, and fs escapes onto the outcome envelope", async () => {
+  const throwing = artifactOf("boom", toolPayload(`
+    parseInput(input) { return input; },
+    async run() { throw Object.assign(new Error("kaboom"), { code: "boom_code" }); }`));
+  const slow = artifactOf("slow", toolPayload(`
+    parseInput(input) { return input; },
+    async run(input, context) { await new Promise((_, reject) => context.signal.addEventListener("abort", () => reject(context.signal.reason))); }`));
+  const reader = artifactOf("reader", toolPayload(`
+    parseInput(input) { return input; },
+    async run(input, context) { return new TextDecoder().decode(await context.fs.read(input.path)); }`), { requires: ["fs"] });
+  const handle = hostingEnvironment([throwing, slow, reader]);
+  await handle(command({ type: "setup", configuration: {} }));
+  const provisions = [throwing, slow, reader].map((artifact) => ({ manifest: artifact.manifest, payload_identity: artifact.manifest.payload.identity }));
+  assert.equal((await handle(command(attachRequest(provisions), "att_1"))).receipt.type, "accepted");
+
+  const thrown = await handle(command(invokeRequest("boom", {}), "att_1"));
+  assert.deepEqual(thrown.receipt.outcome, { status: "error", error: { code: "boom_code", message: "kaboom" } });
+
+  const timedOut = await handle(command(invokeRequest("slow", {}, 25), "att_1"));
+  assert.deepEqual(timedOut.receipt.outcome, { status: "timeout" }, "the caller-owned deadline is a distinguished outcome");
+
+  const inside = await handle(command(invokeRequest("reader", { path: "notes/a.txt" }), "att_1"));
+  assert.deepEqual(inside.receipt.outcome, { status: "ok", value: "/workspace/notes/a.txt" });
+  const escape = await handle(command(invokeRequest("reader", { path: "../etc/passwd" }), "att_1"));
+  assert.equal(escape.receipt.outcome.status, "error");
+  assert.equal(escape.receipt.outcome.error.code, "path_escape", "a CapabilityError keeps its code through the outcome");
+});
+
+test("a broken or unsatisfiable provision fails the attach receipt, not the first call", async () => {
+  const broken = artifactOf("broken", `throw new Error("broken at import");`);
+  const wantsPage = artifactOf("pager", toolPayload(`parseInput(input) { return input; }, async run() { return null; }`), { requires: ["page"] });
+  const needsToken = artifactOf("secretive", toolPayload(`parseInput(input) { return input; }, async run() { return null; }`), { binding_names: ["TOKEN"] });
+  const handle = hostingEnvironment([broken, wantsPage, needsToken]);
+  await handle(command({ type: "setup", configuration: {} }));
+
+  const provisionOf = (artifact) => [{ manifest: artifact.manifest, payload_identity: artifact.manifest.payload.identity }];
+  const brokenAttach = await handle(command(attachRequest(provisionOf(broken)), "att_1"));
+  assert.equal(brokenAttach.receipt.type, "failure");
+
+  const missingCapability = await handle(command(attachRequest(provisionOf(wantsPage)), "att_2"));
+  assert.equal(missingCapability.receipt.type, "failure");
+  assert.match(missingCapability.receipt.message, /requires page/u);
+
+  const missingBinding = await handle(command(attachRequest(provisionOf(needsToken)), "att_3"));
+  assert.equal(missingBinding.receipt.type, "failure");
+  assert.match(missingBinding.receipt.message, /binding TOKEN/u);
+
+  const unknownIdentity = await handle(command(attachRequest([{ manifest: broken.manifest, payload_identity: "e".repeat(64) }]), "att_4"));
+  assert.equal(unknownIdentity.receipt.type, "failure");
+  assert.match(unknownIdentity.receipt.message, /no ESM payload/u);
+
+  // The failed attaches leave nothing usable behind.
+  const invoked = await handle(command(invokeRequest("broken", {}), "att_1"));
+  assert.equal(invoked.receipt.type, "failure");
+});
+
+test("environments without host.esm keep provisions on their own run handler", async () => {
+  const bare = environment((author) => {
+    const box = author.open(async () => ({}));
+    box.run(async (request) => ({ echoed: request.input }));
+    box.close(async () => undefined);
+    return {};
+  });
+  const handle = createEnvironmentHandler(bare);
+  await handle(command({ type: "setup", configuration: {} }));
+  // No SDK hosting here, so the provision is tolerated and its invocations run
+  // through the environment's own run handler — the legacy runtime path.
+  const artifact = artifactOf("any", toolPayload(`parseInput(input) { return input; }, async run() { return null; }`));
+  assert.equal((await handle(command(attachRequest([{ manifest: artifact.manifest, payload_identity: artifact.manifest.payload.identity }]), "att_1"))).receipt.type, "accepted");
+  const provisioned = await handle(command(invokeRequest("any", { y: 2 }), "att_1"));
+  assert.deepEqual(provisioned.receipt.outcome, { status: "ok", value: { echoed: { y: 2 } } });
+
+  assert.equal((await handle(command(attachRequest([]), "att_2"))).receipt.type, "accepted");
+  const invoked = await handle(command(invokeRequest("legacy", { x: 1 }), "att_2"));
+  assert.deepEqual(invoked.receipt.outcome, { status: "ok", value: { echoed: { x: 1 } } });
+});
+
+test("unused-requires stays a warning keyed on handle appearance", () => {
+  assert.deepEqual(unusedRequiresWarnings("t", ["exec"], "await context.exec.run(x)"), []);
+  assert.deepEqual(unusedRequiresWarnings("t", ["fs"], "const { fs } = context;"), []);
+  const warned = unusedRequiresWarnings("t", ["exec", "fs"], `tool({ requires: ["exec", "fs"] }); context.exec.run(x);`);
+  assert.equal(warned.length, 1);
+  assert.match(warned[0], /"fs"/u);
+});
+
+test("an undeclared capability does not type-check", async () => {
+  const fixture = fileURLToPath(new URL("./fixtures/capability-typing.ts", import.meta.url));
+  const compiler = fileURLToPath(import.meta.resolve("typescript/bin/tsc"));
+  const args = [compiler, fixture, "--noEmit", "--strict", "--skipLibCheck", "--target", "es2023", "--module", "nodenext", "--moduleResolution", "nodenext"];
+  const { code, output } = await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout.on("data", (chunk) => { output += chunk; });
+    child.stderr.on("data", (chunk) => { output += chunk; });
+    child.once("error", reject);
+    child.once("exit", (code) => resolve({ code, output }));
+  });
+  assert.equal(code, 0, `the typing fixture must compile with its @ts-expect-error assertions:\n${output}`);
+});
+
+test("brain build emits the tool artifact: golden manifest, content identity, unused warning", async () => {
+  const out = await mkdtemp(join(tmpdir(), "brain-sdk-artifact-"));
+  try {
+    const entry = fileURLToPath(new URL("./fixtures/provisioned-entry.mjs", import.meta.url));
+    const built = await build({ entry, out });
+    const bash = built.find((extension) => extension.name === "bash");
+    const idle = built.find((extension) => extension.name === "idle");
+    assert.equal(bash.kind, "tool");
+    assert.equal(bash.warnings, undefined, "a used capability does not warn");
+    assert.equal(idle.warnings.length, 1);
+    assert.match(idle.warnings[0], /"fs"/u);
+
+    const artifact = JSON.parse(await readFile(join(out, bash.artifact), "utf8"));
+    assert.deepEqual(artifact.manifest, {
+      name: "bash",
+      description: "Run a shell command in the session workspace.",
+      input_schema: z.toJSONSchema(z.object({ command: z.string(), timeout_ms: z.number().int().optional() })),
+      output_schema: z.toJSONSchema(z.object({ exit_code: z.number(), stdout: z.string(), stderr: z.string() })),
+      requires: ["exec"],
+      binding_names: ["API_BASE"],
+      hosting: "provisioned",
+      payload: { kind: "esm", identity: identityOf(artifact.payload) },
+    });
+    assert.equal(bash.identity, artifact.manifest.payload.identity);
+
+    // The emitted artifact runs end to end on a hosting environment.
+    const handle = hostingEnvironment([artifact]);
+    await handle(command({ type: "setup", configuration: {} }));
+    const attached = await handle(command(attachRequest([{ manifest: artifact.manifest, payload_identity: artifact.manifest.payload.identity }]), "att_1"));
+    assert.equal(attached.receipt.type, "accepted");
+    const invoked = await handle(command(invokeRequest("bash", { command: "echo hi" }), "att_1"));
+    assert.equal(invoked.receipt.outcome.status, "ok");
+    const value = invoked.receipt.outcome.value;
+    assert.equal(value.exit_code, 0);
+    assert.deepEqual(JSON.parse(value.stdout), { timeoutMs: 1_000 }, "grants clamp the tool's requested timeout");
+    assert.equal(value.stderr, "echo hi # https://api.internal", "binding values reach the tool at runtime");
+  } finally {
+    await rm(out, { recursive: true, force: true });
+  }
+});

--- a/packages/brain-sdk/test/fixtures/capability-typing.ts
+++ b/packages/brain-sdk/test/fixtures/capability-typing.ts
@@ -1,0 +1,44 @@
+/**
+ * Compile-time fixture for the provisioned tool context: the run context is
+ * derived from `requires` (an undeclared capability must not type-check) and
+ * from the `bindings` schemas. Compiled by test/capability.test.mjs with
+ * `tsc --noEmit`; every `@ts-expect-error` line asserts a required error.
+ */
+import { tool } from "../../dist/index.js";
+import { z } from "zod";
+
+export const declared = tool({
+  description: "Uses only what it declares.",
+  input: z.object({ command: z.string() }),
+  output: z.object({ exit_code: z.number() }),
+  requires: ["exec", "fs"],
+  bindings: { API_BASE: z.string() },
+}, (author) => {
+  author.run(async (input, context) => {
+    const result = await context.exec.run(input.command, { timeoutMs: 1_000 });
+    await context.fs.write("out.txt", result.stdout);
+    const base: string = context.bindings.API_BASE;
+    void base;
+    void context.signal;
+    void context.deadline;
+    void context.callId;
+    // @ts-expect-error net is not declared in requires
+    void context.net;
+    // @ts-expect-error page is not declared in requires
+    void context.page;
+    // @ts-expect-error MISSING is not a declared binding
+    void context.bindings.MISSING;
+    return { exit_code: result.exitCode };
+  });
+});
+
+export const undeclared = tool({
+  description: "Declares nothing.",
+  input: z.object({}),
+}, (author) => {
+  author.run(async (_input, context) => {
+    // @ts-expect-error exec is not declared in requires
+    void context.exec;
+    return null;
+  });
+});

--- a/packages/brain-sdk/test/fixtures/provisioned-entry.mjs
+++ b/packages/brain-sdk/test/fixtures/provisioned-entry.mjs
@@ -1,0 +1,24 @@
+// Build fixture for the provisioned-tool artifact golden test.
+import { tool } from "@aexhq/brain";
+import { z } from "zod";
+
+export const bash = tool({
+  description: "Run a shell command in the session workspace.",
+  input: z.object({ command: z.string(), timeout_ms: z.number().int().optional() }),
+  output: z.object({ exit_code: z.number(), stdout: z.string(), stderr: z.string() }),
+  requires: ["exec"],
+  bindings: { API_BASE: z.string() },
+}, (author) => {
+  author.run(async (input, context) => {
+    const result = await context.exec.run(`${input.command} # ${context.bindings.API_BASE}`, { timeoutMs: input.timeout_ms ?? 999_999_999 });
+    return { exit_code: result.exitCode, stdout: result.stdout, stderr: result.stderr };
+  });
+});
+
+export const idle = tool({
+  description: "Declares fs but never touches it.",
+  input: z.object({}),
+  requires: ["fs"],
+}, (author) => {
+  author.run(async () => null);
+});


### PR DESCRIPTION
The provisioned half of the capability contract (#119): typed tool authoring, environment capability providers, the tool artifact build, and the SDK-owned ESM host runtime.

## What

- **Typed tool authoring** — `tool({ ..., requires, bindings })` derives the run context type from the declaration (`Pick<CapabilityHandles, requires[number]>` plus schema-typed `bindings` values), so using an undeclared capability does not compile. Handle interfaces per the contract (`ExecHandle`, `FsHandle`, `NetHandle`, `JsHandle`, `PageHandle`) surface failures as typed `CapabilityError`s; grant policy stays invisible to tools.
- **Environment capability providers** — `provide.exec(...)`, `provide.fs(...)`, … register providers whose factory receives `{ instance, grants }`; the registered set becomes the `provides` list on the setup and attach receipts (replacing the hardcoded `provides: []`), feeding the kernel's `requires ⊆ provides` check. A shared `clamp` helper covers exec bounds (`clamp(opts, grants.exec)`) and fs-root confinement (`clamp.path` rejects any resolved path escaping the root with a `path_escape` CapabilityError).
- **Artifact build** — `brain build` emits `<name>.tool.json` per tool: the `tool/v1` manifest (schemas from zod, `requires`, `binding_names`, `hosting: "provisioned"`, payload identity = sha-256 of the bundle) plus the self-contained single-file ESM bundle. Binding values are structurally impossible in the artifact. Build warns — never errors — on a declared capability whose handle never appears in the authored code, checked against a dependencies-external bundle so capability names inside the SDK or third-party packages cannot mask it.
- **Host runtime** — `host.esm({ artifacts })` opts an environment into hosting. Payloads are cached by content identity and imported + `initialize`d once at provision, so a throwing bundle, an unprovided capability, or a missing binding value fails the attach receipt, never the first model call. At invoke the host validates input against the tool's schema (`invalid_input`), wires handles in-process to the environment's providers for exactly the tool's `requires`, injects binding values from attach, and maps result / thrown error (identifier-shaped `code` preserved) / deadline (`timeout`) / cancel (`cancelled`) onto the one Outcome envelope.

## Confinement choice

Plain `import()` of the bundle (data: URL) under a trusted-artifact assumption, stated in the code: worker/vm isolation would need an RPC layer to carry capability handles across the boundary, which is not worth its weight until an untrusted-tool story needs it. Payload identity is verified before import.

## Deviations from the interface draft

- `provide.*` and `host.esm()` hang off the object `author.open(...)` returns (alongside the existing `run`/`close`/`method`/`stream`), not the top-level author — that is where `Instance` is typed, so provider factories get a typed `instance`.
- The run context keeps `options`, `requestId` (alias of `callId`), `workspace?`, and `progress()` from the existing surface alongside the draft's handles/`bindings`/`signal`/`deadline`/`callId`.
- Payload bytes travel out of band: attach names payloads by identity per the wire contract, and `host.esm({ artifacts })` is how a process registers what it can serve.

## Tests

Type-level fixture compiled by `tsc` in-test (undeclared capability and undeclared binding fail via `@ts-expect-error`), provision-fail-at-attach (broken bundle, missing capability, missing binding, unknown identity), invoke happy path + input-validation failure + thrown error + deadline timeout, fs-root escape, exec clamp, unused-requires warning, and a manifest golden test that also runs the emitted artifact end to end on a hosting environment.

## Verification

`npm run gen` clean · `npm run build` · `npm test` green (SDK 17/17, examples build) · `cargo test --workspace --all-targets` green (no Rust changes).

Note: overlaps with the in-flight callback PR (`capability-callback-path`) in `extensions.ts`, `index.ts`, and `docs/concepts/tool.mdx`; whichever lands second needs a small merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
