### PR TITLE
docs: tighten the technical copy and give the quick start an in-process tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ OpenClaw   ███████████████████████
 <code>c7g.xlarge</code> with the same instant scripted model behind every subject; the LangGraph
 figures measure LangGraph Server, and Brain's first-token figure is an upper bound (its whole-turn
 median). Memory bars are log-scaled; Brain's is the marginal cost per additional idle session.
-<strong>°</strong> the project's own published figure, not measured by our harness — Cloudflare
-Agents' is a V8 isolate spawn on their cloud, Vertex AI Agent Engine's is its documented cold
-start, and Agno's are in-process agent instantiation with no server round trip.
+<strong>°</strong> the project's own published figure — Cloudflare Agents' is a V8 isolate spawn
+on their cloud, Vertex AI Agent Engine's is its documented cold start, and Agno's are
+in-process agent instantiation with no server round trip.
 <strong>†</strong> personal/local assistant runtimes — a different deployment model than a server
 runtime, kept for reference. Runtimes that publish no comparable figures (Letta, Mastra, Golem,
 Awaken, Restate, Temporal, AgentScope, VoltAgent, Julep, …) are absent until we measure them
@@ -106,43 +106,41 @@ ourselves. Methodology and the bounds CI enforces on every push are in
 ## How it works
 
 ```text
-your app ──── send (HTTP) ────►  [ brain runtime ]  ──── event feed (SSE), token by token ────► your app
+your app ──── send (HTTP) ────►  [ brain runtime ]  ──── event feed (SSE) ────► your app
 
 ┌───────────────────────────────────── inside one turn ────────────────────────────────────┐
 │                                                                                          │
-│  observation ──► agent loop ──► decision      a Wasm component, sealed: no network, no   │
-│                                               filesystem, no secrets, no clock — Brain   │
-│                                               performs every effect on its behalf, so    │
-│                                               any decision replays exactly               │
+│  observation ──► agent loop ──► decision      a secured, isolated Wasm component,        │
+│                                               with limited resources; every decision     │
+│                                               replays exactly from the log               │
 │                                                                                          │
-│  decision ──┬──► model call ──► provider      pinned per session; deltas stream          │
-│             │                                 straight through to the feed               │
+│  decision ──┬──► model call ──► provider      pinned per session; deltas streamed        │
+│             │                                 to the event feed as they arrive           │
 │             │                                                                            │
-│             └──► tool call ──► environment    plain HTTP: a microVM sandbox, a browser   │
-│                                               tab, your own backend — one session can    │
-│                                               span several at once                       │
+│             └──► tool call ──► environment    environments are where tools are           │
+│                                               executed, at your choice: browser,         │
+│                                               microVM sandbox, lambda, etc.              │
 │                                                                                          │
-│  every step ──► append-only journal           the write-ahead record, appended behind    │
-│                                               the turn; a restart rebuilds every         │
-│                                               session from it                            │
+│  every step ──► write-ahead log (WAL)         appended behind the turn; a restart        │
+│                                               rebuilds every session from it             │
 └──────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 Brain owns the session; the agent loop, model, tools, and environment are yours to supply. The
 speed comes from a handful of techniques most runtimes don't use:
 
-- **Sealed WebAssembly agent loops** — a loop compiles from any language to a component on
-  [Wasmtime](https://wasmtime.dev/), compiled once and activated per decision at native speed.
-  It gets no ambient capabilities — Brain performs every effect for it — which is what makes a
-  decision deterministic and replayable from its position in the journal.
-- **A write-ahead journal instead of a database** — the only durable state is an append-only
-  segment log, written behind the turn, off the hot path. Sessions are memory-resident and
-  rebuilt from the journal after a restart; a session interrupted mid-turn comes back with a
+- **Isolated WebAssembly agent loops** — a loop compiles from any language to a component on
+  [Wasmtime](https://wasmtime.dev/): secured, isolated, resource-limited, compiled once and
+  activated per decision at native speed. Brain performs every effect on the loop's behalf,
+  which makes each decision deterministic and replayable from its position in the log.
+- **Write-ahead log (WAL) persistence** — the runtime's only durable state is an append-only
+  write-ahead log, written behind the turn, off the hot path. Sessions are memory-resident and
+  rebuild from the WAL after a restart; a session interrupted mid-turn comes back with a
   `turn_interrupted` event and lets the client decide.
-- **Streaming with a bound, not a buffer** — a model delta reaches subscribers the moment the
-  provider emits it; nothing is accumulated per turn. The live feed rides a fixed 1,024-event
-  ring per subscriber, so a reader that falls behind drops (and is told how many it missed)
-  rather than slowing the turn — the journal is the record it re-reads.
+- **Bounded live streaming** — a model delta reaches subscribers the moment the provider emits
+  it. The live feed rides a fixed 1,024-event ring per subscriber; a reader that falls behind
+  drops, learns how many records it missed, and re-reads them from the WAL, so a slow consumer
+  can never slow a turn.
 - **Observability as the data model** — every observation, decision, model intent, token, and
   tool outcome is an event in one feed; watching live and reading history back are the same
   records, so tracing a session is replaying it.
@@ -157,89 +155,71 @@ the session API over [Axum](https://github.com/tokio-rs/axum) HTTP/SSE, with no 
 - **Built for low overhead** — memory-resident session state, appends behind the turn, ~14 KiB
   per idle session, 25 ms round trips. The numbers above are measured, and CI holds them.
 - **Bring your model, spawn your agents** — built-in bindings for 70+ LLM providers via
-  [models.dev](https://models.dev), sealed per session, and sessions that create sessions for
+  [models.dev](https://models.dev), pinned per session, and sessions that create sessions for
   subagent work.
-- **Sealed extension execution** — agent loops compile to WebAssembly and run in a standalone
-  runtime with no network, filesystem, secrets, or clock; Brain performs every effect.
+- **Isolated extension execution** — agent loops compile to WebAssembly and run in a
+  standalone, resource-limited runtime with no network, filesystem, secrets, or clock; Brain
+  performs every effect.
 - **Observable end to end** — every observation, decision, model intent, and tool result is an
-  event you can stream live or read back later, token by token while the turn runs.
+  event you can stream live or read back later while the turn runs.
 
 ## Quick start
 
-Give the agent a voice: its only tool lives in a browser tab, and it answers out loud through
-your speakers.
+The session's tool is a plain function in your own process: the model decides to call it, Brain
+dials the environment, and the environment routes the call back to your code.
 
 Run a server (host networking, so Brain can dial the environment on loopback — on Docker
 Desktop enable host networking in settings, or run the binary from the
 [Quickstart](https://aex.dev/brain/docs/quickstart)):
 
 ```sh
