### PR TITLE
release: @aexhq/brain 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.9.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for the npm release carrying #118–#121 and #126 (client-hosted tools). Breaking by pre-1.0 minor convention; extensions packages follow as 1.2.0 pinned to this exact version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)