-docker run --rm --network host \
-  -e BRAIN_LISTEN=127.0.0.1:8080 \
-  -e BRAIN_ENVIRONMENT_BASE_URL=http://127.0.0.1:8787 \
-  -v brain-data:/var/lib/brain ghcr.io/aexhq/brain:latest
+docker run --rm --network host   -e BRAIN_LISTEN=127.0.0.1:8080   -e BRAIN_ENVIRONMENT_BASE_URL=http://127.0.0.1:8787   -v brain-data:/var/lib/brain ghcr.io/aexhq/brain:latest
 ```
 
 ```sh
 npm install @aexhq/brain @aexhq/agentloop-pi @aexhq/env-app zod
 ```
 
-Save as `talk.mjs` and run with `node talk.mjs`:
+Save as `order.mjs` and run with `node order.mjs`:
 
 ```js
 import { createServer } from "node:http";
-import { Brain, appTool, createEnvironmentHandler } from "@aexhq/brain";
+import { Brain, appTool, appTools, createEnvironmentHandler } from "@aexhq/brain";
 import { app } from "@aexhq/env-app";
 import { pi } from "@aexhq/agentloop-pi";
 import { z } from "zod";
 
-// The page: it holds an outbound WebSocket to the environment and answers
-// the `say` tool from inside the tab — with your speakers.
-const page = `<!doctype html><title>brain, out loud</title><body>🔊 This tab is a Brain environment.
-<script type="module">
-import { appTools } from "https://esm.sh/@aexhq/brain";
-import { z } from "https://esm.sh/zod@4";
-appTools.connect({ url: "ws://127.0.0.1:8787/environments/env_1/channel", token: "quickstart" })
-  .register(
-    { name: "say", description: "Speak out loud through the user's speakers.", input: z.object({ text: z.string() }) },
-    ({ text }) => { speechSynthesis.speak(new SpeechSynthesisUtterance(text)); return "spoken"; },
-  );
-</script>`;
+// The tool: one contract, one plain function, closing over your app's state.
+const orders = { "A-1001": { status: "shipped", eta: "Thursday" } };
+const lookupOrder = {
+  name: "lookup_order",
+  description: "Look up an order's status by id.",
+  input: z.object({ id: z.string() }),
+};
 
-// Host the environment beside the page: Brain POSTs operations here, the tab holds the channel.
+// Host the environment: Brain POSTs operations here, and the tool answers in-process.
 const handle = createEnvironmentHandler(app);
 const server = createServer(async (request, response) => {
-  if (request.method === "POST") {
-    let body = "";
-    for await (const chunk of request) body += chunk;
-    response.setHeader("content-type", "application/json");
-    return response.end(JSON.stringify(await handle(JSON.parse(body))));
-  }
-  response.setHeader("content-type", "text/html; charset=utf-8");
-  response.end(page);
+  let body = "";
+  for await (const chunk of request) body += chunk;
+  response.setHeader("content-type", "application/json");
+  response.end(JSON.stringify(await handle(JSON.parse(body))));
 });
 server.on("upgrade", (request, socket, head) => handle.channel.upgrade(request, socket, head));
 server.listen(8787, "127.0.0.1");
 
+appTools
+  .connect({ url: "ws://127.0.0.1:8787/environments/env_1/channel", token: "quickstart" })
+  .register(lookupOrder, ({ id }) => orders[id] ?? { status: "unknown order" });
+
 const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });
-const channel = app({ channelToken: "quickstart" });
 const session = await brain.sessions.create({
   model: { provider: "openai", name: "gpt-5-mini", apiKey: process.env.OPENAI_API_KEY },
   agentloop: pi(),
-  tools: [
-    appTool({
-      name: "say",
-      description: "Speak out loud through the user's speakers.",
-      input: z.object({ text: z.string() }),
-    }).useIn(channel),
-  ],
-  system: "You can speak out loud. Answer by saying it.",
+  tools: [appTool(lookupOrder).useIn(app({ channelToken: "quickstart" }))],
 });
 
-console.log("Open http://127.0.0.1:8787 in a browser, sound on, then press Enter.");
-await new Promise((resolve) => process.stdin.once("data", resolve));
-
-await session.send("Introduce yourself out loud, in one sentence.");
+await session.send("Where is order A-1001?");
 for await (const event of session.events()) console.log(event.sequence, event.type);
 
 await session.end();
@@ -247,17 +227,17 @@ await session.delete();
 process.exit(0);
 ```
 
-That's a session whose only tool runs in a browser tab: the Node script hosts the environment and
-serves the page, the tab connects out over a WebSocket and registers `say`, Brain routes the
-model's tool call down the channel — and the answer comes out of your speakers while the event
-feed streams in the terminal.
+The model reads the question, calls `lookup_order`, and your function answers from the `orders`
+object beside it — the whole exchange lands in the event feed, tool call and result included.
+The same channel works from a browser page or anything behind NAT, and provisioned tools ship
+their code into a sandbox environment the same way.
 
 ## Roadmap
 
 - [x] The four-part runtime: agent loop, model, tools, environment
 - [x] Unified `brain`, `tool`, and `environment` authoring with `brain build`
 - [x] Append-only segment log with restart recovery
-- [x] Content identity as a type rather than a digest string
+- [x] Typed content identity
 - [x] HTTP/SSE session API and the `@aexhq/brain` SDK
 - [x] Remote environment contract with `env-app` and `env-aws-microvm`
 - [ ] Cross-session isolation test
@@ -271,5 +251,6 @@ feed streams in the terminal.
 
 ## Contact
 
-Questions, ideas, or something broken? Open an [issue](https://github.com/aexhq/brain/issues) or
-write to [admin@aex.dev](mailto:admin@aex.dev).
+Support and bug reports: open an [issue](https://github.com/aexhq/brain/issues) or write to
+[support@aex.dev](mailto:support@aex.dev). Collaboration and partnerships:
+[admin@aex.dev](mailto:admin@aex.dev).

--- a/README.md
+++ b/README.md
@@ -90,17 +90,10 @@ ZeroClaw   █████████████████████      
 OpenClaw   ██████████████████████████████     490 MiB †
 ```
 
-<sub>Medians measured by the harness in <a href="tools/bench">tools/bench</a> on an AWS
-<code>c7g.xlarge</code> with the same instant scripted model behind every subject; the LangGraph
-figures measure LangGraph Server, and Brain's first-token figure is an upper bound (its whole-turn
-median). Memory bars are log-scaled; Brain's is the marginal cost per additional idle session.
-<strong>°</strong> the project's own published figure — Cloudflare Agents' is a V8 isolate spawn
-on their cloud, Vertex AI Agent Engine's is its documented cold start, and Agno's are
-in-process agent instantiation with no server round trip.
-<strong>†</strong> personal/local assistant runtimes — a different deployment model than a server
-runtime, kept for reference. Runtimes that publish no comparable figures (Letta, Mastra, Golem,
-Awaken, Restate, Temporal, AgentScope, VoltAgent, Julep, …) are absent until we measure them
-ourselves. Methodology and the bounds CI enforces on every push are in
+<sub>Medians from the harness in <a href="tools/bench">tools/bench</a> on an AWS
+<code>c7g.xlarge</code>. Brain's first-token figure is an upper bound (its whole-turn median);
+memory bars are log-scaled. <strong>°</strong> a project's own published figure.
+<strong>†</strong> personal/local assistant runtimes. Methodology and the bounds CI enforces:
 <a href="BENCHMARKS.md">BENCHMARKS.md</a>.</sub>
 
 ## How it works

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Run a Brain server and give a session a voice — its only tool lives in a browser tab.
+description: Run a Brain server and give a session a tool that answers from your own process.
 ---
 
 ## Run a server
@@ -28,71 +28,55 @@ BRAIN_ENVIRONMENT_BASE_URL=http://127.0.0.1:8787 \
 Brain listens on loopback and needs no token there. Set `BRAIN_API_TOKEN` to listen anywhere else —
 it refuses to start on a non-loopback address without one.
 
-## Give the agent a voice
+## Give the agent a tool
 
-The session's only tool runs in a browser tab: the page holds an outbound WebSocket to the
-environment and answers the model's `say` call with your speakers.
+The session's tool is a plain function in your own process: the model decides to call it,
+Brain dials the environment, and the environment routes the call back to your code.
 
 ```sh
 npm install @aexhq/brain @aexhq/agentloop-pi @aexhq/env-app zod
 ```
 
-Save as `talk.mjs` and run with `node talk.mjs`:
+Save as `order.mjs` and run with `node order.mjs`:
 
 ```js
 import { createServer } from "node:http";
-import { Brain, appTool, createEnvironmentHandler } from "@aexhq/brain";
+import { Brain, appTool, appTools, createEnvironmentHandler } from "@aexhq/brain";
 import { app } from "@aexhq/env-app";
 import { pi } from "@aexhq/agentloop-pi";
 import { z } from "zod";
 
-// The page: it holds an outbound WebSocket to the environment and answers
-// the `say` tool from inside the tab — with your speakers.
-const page = `<!doctype html><title>brain, out loud</title><body>🔊 This tab is a Brain environment.
-<script type="module">
-import { appTools } from "https://esm.sh/@aexhq/brain";
-import { z } from "https://esm.sh/zod@4";
-appTools.connect({ url: "ws://127.0.0.1:8787/environments/env_1/channel", token: "quickstart" })
-  .register(
-    { name: "say", description: "Speak out loud through the user's speakers.", input: z.object({ text: z.string() }) },
-    ({ text }) => { speechSynthesis.speak(new SpeechSynthesisUtterance(text)); return "spoken"; },
-  );
-</script>`;
+// The tool: one contract, one plain function, closing over your app's state.
+const orders = { "A-1001": { status: "shipped", eta: "Thursday" } };
+const lookupOrder = {
+  name: "lookup_order",
+  description: "Look up an order's status by id.",
+  input: z.object({ id: z.string() }),
+};
 
-// Host the environment beside the page: Brain POSTs operations here, the tab holds the channel.
+// Host the environment: Brain POSTs operations here, and the tool answers in-process.
 const handle = createEnvironmentHandler(app);
 const server = createServer(async (request, response) => {
-  if (request.method === "POST") {
-    let body = "";
-    for await (const chunk of request) body += chunk;
-    response.setHeader("content-type", "application/json");
-    return response.end(JSON.stringify(await handle(JSON.parse(body))));
-  }
-  response.setHeader("content-type", "text/html; charset=utf-8");
-  response.end(page);
+  let body = "";
+  for await (const chunk of request) body += chunk;
+  response.setHeader("content-type", "application/json");
+  response.end(JSON.stringify(await handle(JSON.parse(body))));
 });
 server.on("upgrade", (request, socket, head) => handle.channel.upgrade(request, socket, head));
 server.listen(8787, "127.0.0.1");
 
+appTools
+  .connect({ url: "ws://127.0.0.1:8787/environments/env_1/channel", token: "quickstart" })
+  .register(lookupOrder, ({ id }) => orders[id] ?? { status: "unknown order" });
+
 const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });
-const channel = app({ channelToken: "quickstart" });
 const session = await brain.sessions.create({
   model: { provider: "openai", name: "gpt-5-mini", apiKey: process.env.OPENAI_API_KEY },
   agentloop: pi(),
-  tools: [
-    appTool({
-      name: "say",
-      description: "Speak out loud through the user's speakers.",
-      input: z.object({ text: z.string() }),
-    }).useIn(channel),
-  ],
-  system: "You can speak out loud. Answer by saying it.",
+  tools: [appTool(lookupOrder).useIn(app({ channelToken: "quickstart" }))],
 });
 
-console.log("Open http://127.0.0.1:8787 in a browser, sound on, then press Enter.");
-await new Promise((resolve) => process.stdin.once("data", resolve));
-
-await session.send("Introduce yourself out loud, in one sentence.");
+await session.send("Where is order A-1001?");
 for await (const event of session.events()) console.log(event.sequence, event.type);
 
 await session.end();
@@ -100,10 +84,12 @@ await session.delete();
 process.exit(0);
 ```
 
-The Node script hosts the environment and serves the page, the tab connects out over a WebSocket
-and registers `say`, Brain routes the model's tool call down the channel — and the answer comes
-out of your speakers while the event feed streams in the terminal. See
-[App tools](/brain/docs/guides/app-tools) for how callback tools work, and
+The model reads the question, calls `lookup_order`, and your function answers from the `orders`
+object beside it — the whole exchange lands in the event feed, tool call and result included.
+The same channel works from a browser page or anything behind NAT, and provisioned tools ship
+their code into a sandbox environment the same way.
+
+See [App tools](/brain/docs/guides/app-tools) for both callback transports, and
 [Environments](/brain/docs/concepts/environment) for what else can host a tool.
 
 ## Runnable versions


### PR DESCRIPTION
How-it-works names the techniques directly — write-ahead log (WAL), a secured, isolated Wasm component with limited resources, bounded live streaming — and the diagram's top line fits without horizontal scrolling. The quick start demos a tool running in an environment in one short script: a lookup_order function in the reader's own process, served over env-app's callback channel, with one contract shared between registration and session create. Contact splits into support@aex.dev for issues and admin@aex.dev for collaboration. Follows #122.