### PR TITLE
bench: seven new subjects and the publication charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,43 +41,65 @@ Brain in each chart.
 **Turn round-trip**
 
 ```text
-Brain      █                                     25 ms ★
-ZeroClaw   ██                                    51 ms †
-LangGraph  ██████████████████████████████      1049 ms
-OpenClaw   ████████████████████████████████████ 1257 ms †
+VoltAgent  █                                       4.3 ms
+Agno       ███████                                  13 ms
+Mastra     █████████                                20 ms
+Restate    ███████████                              31 ms
+Brain      ██████████████                           51 ms ★
+ZeroClaw   ██████████████                           53 ms †
+OpenFang   ███████████████████                     128 ms
+Temporal   ████████████████████                    174 ms
+AgentScope ████████████████████████                338 ms
+Letta      ████████████████████████████            678 ms
+LangGraph  ███████████████████████████████         1.22 s
+Awaken     ██████████████████████████████████      2.23 s
+OpenClaw   ████████████████████████████████████    3.33 s †
 ```
 
 **Time to first token**
 
 ```text
-ZeroClaw   █                                    9.6 ms †
-Brain      ██                                    25 ms ★
-LangGraph  ████                                48.6 ms
-OpenFang   ██████                              75.8 ms
-OpenClaw   ██████████████████████████████     874.4 ms †
+VoltAgent  █                                       6.6 ms
+ZeroClaw   ████                                     11 ms †
+Mastra     ████                                     11 ms
+Agno       ███████                                  16 ms
+Brain      ██████████████                           51 ms ★
+OpenFang   ████████████████                         70 ms
+LangGraph  ██████████████████████                  207 ms
+AgentScope █████████████████████████               332 ms
+Letta      ██████████████████████████              407 ms
+OpenClaw   ██████████████████████████████████      1.33 s †
+Awaken     ████████████████████████████████████    1.93 s
 ```
 
 **New session**
 
 ```text
-Agno       █                                     3 µs °
-Brain      ███                                 0.6 ms ★
-LangGraph  ████                                0.7 ms
-ZeroClaw   ███████                             1.9 ms †
-OpenClaw   ████████████                        3.7 ms †
-OpenFang   ██████████████████████████████     10.3 ms
+VoltAgent  █                                      0.59 ms
+LangGraph  ██                                     0.66 ms
+Brain      ███                                    0.76 ms ★
+Mastra     █████                                  0.99 ms
+ZeroClaw   ██████████                              2.2 ms †
+Agno       ██████████████                          3.7 ms
+Awaken     ████████████████                        5.1 ms
+OpenClaw   █████████████████                       5.4 ms †
+OpenFang   █████████████████████                   9.8 ms
+Letta      ███████████████████████████████████      67 ms
+Temporal   ████████████████████████████████████     83 ms
 ```
 
-**Cold start**
+**Journal growth per 100 turns**
 
 ```text
-Cloudflare  █                                   <5 ms °
-ZeroClaw    ██                                  10 ms †
-Brain       ███                                 25 ms ★
-OpenFang    ██████                             180 ms
-LangGraph   ████████████████                   2.5 s
-Vertex AI   ███████████████████████            4.7 s °
-OpenClaw    ██████████████████████████████     5.98 s †
+AgentScope █                                       37 KiB
+OpenFang   █████████                             0.10 MiB
+Brain      ███████████████                       0.23 MiB ★
+Restate    ████████████████████                  0.45 MiB
+Temporal   ██████████████████████████████        1.59 MiB
+Awaken     ███████████████████████████████       1.77 MiB
+Letta      ████████████████████████████████      2.03 MiB
+Agno       ███████████████████████████████████   3.07 MiB
+Mastra     ████████████████████████████████████  3.44 MiB
 ```
 
 **Memory per idle session**
@@ -90,11 +112,13 @@ ZeroClaw   █████████████████████      
 OpenClaw   ██████████████████████████████     490 MiB †
 ```
 
-<sub>Medians from the harness in <a href="tools/bench">tools/bench</a> on an AWS
-<code>c7g.xlarge</code>. Brain's first-token figure is an upper bound (its whole-turn median);
-memory bars are log-scaled. <strong>°</strong> a project's own published figure.
-<strong>†</strong> personal/local assistant runtimes. Methodology and the bounds CI enforces:
-<a href="BENCHMARKS.md">BENCHMARKS.md</a>.</sub>
+<sub>Medians from the harness in <a href="tools/bench">tools/bench</a>, every subject measured on
+the same AWS <code>c7g.xlarge</code>; bars are log-scaled. Brain's first-token figure is an upper
+bound (its whole-turn median — against an instant scripted model the turn completes before a
+delta reaches the stream). VoltAgent and LangGraph's dev server persist nothing to disk, so they
+have no journal-growth bar. <strong>°</strong> a project's own published figure.
+<strong>†</strong> personal/local assistant runtimes. Subject versions, methodology, and the
+bounds CI enforces: <a href="BENCHMARKS.md">BENCHMARKS.md</a>.</sub>
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -46,21 +46,21 @@ Agno       ███████                                  13 ms
 Mastra     █████████                                20 ms
 Restate    ███████████                              31 ms
 Brain      ██████████████                           51 ms ★
-ZeroClaw   ██████████████                           53 ms †
+ZeroClaw   ██████████████                           53 ms
 OpenFang   ███████████████████                     128 ms
 Temporal   ████████████████████                    174 ms
 AgentScope ████████████████████████                338 ms
 Letta      ████████████████████████████            678 ms
 LangGraph  ███████████████████████████████         1.22 s
 Awaken     ██████████████████████████████████      2.23 s
-OpenClaw   ████████████████████████████████████    3.33 s †
+OpenClaw   ████████████████████████████████████    3.33 s
 ```
 
 **Time to first token**
 
 ```text
 VoltAgent  █                                       6.6 ms
-ZeroClaw   ████                                     11 ms †
+ZeroClaw   ████                                     11 ms
 Mastra     ████                                     11 ms
 Agno       ███████                                  16 ms
 Brain      ██████████████                           51 ms ★
@@ -68,7 +68,7 @@ OpenFang   ████████████████                     
 LangGraph  ██████████████████████                  207 ms
 AgentScope █████████████████████████               332 ms
 Letta      ██████████████████████████              407 ms
-OpenClaw   ██████████████████████████████████      1.33 s †
+OpenClaw   ██████████████████████████████████      1.33 s
 Awaken     ████████████████████████████████████    1.93 s
 ```
 
@@ -79,10 +79,10 @@ VoltAgent  █                                      0.59 ms
 LangGraph  ██                                     0.66 ms
 Brain      ███                                    0.76 ms ★
 Mastra     █████                                  0.99 ms
-ZeroClaw   ██████████                              2.2 ms †
+ZeroClaw   ██████████                              2.2 ms
 Agno       ██████████████                          3.7 ms
 Awaken     ████████████████                        5.1 ms
-OpenClaw   █████████████████                       5.4 ms †
+OpenClaw   █████████████████                       5.4 ms
 OpenFang   █████████████████████                   9.8 ms
 Letta      ███████████████████████████████████      67 ms
 Temporal   ████████████████████████████████████     83 ms
@@ -105,20 +105,18 @@ Mastra     ███████████████████████
 **Memory per idle session**
 
 ```text
-Agno       █                                  6.5 KiB °
-Brain      ██                                  14 KiB ★
-OpenFang   █████████                          0.6 MiB
-ZeroClaw   █████████████████████               50 MiB †
-OpenClaw   ██████████████████████████████     490 MiB †
+Brain      █                                        14 KiB ★
+OpenFang   ██████████████                          0.6 MiB
+ZeroClaw   ████████████████████████████             50 MiB
+OpenClaw   ████████████████████████████████████    490 MiB
 ```
 
 <sub>Medians from the harness in <a href="tools/bench">tools/bench</a>, every subject measured on
 the same AWS <code>c7g.xlarge</code>; bars are log-scaled. Brain's first-token figure is an upper
 bound (its whole-turn median — against an instant scripted model the turn completes before a
 delta reaches the stream). VoltAgent and LangGraph's dev server persist nothing to disk, so they
-have no journal-growth bar. <strong>°</strong> a project's own published figure.
-<strong>†</strong> personal/local assistant runtimes. Subject versions, methodology, and the
-bounds CI enforces: <a href="BENCHMARKS.md">BENCHMARKS.md</a>.</sub>
+have no journal-growth bar. Subject versions, methodology, and the bounds CI enforces:
+<a href="BENCHMARKS.md">BENCHMARKS.md</a>.</sub>
 
 ## How it works
 

--- a/tools/bench/.gitignore
+++ b/tools/bench/.gitignore
@@ -1,2 +1,6 @@
 target
 results
+subjects/awaken/checkout
+subjects/mastra/app/.mastra
+subjects/mastra/app/package-lock.json
+subjects/voltagent/app/package-lock.json

--- a/tools/bench/README.md
+++ b/tools/bench/README.md
@@ -186,8 +186,11 @@ move them by a different amount than it moves the next subject's. On Unix the su
 in its own process group and the group is signalled on teardown, so loop workers and other
 children cannot outlive it and hold ports or memory into the next measurement.
 
-Only `brain` has a driver so far. Any other subject is recorded as a skip rather than
-driven with Brain's client, which would produce numbers that look real and mean nothing.
+A subject without a driver is recorded as a skip rather than driven with another
+subject's client, which would produce numbers that look real and mean nothing. Drivers
+exist today for brain, langgraph-server, letta, openfang, zeroclaw, openclaw,
+agno-agentos, voltagent, mastra, agentscope-runtime, awaken, restate, temporal, the
+framework harness, and the sandbox subjects — see `drivers/mod.rs` for the registry.
 
 A project with both an open-source build and a hosted service is **two subjects**
 (`e2b-selfhosted` and `e2b-cloud`): one measures their code on our instance, the other

--- a/tools/bench/runner/src/drivers/agentscope.rs
+++ b/tools/bench/runner/src/drivers/agentscope.rs
@@ -1,0 +1,204 @@
+//! AgentScope Runtime, driven through its own HTTP API.
+//!
+//! The runtime has no create endpoint at all: the client mints a `session_id` and the
+//! first turn creates it, so `create` here is a local id mint that costs nothing and no
+//! create probe is declared in the manifest. A turn is `POST /process`, which answers
+//! only as an SSE stream — the round-trip probe therefore reads its own stream to the
+//! terminal `response`/`completed` event, because there is no blocking form to time
+//! instead.
+//!
+//! **Pointing it at the scripted provider.** The subject's `app.py` builds its model
+//! with the launch environment's base URL, so the wiring is done before this driver
+//! says anything; `prepare` drives one untimed warmup turn so the lazily created
+//! session store exists before anything is measured.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde_json::{Value, json};
+
+use crate::driver::{Driver, Unit};
+
+pub struct AgentScopeDriver {
+    client: reqwest::Client,
+    base_url: String,
+    turns_requested: AtomicU64,
+}
+
+enum TurnEnd {
+    FirstContent,
+    Completed,
+}
+
+impl AgentScopeDriver {
+    /// `_pid` is deliberately unused: the runner started the uvicorn process itself, so
+    /// it samples that tree without the driver's help.
+    pub fn new(base_url: impl Into<String>, _pid: Option<u32>) -> Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                // Matched to Brain's, so neither subject's number is its client's pool.
+                .pool_max_idle_per_host(512)
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?,
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            turns_requested: AtomicU64::new(0),
+        })
+    }
+
+    fn requesting_a_turn(&self) {
+        self.turns_requested.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The body every timed turn submits. Fixed, because input length is an input to
+    /// turn cost and has to be identical across subjects. Content is a block list —
+    /// a bare string is rejected by the schema.
+    fn turn_body(unit: &Unit) -> Value {
+        json!({
+            "input": [{
+                "role": "user",
+                "content": [{ "type": "text", "text": "benchmark" }],
+            }],
+            "session_id": unit.id,
+            "user_id": "bench",
+        })
+    }
+
+    /// Drives one turn's stream until `until`, returning the elapsed milliseconds.
+    ///
+    /// One walker for both probes, because the framing is the same and only the stopping
+    /// point differs: the first `content` event is the first model token, and the
+    /// `response`/`completed` event is the turn's own report that it ended. A `failed`
+    /// response or an in-band `error` line fails the sample rather than timing it.
+    async fn drive(&self, unit: &Unit, until: TurnEnd) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        let response = self
+            .client
+            .post(format!("{}/process", self.base_url))
+            .json(&Self::turn_body(unit))
+            .send()
+            .await?;
+        let response = ok(response, "submitting a turn").await?;
+
+        let mut frames = response.bytes_stream();
+        let mut pending = String::new();
+        let mut first_content: Option<std::time::Duration> = None;
+        while let Some(chunk) = frames.next().await {
+            pending.push_str(&String::from_utf8_lossy(&chunk?));
+            while let Some(newline) = pending.find('\n') {
+                let line: String = pending.drain(..=newline).collect();
+                let Some(payload) = line.trim().strip_prefix("data: ") else {
+                    continue;
+                };
+                let frame: Value = serde_json::from_str(payload)
+                    .with_context(|| format!("reading a stream frame: {payload}"))?;
+                // Ordinary frames carry `"error": null`; only a non-null error is one.
+                if let Some(error) = frame.get("error").filter(|error| !error.is_null()) {
+                    anyhow::bail!("the turn failed: {error}");
+                }
+                let object = frame.get("object").and_then(Value::as_str);
+                let status = frame.get("status").and_then(Value::as_str);
+                match (object, status) {
+                    (Some("content"), _) => {
+                        // The measurement for the first-byte probe — but the stream is
+                        // drained to completion either way, because hanging up early
+                        // cancels the handler mid-save and truncates the session's JSON
+                        // file, poisoning every turn after it.
+                        first_content = first_content.or(Some(started.elapsed()));
+                    }
+                    (Some("response"), Some("completed")) => {
+                        return match until {
+                            TurnEnd::Completed => Ok(started.elapsed().as_secs_f64() * 1_000.0),
+                            TurnEnd::FirstContent => first_content
+                                .map(|at| at.as_secs_f64() * 1_000.0)
+                                // Completing with no content event means the turn
+                                // finished without the assistant ever saying anything,
+                                // which is not a first-byte measurement however fast it
+                                // arrived.
+                                .with_context(|| {
+                                    format!("the stream completed with no assistant output: {frame}")
+                                }),
+                        };
+                    }
+                    (Some("response"), Some("failed")) => {
+                        anyhow::bail!("the turn failed: {frame}")
+                    }
+                    _ => continue,
+                }
+            }
+        }
+        anyhow::bail!("the turn stream ended before its terminal response event")
+    }
+}
+
+#[async_trait]
+impl Driver for AgentScopeDriver {
+    /// One untimed warmup turn on a scratch session: the session store and the model
+    /// path exist before anything is measured.
+    async fn prepare(&mut self) -> Result<()> {
+        let scratch = Unit {
+            id: format!("bench-warmup-{}", uuid_like()),
+        };
+        self.drive(&scratch, TurnEnd::Completed).await?;
+        eprintln!("agentscope-runtime: warmup turn completed against the scripted provider");
+        Ok(())
+    }
+
+    /// A local id mint. The runtime has no create endpoint — the first turn creates the
+    /// session — so there is nothing to time here and the manifest declares no create
+    /// probe.
+    async fn create(&self) -> Result<Unit> {
+        Ok(Unit {
+            id: format!("bench-{}", uuid_like()),
+        })
+    }
+
+    async fn ttfb_ms(&self, unit: &Unit) -> Result<f64> {
+        self.drive(unit, TurnEnd::FirstContent).await
+    }
+
+    async fn round_trip_ms(&self, unit: &Unit) -> Result<f64> {
+        self.drive(unit, TurnEnd::Completed).await
+    }
+
+    /// Nothing to tear down server-side: a session is a JSON file the runtime owns, and
+    /// deleting it out from under the server would measure the benchmark's own cleanup.
+    async fn destroy(&self, _unit: &Unit) -> Result<()> {
+        Ok(())
+    }
+
+    fn turns_requested(&self) -> u64 {
+        self.turns_requested.load(Ordering::Relaxed)
+    }
+}
+
+/// `error_for_status` throws the body away, and the body is where the subject says what
+/// went wrong.
+async fn ok(response: reqwest::Response, doing: &str) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("<body unreadable: {error}>"));
+    anyhow::bail!("{doing}: {status}: {body}")
+}
+
+/// Distinct session names without pulling in a uuid crate for a few probes' worth.
+fn uuid_like() -> String {
+    format!(
+        "{:x}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|since| since.as_nanos())
+            .unwrap_or_default()
+    )
+}

--- a/tools/bench/runner/src/drivers/agno_agentos.rs
+++ b/tools/bench/runner/src/drivers/agno_agentos.rs
@@ -1,0 +1,231 @@
+//! Agno AgentOS, driven through its own HTTP API.
+//!
+//! AgentOS's unit of work is a *session* on an agent that has lived since boot: the agent
+//! is defined in the server script, and every turn names a `session_id` that Agno creates
+//! lazily on first use. So `create` is the explicit form of that same row insert
+//! (`POST /sessions`), and a turn is `POST /agents/{id}/runs` — form-encoded, because
+//! that is the only body the endpoint takes, and with `stream=false` stated explicitly,
+//! because streaming is Agno's default.
+//!
+//! **Pointing it at the scripted provider.** The server script builds its one agent with
+//! `OpenAILike(base_url=BENCH_MODEL_BASE_URL)` from the launch environment, so the wiring
+//! is done before this driver says anything. `prepare` still drives one untimed warmup
+//! turn: it forces the lazy SQLite store into existence and proves a turn produces
+//! content before anything is timed, and the runner's fixture-count cross-check catches a
+//! server that answered from anywhere but the scripted provider.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde_json::Value;
+
+use crate::driver::{Driver, Unit};
+
+/// The agent id `server.py` fixes, so the run URL is knowable without discovery.
+const AGENT_ID: &str = "bench-agent";
+
+pub struct AgnoAgentOsDriver {
+    client: reqwest::Client,
+    base_url: String,
+    turns_requested: AtomicU64,
+}
+
+impl AgnoAgentOsDriver {
+    /// `_pid` is deliberately unused: the runner started the uvicorn process itself, so
+    /// it samples that tree without the driver's help.
+    pub fn new(base_url: impl Into<String>, _pid: Option<u32>) -> Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                // Matched to Brain's, so neither subject's number is its client's pool.
+                .pool_max_idle_per_host(512)
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?,
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            turns_requested: AtomicU64::new(0),
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    fn requesting_a_turn(&self) {
+        self.turns_requested.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The form every timed turn submits, encoded by hand because this reqwest build
+    /// carries no urlencoding feature and every value here is plain ASCII. Fixed,
+    /// because input length is an input to turn cost and has to be identical across
+    /// subjects. `stream` is stated even when false: Agno streams by default, and a
+    /// probe that forgot to say so would time the wrong path.
+    fn run_form(unit: &Unit, stream: bool) -> String {
+        format!(
+            "message=benchmark&stream={stream}&session_id={}&user_id=bench",
+            unit.id
+        )
+    }
+
+    async fn blocking_turn(&self, unit: &Unit) -> Result<Value> {
+        let response = self
+            .client
+            .post(self.url(&format!("/agents/{AGENT_ID}/runs")))
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(Self::run_form(unit, false))
+            .send()
+            .await?;
+        let body: Value = ok(response, "running a blocking turn").await?.json().await?;
+
+        // A turn that produced no assistant content did not happen, however the HTTP
+        // status reads. Agno reports the run's own status beside the content, so both
+        // are held: content because it is the output, status because RunError arrives
+        // with 200 on this endpoint's blocking form as well.
+        let content = body.get("content").and_then(Value::as_str).unwrap_or("");
+        anyhow::ensure!(
+            !content.is_empty(),
+            "the turn produced no assistant content: {body}"
+        );
+        if let Some(status) = body.get("status").and_then(Value::as_str) {
+            anyhow::ensure!(
+                status.eq_ignore_ascii_case("completed"),
+                "the turn did not complete: status {status}: {body}"
+            );
+        }
+        Ok(body)
+    }
+}
+
+#[async_trait]
+impl Driver for AgnoAgentOsDriver {
+    /// One untimed warmup turn on a scratch session: the SQLite store and the model path
+    /// exist before anything is measured, exactly as they would for a server that had
+    /// answered one request in its life.
+    async fn prepare(&mut self) -> Result<()> {
+        let scratch = Unit {
+            id: format!("bench-warmup-{}", uuid_like()),
+        };
+        self.blocking_turn(&scratch).await?;
+        eprintln!("agno-agentos: warmup turn completed against the scripted provider");
+        Ok(())
+    }
+
+    async fn create(&self) -> Result<Unit> {
+        let session_id = format!("bench-{}", uuid_like());
+        let response = self
+            .client
+            .post(self.url("/sessions?session_type=agent"))
+            .json(&serde_json::json!({
+                "session_id": session_id,
+                "agent_id": AGENT_ID,
+                "user_id": "bench",
+            }))
+            .send()
+            .await?;
+        let session: Value = ok(response, "creating a session").await?.json().await?;
+        Ok(Unit {
+            id: session
+                .get("session_id")
+                .and_then(Value::as_str)
+                .context("session response carried no session_id")?
+                .to_owned(),
+        })
+    }
+
+    /// Milliseconds until the first `RunContent` event on the run's own SSE stream.
+    ///
+    /// Like LangGraph Server's and Letta's, and unlike Brain's, the stream is opened *by*
+    /// submitting the turn — AgentOS has no separate subscribe — so the subscribe cost is
+    /// inside this number by construction, and the manifest says so.
+    async fn ttfb_ms(&self, unit: &Unit) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        let response = self
+            .client
+            .post(self.url(&format!("/agents/{AGENT_ID}/runs")))
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body(Self::run_form(unit, true))
+            .send()
+            .await?;
+        let response = ok(response, "opening a streaming turn").await?;
+
+        let mut frames = response.bytes_stream();
+        let mut pending = String::new();
+        while let Some(chunk) = frames.next().await {
+            pending.push_str(&String::from_utf8_lossy(&chunk?));
+            while let Some(newline) = pending.find('\n') {
+                let line: String = pending.drain(..=newline).collect();
+                let Some(payload) = line.trim().strip_prefix("data: ") else {
+                    continue;
+                };
+                let frame: Value = serde_json::from_str(payload)
+                    .with_context(|| format!("reading a stream frame: {payload}"))?;
+                match frame.get("event").and_then(Value::as_str) {
+                    // Output. The first delta is the measurement.
+                    Some("RunContent") => return Ok(started.elapsed().as_secs_f64() * 1_000.0),
+                    Some("RunError") | Some("RunCancelled") => {
+                        anyhow::bail!("the turn failed: {frame}")
+                    }
+                    // Terminal frames before any content mean the turn finished without
+                    // the assistant ever saying anything, which is not a first-byte
+                    // measurement however fast it arrived.
+                    Some("RunCompleted") => anyhow::bail!(
+                        "the stream reached its terminal frame with no assistant output: {frame}"
+                    ),
+                    _ => continue,
+                }
+            }
+        }
+        anyhow::bail!("the turn stream ended before any assistant output")
+    }
+
+    async fn round_trip_ms(&self, unit: &Unit) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        self.blocking_turn(unit).await?;
+        Ok(started.elapsed().as_secs_f64() * 1_000.0)
+    }
+
+    async fn destroy(&self, unit: &Unit) -> Result<()> {
+        let response = self
+            .client
+            .delete(self.url(&format!("/sessions/{}", unit.id)))
+            .send()
+            .await?;
+        ok(response, "deleting a session").await?;
+        Ok(())
+    }
+
+    fn turns_requested(&self) -> u64 {
+        self.turns_requested.load(Ordering::Relaxed)
+    }
+}
+
+/// `error_for_status` throws the body away, and the body is where the subject says what
+/// went wrong.
+async fn ok(response: reqwest::Response, doing: &str) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("<body unreadable: {error}>"));
+    anyhow::bail!("{doing}: {status}: {body}")
+}
+
+/// Distinct session names without pulling in a uuid crate for a few probes' worth.
+fn uuid_like() -> String {
+    format!(
+        "{:x}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|since| since.as_nanos())
+            .unwrap_or_default()
+    )
+}

--- a/tools/bench/runner/src/drivers/awaken.rs
+++ b/tools/bench/runner/src/drivers/awaken.rs
@@ -1,0 +1,208 @@
+//! Awaken, driven through its protocol-neutral runs API.
+//!
+//! Awaken's unit of work is a *thread*, and its runs API is SSE-first: submitting a run
+//! *is* opening its stream, and there is no blocking completion form — so the
+//! round-trip probe reads its own stream to the `run_finish` event, and the durable
+//! event journal every frame lands in is part of what the number measures.
+//!
+//! **Pointing it at the scripted provider.** The launch environment does the wiring
+//! (OPENAI_BASE_URL with its load-bearing trailing slash, and a dummy OPENAI_API_KEY so
+//! the starter cannot silently fall back to its built-in scripted executor); the
+//! runner's fixture-count cross-check catches a server that answered from anywhere but
+//! the scripted provider.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde_json::{Value, json};
+
+use crate::driver::{Driver, Unit};
+
+/// The agent id the launch environment seeds.
+const AGENT_ID: &str = "default";
+
+pub struct AwakenDriver {
+    client: reqwest::Client,
+    base_url: String,
+    turns_requested: AtomicU64,
+}
+
+enum TurnEnd {
+    FirstDelta,
+    Finished,
+}
+
+impl AwakenDriver {
+    /// `_pid` is deliberately unused: the runner started the server itself, so it
+    /// samples that tree without the driver's help.
+    pub fn new(base_url: impl Into<String>, _pid: Option<u32>) -> Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                // Matched to Brain's, so neither subject's number is its client's pool.
+                .pool_max_idle_per_host(512)
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?,
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            turns_requested: AtomicU64::new(0),
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    fn requesting_a_turn(&self) {
+        self.turns_requested.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Drives one run's stream until `until`, returning the elapsed milliseconds.
+    ///
+    /// The stream interleaves named SSE events with data payloads, and some frames name
+    /// themselves in the payload instead — so both the last `event:` line and the
+    /// payload's own `event`/`type` field are consulted, whichever the server used.
+    async fn drive(&self, unit: &Unit, until: TurnEnd) -> Result<f64> {
+        self.requesting_a_turn();
+        // Awaken finalizes a run asynchronously after its stream's run_finish, and a
+        // thread with a run still finalizing answers the next submission with a 409.
+        // That window is waited out untimed — the timer restarts on every attempt — so
+        // the number is the accepted run's latency, not the previous run's cleanup.
+        let waiting_since = Instant::now();
+        let mut started;
+        let response = loop {
+            started = Instant::now();
+            let response = self
+                .client
+                .post(self.url("/v1/runs"))
+                .json(&json!({
+                    "agentId": AGENT_ID,
+                    "threadId": unit.id,
+                    // Fixed, because input length is an input to turn cost and has to
+                    // be identical across subjects.
+                    "messages": [{ "role": "user", "content": "benchmark" }],
+                }))
+                .send()
+                .await?;
+            if response.status() == reqwest::StatusCode::CONFLICT {
+                anyhow::ensure!(
+                    waiting_since.elapsed() < std::time::Duration::from_secs(10),
+                    "the thread's previous run never finished finalizing"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                continue;
+            }
+            break response;
+        };
+        let response = ok(response, "submitting a run").await?;
+
+        let mut frames = response.bytes_stream();
+        let mut pending = String::new();
+        let mut named = String::new();
+        while let Some(chunk) = frames.next().await {
+            pending.push_str(&String::from_utf8_lossy(&chunk?));
+            while let Some(newline) = pending.find('\n') {
+                let line: String = pending.drain(..=newline).collect();
+                let line = line.trim();
+                if let Some(name) = line.strip_prefix("event: ") {
+                    named = name.to_owned();
+                    continue;
+                }
+                let Some(payload) = line.strip_prefix("data: ") else {
+                    continue;
+                };
+                let frame: Value = serde_json::from_str(payload).unwrap_or(Value::Null);
+                let kind = frame
+                    .get("event_type")
+                    .and_then(Value::as_str)
+                    .unwrap_or(named.as_str());
+                match kind {
+                    "text_delta" => {
+                        if matches!(until, TurnEnd::FirstDelta) {
+                            return Ok(started.elapsed().as_secs_f64() * 1_000.0);
+                        }
+                    }
+                    "run_finish" => {
+                        return match until {
+                            TurnEnd::Finished => Ok(started.elapsed().as_secs_f64() * 1_000.0),
+                            // Finishing with no delta means the turn produced no
+                            // assistant output, which is not a first-byte measurement
+                            // however fast it arrived.
+                            TurnEnd::FirstDelta => anyhow::bail!(
+                                "the run finished with no assistant output: {frame}"
+                            ),
+                        };
+                    }
+                    "run_error" | "error" => anyhow::bail!("the run failed: {frame}"),
+                    _ => continue,
+                }
+            }
+        }
+        anyhow::bail!("the run stream ended before its run_finish event")
+    }
+}
+
+#[async_trait]
+impl Driver for AwakenDriver {
+    /// One untimed warmup run on a scratch thread, so the stores exist and the provider
+    /// path is proven before anything is measured.
+    async fn prepare(&mut self) -> Result<()> {
+        let scratch = self.create().await?;
+        self.drive(&scratch, TurnEnd::Finished).await?;
+        eprintln!("awaken: warmup run completed against the scripted provider");
+        Ok(())
+    }
+
+    async fn create(&self) -> Result<Unit> {
+        let response = self
+            .client
+            .post(self.url("/v1/threads"))
+            .json(&json!({ "title": "bench" }))
+            .send()
+            .await?;
+        let thread: Value = ok(response, "creating a thread").await?.json().await?;
+        Ok(Unit {
+            id: thread
+                .get("id")
+                .and_then(Value::as_str)
+                .with_context(|| format!("thread response carried no id: {thread}"))?
+                .to_owned(),
+        })
+    }
+
+    async fn ttfb_ms(&self, unit: &Unit) -> Result<f64> {
+        self.drive(unit, TurnEnd::FirstDelta).await
+    }
+
+    async fn round_trip_ms(&self, unit: &Unit) -> Result<f64> {
+        self.drive(unit, TurnEnd::Finished).await
+    }
+
+    /// Nothing to tear down server-side: the runs API exposes no thread delete, and a
+    /// thread is rows in the server's own durable store.
+    async fn destroy(&self, _unit: &Unit) -> Result<()> {
+        Ok(())
+    }
+
+    fn turns_requested(&self) -> u64 {
+        self.turns_requested.load(Ordering::Relaxed)
+    }
+}
+
+/// `error_for_status` throws the body away, and the body is where the subject says what
+/// went wrong.
+async fn ok(response: reqwest::Response, doing: &str) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("<body unreadable: {error}>"));
+    anyhow::bail!("{doing}: {status}: {body}")
+}

--- a/tools/bench/runner/src/drivers/brain.rs
+++ b/tools/bench/runner/src/drivers/brain.rs
@@ -205,7 +205,7 @@ impl Driver for BrainDriver {
                 reqwest::Method::POST,
                 &format!("/v1/sessions/{}/messages", unit.id),
             )
-            .json(&json!({"content": self.prompt}))
+            .json(&json!({"input": {"message": self.prompt}}))
             .send();
 
         // The send is not awaited first: the whole point is that the first token arrives
@@ -301,7 +301,7 @@ impl Driver for BrainDriver {
                 reqwest::Method::POST,
                 &format!("/v1/sessions/{}/messages", unit.id),
             )
-            .json(&json!({"content": self.prompt}))
+            .json(&json!({"input": {"message": self.prompt}}))
             .send()
             .await?
             .error_for_status()
@@ -331,7 +331,7 @@ impl Driver for BrainDriver {
             reqwest::Method::POST,
             &format!("/v1/sessions/{}/messages", unit.id),
         )
-        .json(&json!({"content": TOOL_PROMPT}))
+        .json(&json!({"input": {"message": TOOL_PROMPT}}))
         .send()
         .await?
         .error_for_status()

--- a/tools/bench/runner/src/drivers/mastra.rs
+++ b/tools/bench/runner/src/drivers/mastra.rs
@@ -1,0 +1,198 @@
+//! Mastra, driven through its own HTTP API.
+//!
+//! Mastra's unit of work is a *thread*, scoped by thread + resource and created lazily
+//! on first use; `create` measures the explicit form of the same moment
+//! (`POST /api/memory/threads`), and a turn is `POST /api/agents/{id}/generate` — or
+//! `/stream` for the first-byte probe, whose SSE chunks wrap AI-SDK-shaped parts in
+//! Mastra's own `{type, payload}` envelope.
+//!
+//! **Pointing it at the scripted provider.** The subject's `src/mastra/index.ts` builds
+//! its one agent through Mastra's model router with the launch environment's base URL,
+//! so the wiring is done before this driver says anything.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde_json::{Value, json};
+
+use crate::driver::{Driver, Unit};
+
+/// The agent id `src/mastra/index.ts` fixes.
+const AGENT_ID: &str = "bench-agent";
+
+pub struct MastraDriver {
+    client: reqwest::Client,
+    base_url: String,
+    turns_requested: AtomicU64,
+}
+
+impl MastraDriver {
+    /// `_pid` is deliberately unused: the runner started the node process itself, so it
+    /// samples that tree without the driver's help.
+    pub fn new(base_url: impl Into<String>, _pid: Option<u32>) -> Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                // Matched to Brain's, so neither subject's number is its client's pool.
+                .pool_max_idle_per_host(512)
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?,
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            turns_requested: AtomicU64::new(0),
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    fn requesting_a_turn(&self) {
+        self.turns_requested.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The body every timed turn submits. Fixed, because input length is an input to
+    /// turn cost and has to be identical across subjects. The v1 memory shape is the
+    /// nested `memory: {thread, resource}` object — the flat 0.x keys are silently
+    /// ignored and would fork a fresh context per turn.
+    fn turn_body(unit: &Unit) -> Value {
+        json!({
+            "messages": [{ "role": "user", "content": "benchmark" }],
+            "memory": { "thread": unit.id, "resource": "bench" },
+        })
+    }
+}
+
+#[async_trait]
+impl Driver for MastraDriver {
+    async fn create(&self) -> Result<Unit> {
+        let thread_id = format!("bench-{}", uuid_like());
+        let response = self
+            .client
+            .post(self.url(&format!("/api/memory/threads?agentId={AGENT_ID}")))
+            .json(&json!({
+                "threadId": thread_id,
+                "resourceId": "bench",
+                "title": "bench",
+            }))
+            .send()
+            .await?;
+        let thread: Value = ok(response, "creating a thread").await?.json().await?;
+        Ok(Unit {
+            id: thread
+                .get("id")
+                .and_then(Value::as_str)
+                .with_context(|| format!("thread response carried no id: {thread}"))?
+                .to_owned(),
+        })
+    }
+
+    /// Milliseconds until the first `text-delta` chunk on the turn's own SSE stream.
+    ///
+    /// Like every other served framework here and unlike Brain, the stream is opened
+    /// *by* submitting the turn — Mastra has no separate subscribe — so the subscribe
+    /// cost is inside this number by construction, and the manifest says so.
+    async fn ttfb_ms(&self, unit: &Unit) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        let response = self
+            .client
+            .post(self.url(&format!("/api/agents/{AGENT_ID}/stream")))
+            .json(&Self::turn_body(unit))
+            .send()
+            .await?;
+        let response = ok(response, "opening a streaming turn").await?;
+
+        let mut frames = response.bytes_stream();
+        let mut pending = String::new();
+        while let Some(chunk) = frames.next().await {
+            pending.push_str(&String::from_utf8_lossy(&chunk?));
+            while let Some(newline) = pending.find('\n') {
+                let line: String = pending.drain(..=newline).collect();
+                let Some(payload) = line.trim().strip_prefix("data: ") else {
+                    continue;
+                };
+                if payload == "[DONE]" {
+                    anyhow::bail!("the turn stream ended before any assistant output");
+                }
+                let frame: Value = serde_json::from_str(payload)
+                    .with_context(|| format!("reading a stream frame: {payload}"))?;
+                match frame.get("type").and_then(Value::as_str) {
+                    // Output. The first delta is the measurement.
+                    Some("text-delta") => return Ok(started.elapsed().as_secs_f64() * 1_000.0),
+                    Some("error") => anyhow::bail!("the turn failed: {frame}"),
+                    // The terminal chunk before any content means the turn finished
+                    // without the assistant ever saying anything, which is not a
+                    // first-byte measurement however fast it arrived.
+                    Some("finish") => anyhow::bail!(
+                        "the stream reached its terminal chunk with no assistant output: {frame}"
+                    ),
+                    _ => continue,
+                }
+            }
+        }
+        anyhow::bail!("the turn stream ended before any assistant output")
+    }
+
+    async fn round_trip_ms(&self, unit: &Unit) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        let response = self
+            .client
+            .post(self.url(&format!("/api/agents/{AGENT_ID}/generate")))
+            .json(&Self::turn_body(unit))
+            .send()
+            .await?;
+        let body: Value = ok(response, "sending a turn").await?.json().await?;
+        let elapsed = started.elapsed().as_secs_f64() * 1_000.0;
+
+        // A turn that produced no assistant text did not happen, however the HTTP
+        // status reads.
+        let text = body.get("text").and_then(Value::as_str).unwrap_or("");
+        anyhow::ensure!(!text.is_empty(), "the turn produced no assistant text: {body}");
+        Ok(elapsed)
+    }
+
+    async fn destroy(&self, unit: &Unit) -> Result<()> {
+        let response = self
+            .client
+            .delete(self.url(&format!("/api/memory/threads/{}?agentId={AGENT_ID}", unit.id)))
+            .send()
+            .await?;
+        ok(response, "deleting a thread").await?;
+        Ok(())
+    }
+
+    fn turns_requested(&self) -> u64 {
+        self.turns_requested.load(Ordering::Relaxed)
+    }
+}
+
+/// `error_for_status` throws the body away, and the body is where the subject says what
+/// went wrong.
+async fn ok(response: reqwest::Response, doing: &str) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("<body unreadable: {error}>"));
+    anyhow::bail!("{doing}: {status}: {body}")
+}
+
+/// Distinct thread names without pulling in a uuid crate for a few probes' worth.
+fn uuid_like() -> String {
+    format!(
+        "{:x}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|since| since.as_nanos())
+            .unwrap_or_default()
+    )
+}

--- a/tools/bench/runner/src/drivers/mod.rs
+++ b/tools/bench/runner/src/drivers/mod.rs
@@ -15,6 +15,9 @@ use anyhow::Result;
 
 use crate::{driver::Driver, fixtures::Fixture};
 
+pub mod agentscope;
+pub mod agno_agentos;
+pub mod awaken;
 pub mod brain;
 pub mod daytona;
 pub mod e2b;
@@ -22,8 +25,12 @@ pub mod e2b_selfhosted;
 pub mod firecracker;
 pub mod framework;
 pub mod managed_agents;
+pub mod mastra;
 pub mod modal;
 pub mod openclaw;
+pub mod restate;
+pub mod temporal;
+pub mod voltagent;
 pub mod openfang;
 pub mod zeroclaw;
 pub mod langgraph_server;
@@ -70,6 +77,18 @@ pub fn for_subject(subject: &str, bench: &Bench) -> Result<Option<Box<dyn Driver
             bench.pid,
             Arc::clone(&bench.environment),
         )?))),
+        "agentscope-runtime" => Ok(Some(Box::new(agentscope::AgentScopeDriver::new(
+            &bench.base_url,
+            bench.pid,
+        )?))),
+        "awaken" => Ok(Some(Box::new(awaken::AwakenDriver::new(
+            &bench.base_url,
+            bench.pid,
+        )?))),
+        "agno-agentos" => Ok(Some(Box::new(agno_agentos::AgnoAgentOsDriver::new(
+            &bench.base_url,
+            bench.pid,
+        )?))),
         "langgraph-server" => Ok(Some(Box::new(
             langgraph_server::LangGraphServerDriver::new(&bench.base_url, bench.pid)?,
         ))),
@@ -101,6 +120,22 @@ pub fn for_subject(subject: &str, bench: &Bench) -> Result<Option<Box<dyn Driver
         ))),
         "modal" => Ok(Some(Box::new(modal::ModalDriver::new()?))),
         "zeroclaw" => Ok(Some(Box::new(zeroclaw::ZeroclawDriver::new(
+            &bench.base_url,
+            bench.pid,
+        )?))),
+        "mastra" => Ok(Some(Box::new(mastra::MastraDriver::new(
+            &bench.base_url,
+            bench.pid,
+        )?))),
+        "temporal" => Ok(Some(Box::new(temporal::TemporalDriver::new(
+            &bench.base_url,
+            bench.pid,
+        )?))),
+        "restate" => Ok(Some(Box::new(restate::RestateDriver::new(
+            &bench.base_url,
+            bench.pid,
+        )?))),
+        "voltagent" => Ok(Some(Box::new(voltagent::VoltAgentDriver::new(
             &bench.base_url,
             bench.pid,
         )?))),

--- a/tools/bench/runner/src/drivers/restate.rs
+++ b/tools/bench/runner/src/drivers/restate.rs
@@ -1,0 +1,161 @@
+//! Restate, driven through its ingress against the benchmark's own harness service.
+//!
+//! Restate is a durable-execution engine rather than an agent runtime: the agent
+//! session lives in the harness service beside the manifest (their published Durable
+//! Sessions pattern, verbatim but for the model's base URL), and this driver speaks to
+//! it through restate-server's ingress. A Virtual Object exists the moment its key is
+//! first invoked, so `create` is a local id mint and no create probe is declared; and
+//! ingress answers at handler completion — Restate documents token streaming as not
+//! yet supported — so there is no first-byte probe either.
+//!
+//! `prepare` registers the service deployment through the admin API, retrying while
+//! the service process beside restate-server finishes booting, then drives one untimed
+//! warmup turn to prove the whole path before anything is measured.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::driver::{Driver, Unit};
+
+/// Restate's default admin port; the manifest notes the collision this fixes a host at.
+const ADMIN_URL: &str = "http://127.0.0.1:9070";
+/// Where the harness service listens, fixed in the service's own source.
+const SERVICE_URL: &str = "http://127.0.0.1:9080";
+
+pub struct RestateDriver {
+    client: reqwest::Client,
+    base_url: String,
+    turns_requested: AtomicU64,
+}
+
+impl RestateDriver {
+    /// `_pid` is deliberately unused: the runner started the launch script's process
+    /// group itself — restate-server and the service both live in it — so it samples
+    /// that tree without the driver's help.
+    pub fn new(base_url: impl Into<String>, _pid: Option<u32>) -> Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                // Matched to Brain's, so neither subject's number is its client's pool.
+                .pool_max_idle_per_host(512)
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?,
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            turns_requested: AtomicU64::new(0),
+        })
+    }
+
+    fn requesting_a_turn(&self) {
+        self.turns_requested.fetch_add(1, Ordering::Relaxed);
+    }
+
+    async fn turn(&self, unit: &Unit) -> Result<String> {
+        let response = self
+            .client
+            .post(format!(
+                "{}/restate/call/AgentSession/{}/send",
+                self.base_url, unit.id
+            ))
+            // Fixed, because input length is an input to turn cost and has to be
+            // identical across subjects.
+            .json(&json!({ "message": "benchmark" }))
+            .send()
+            .await?;
+        let reply: Value = ok(response, "sending a turn").await?.json().await?;
+        let text = reply.as_str().unwrap_or("");
+        anyhow::ensure!(!text.is_empty(), "the turn produced no assistant text: {reply}");
+        Ok(text.to_owned())
+    }
+}
+
+#[async_trait]
+impl Driver for RestateDriver {
+    /// Registers the harness service's deployment, waiting out the service's own boot,
+    /// then proves one whole turn untimed.
+    async fn prepare(&mut self) -> Result<()> {
+        let mut last_error = String::new();
+        for _ in 0..60 {
+            let response = self
+                .client
+                .post(format!("{ADMIN_URL}/deployments"))
+                .json(&json!({ "uri": SERVICE_URL }))
+                .send()
+                .await;
+            match response {
+                Ok(response) if response.status().is_success() => {
+                    let warmup = self.create().await?;
+                    self.turn(&warmup).await?;
+                    eprintln!("restate: deployment registered, warmup turn completed");
+                    return Ok(());
+                }
+                Ok(response) => {
+                    last_error = format!(
+                        "{}: {}",
+                        response.status(),
+                        response.text().await.unwrap_or_default()
+                    );
+                }
+                Err(error) => last_error = error.to_string(),
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+        anyhow::bail!("registering the harness deployment never succeeded: {last_error}")
+    }
+
+    /// A local id mint. A Virtual Object exists the moment its key is first invoked, so
+    /// there is nothing to time here and the manifest declares no create probe.
+    async fn create(&self) -> Result<Unit> {
+        Ok(Unit {
+            id: format!(
+                "bench-{:x}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|since| since.as_nanos())
+                    .unwrap_or_default()
+            ),
+        })
+    }
+
+    /// Ingress has no streaming form, so a first-byte probe would time completion and
+    /// call it something else; the manifest declares none and this is unreachable.
+    async fn ttfb_ms(&self, unit: &Unit) -> Result<f64> {
+        self.round_trip_ms(unit).await
+    }
+
+    async fn round_trip_ms(&self, unit: &Unit) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        self.turn(unit).await?;
+        Ok(started.elapsed().as_secs_f64() * 1_000.0)
+    }
+
+    /// Nothing to tear down server-side: object state is rows in RocksDB, and clearing
+    /// them out from under the server would measure the benchmark's own cleanup.
+    async fn destroy(&self, _unit: &Unit) -> Result<()> {
+        Ok(())
+    }
+
+    fn turns_requested(&self) -> u64 {
+        self.turns_requested.load(Ordering::Relaxed)
+    }
+}
+
+/// `error_for_status` throws the body away, and the body is where the subject says what
+/// went wrong.
+async fn ok(response: reqwest::Response, doing: &str) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("<body unreadable: {error}>"));
+    anyhow::bail!("{doing}: {status}: {body}")
+}

--- a/tools/bench/runner/src/drivers/temporal.rs
+++ b/tools/bench/runner/src/drivers/temporal.rs
@@ -1,0 +1,131 @@
+//! Temporal, driven through the benchmark's own shim in the harness worker.
+//!
+//! Temporal's client is an SDK rather than an HTTP surface, so the harness worker
+//! carries a stdlib HTTP shim: `/create` starts one session workflow, `/send` executes
+//! an update on it and returns the reply. The workflow, the shim, and the wiring are
+//! all harness code on Temporal's substrate — the manifest says so — mirroring their
+//! own customer_service sample, with the model activity running through their official
+//! OpenAI Agents plugin against the scripted provider.
+//!
+//! No first-byte probe: an update returns one complete reply, and the manifest says
+//! that too.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::driver::{Driver, Unit};
+
+pub struct TemporalDriver {
+    client: reqwest::Client,
+    base_url: String,
+    turns_requested: AtomicU64,
+}
+
+impl TemporalDriver {
+    /// `_pid` is deliberately unused: the runner started the launch script's process
+    /// group itself — the dev server and the worker both live in it — so it samples
+    /// that tree without the driver's help.
+    pub fn new(base_url: impl Into<String>, _pid: Option<u32>) -> Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                // Matched to Brain's, so neither subject's number is its client's pool.
+                .pool_max_idle_per_host(512)
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?,
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            turns_requested: AtomicU64::new(0),
+        })
+    }
+
+    fn requesting_a_turn(&self) {
+        self.turns_requested.fetch_add(1, Ordering::Relaxed);
+    }
+
+    async fn turn(&self, unit: &Unit) -> Result<String> {
+        let response = self
+            .client
+            .post(format!("{}/send", self.base_url))
+            // Fixed, because input length is an input to turn cost and has to be
+            // identical across subjects.
+            .json(&json!({ "id": unit.id, "message": "benchmark" }))
+            .send()
+            .await?;
+        let reply: Value = ok(response, "sending a turn").await?.json().await?;
+        let text = reply.get("text").and_then(Value::as_str).unwrap_or("");
+        anyhow::ensure!(!text.is_empty(), "the turn produced no assistant text: {reply}");
+        Ok(text.to_owned())
+    }
+}
+
+#[async_trait]
+impl Driver for TemporalDriver {
+    /// One untimed warmup turn: the worker's sticky cache, the model activity path, and
+    /// the plugin's data conversion all exist before anything is measured.
+    async fn prepare(&mut self) -> Result<()> {
+        let warmup = self.create().await?;
+        self.turn(&warmup).await?;
+        eprintln!("temporal: warmup turn completed against the scripted provider");
+        Ok(())
+    }
+
+    async fn create(&self) -> Result<Unit> {
+        let response = self
+            .client
+            .post(format!("{}/create", self.base_url))
+            .json(&json!({}))
+            .send()
+            .await?;
+        let body: Value = ok(response, "starting a session workflow").await?.json().await?;
+        Ok(Unit {
+            id: body
+                .get("id")
+                .and_then(Value::as_str)
+                .with_context(|| format!("create response carried no id: {body}"))?
+                .to_owned(),
+        })
+    }
+
+    /// An update returns one complete reply; the manifest declares no first-byte probe
+    /// and this is unreachable.
+    async fn ttfb_ms(&self, unit: &Unit) -> Result<f64> {
+        self.round_trip_ms(unit).await
+    }
+
+    async fn round_trip_ms(&self, unit: &Unit) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        self.turn(unit).await?;
+        Ok(started.elapsed().as_secs_f64() * 1_000.0)
+    }
+
+    /// Nothing to tear down: a session workflow parks in the dev server's store, and
+    /// terminating it would measure the benchmark's own cleanup.
+    async fn destroy(&self, _unit: &Unit) -> Result<()> {
+        Ok(())
+    }
+
+    fn turns_requested(&self) -> u64 {
+        self.turns_requested.load(Ordering::Relaxed)
+    }
+}
+
+/// `error_for_status` throws the body away, and the body is where the subject says what
+/// went wrong.
+async fn ok(response: reqwest::Response, doing: &str) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("<body unreadable: {error}>"));
+    anyhow::bail!("{doing}: {status}: {body}")
+}

--- a/tools/bench/runner/src/drivers/voltagent.rs
+++ b/tools/bench/runner/src/drivers/voltagent.rs
@@ -1,0 +1,211 @@
+//! VoltAgent, driven through its own HTTP API.
+//!
+//! VoltAgent's unit of work is a *conversation*, scoped by `userId` + `conversationId`
+//! and created lazily on first use; `create` measures the explicit form of the same
+//! moment (`POST /api/memory/conversations`), and a turn is `POST /agents/{id}/text` —
+//! or `/stream` for the first-byte probe, which is the raw AI SDK fullStream over SSE.
+//!
+//! **Pointing it at the scripted provider.** The server script builds its one agent
+//! from `@ai-sdk/openai-compatible` with the launch environment's base URL, so the
+//! wiring is done before this driver says anything, and every generate option the
+//! server would otherwise default (temperature, maxOutputTokens, maxSteps,
+//! contextLimit) is pinned in the request body — an unstated default is still
+//! configuration, and it would be VoltAgent's rather than the benchmark's.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Instant,
+};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures_util::StreamExt;
+use serde_json::{Value, json};
+
+use crate::driver::{Driver, Unit};
+
+/// The agent id `server.ts` fixes (VoltAgent derives the id from the agent's name).
+const AGENT_ID: &str = "bench-agent";
+
+pub struct VoltAgentDriver {
+    client: reqwest::Client,
+    base_url: String,
+    turns_requested: AtomicU64,
+}
+
+impl VoltAgentDriver {
+    /// `_pid` is deliberately unused: the runner started the node process itself, so it
+    /// samples that tree without the driver's help.
+    pub fn new(base_url: impl Into<String>, _pid: Option<u32>) -> Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .no_proxy()
+                // Matched to Brain's, so neither subject's number is its client's pool.
+                .pool_max_idle_per_host(512)
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?,
+            base_url: base_url.into().trim_end_matches('/').to_owned(),
+            turns_requested: AtomicU64::new(0),
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base_url)
+    }
+
+    fn requesting_a_turn(&self) {
+        self.turns_requested.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// The body every timed turn submits. Fixed, because input length is an input to
+    /// turn cost and has to be identical across subjects; every optional knob is pinned
+    /// because the server fills schema defaults for anything unstated.
+    fn turn_body(unit: &Unit) -> Value {
+        json!({
+            "input": "benchmark",
+            "options": {
+                "memory": { "userId": "bench", "conversationId": unit.id },
+                "temperature": 0,
+                "maxOutputTokens": 512,
+                "maxSteps": 5,
+                "contextLimit": 10,
+            },
+        })
+    }
+}
+
+#[async_trait]
+impl Driver for VoltAgentDriver {
+    async fn create(&self) -> Result<Unit> {
+        let conversation_id = format!("bench-{}", uuid_like());
+        let response = self
+            .client
+            .post(self.url("/api/memory/conversations"))
+            .json(&json!({
+                "userId": "bench",
+                "conversationId": conversation_id,
+                "resourceId": AGENT_ID,
+            }))
+            .send()
+            .await?;
+        let body: Value = ok(response, "creating a conversation").await?.json().await?;
+        // The id is read back out of the response rather than assumed, so a server that
+        // renamed or regenerated it fails loudly here instead of silently forking a
+        // second conversation on the first turn.
+        let id = body
+            .pointer("/data/conversation/id")
+            .and_then(Value::as_str)
+            .with_context(|| format!("conversation response carried no id: {body}"))?;
+        Ok(Unit { id: id.to_owned() })
+    }
+
+    /// Milliseconds until the first `text-delta` part on the turn's own SSE stream.
+    ///
+    /// Like LangGraph Server's, Letta's, and AgentOS's, and unlike Brain's, the stream
+    /// is opened *by* submitting the turn — VoltAgent has no separate subscribe — so the
+    /// subscribe cost is inside this number by construction, and the manifest says so.
+    async fn ttfb_ms(&self, unit: &Unit) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        let response = self
+            .client
+            .post(self.url(&format!("/agents/{AGENT_ID}/stream")))
+            .json(&Self::turn_body(unit))
+            .send()
+            .await?;
+        let response = ok(response, "opening a streaming turn").await?;
+
+        let mut frames = response.bytes_stream();
+        let mut pending = String::new();
+        while let Some(chunk) = frames.next().await {
+            pending.push_str(&String::from_utf8_lossy(&chunk?));
+            while let Some(newline) = pending.find('\n') {
+                let line: String = pending.drain(..=newline).collect();
+                let Some(payload) = line.trim().strip_prefix("data: ") else {
+                    continue;
+                };
+                let frame: Value = serde_json::from_str(payload)
+                    .with_context(|| format!("reading a stream frame: {payload}"))?;
+                match frame.get("type").and_then(Value::as_str) {
+                    // Output. The first delta is the measurement.
+                    Some("text-delta") => return Ok(started.elapsed().as_secs_f64() * 1_000.0),
+                    Some("error") => anyhow::bail!("the turn failed: {frame}"),
+                    // The terminal part before any content means the turn finished
+                    // without the assistant ever saying anything, which is not a
+                    // first-byte measurement however fast it arrived.
+                    Some("finish") => anyhow::bail!(
+                        "the stream reached its terminal part with no assistant output: {frame}"
+                    ),
+                    _ => continue,
+                }
+            }
+        }
+        anyhow::bail!("the turn stream ended before any assistant output")
+    }
+
+    async fn round_trip_ms(&self, unit: &Unit) -> Result<f64> {
+        self.requesting_a_turn();
+        let started = Instant::now();
+        let response = self
+            .client
+            .post(self.url(&format!("/agents/{AGENT_ID}/text")))
+            .json(&Self::turn_body(unit))
+            .send()
+            .await?;
+        let body: Value = ok(response, "sending a turn").await?.json().await?;
+        let elapsed = started.elapsed().as_secs_f64() * 1_000.0;
+
+        // A turn that produced no assistant text did not happen, however the HTTP
+        // status reads: the envelope's own `success` and a non-empty `data.text` are
+        // both held.
+        anyhow::ensure!(
+            body.get("success").and_then(Value::as_bool) == Some(true),
+            "the turn did not succeed: {body}"
+        );
+        let text = body
+            .pointer("/data/text")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        anyhow::ensure!(!text.is_empty(), "the turn produced no assistant text: {body}");
+        Ok(elapsed)
+    }
+
+    async fn destroy(&self, unit: &Unit) -> Result<()> {
+        let response = self
+            .client
+            .delete(self.url(&format!("/api/memory/conversations/{}", unit.id)))
+            .send()
+            .await?;
+        ok(response, "deleting a conversation").await?;
+        Ok(())
+    }
+
+    fn turns_requested(&self) -> u64 {
+        self.turns_requested.load(Ordering::Relaxed)
+    }
+}
+
+/// `error_for_status` throws the body away, and the body is where the subject says what
+/// went wrong.
+async fn ok(response: reqwest::Response, doing: &str) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    let body = response
+        .text()
+        .await
+        .unwrap_or_else(|error| format!("<body unreadable: {error}>"));
+    anyhow::bail!("{doing}: {status}: {body}")
+}
+
+/// Distinct conversation names without pulling in a uuid crate for a few probes' worth.
+fn uuid_like() -> String {
+    format!(
+        "{:x}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|since| since.as_nanos())
+            .unwrap_or_default()
+    )
+}

--- a/tools/bench/subjects/agentscope-runtime/app.py
+++ b/tools/bench/subjects/agentscope-runtime/app.py
@@ -1,0 +1,65 @@
+"""The AgentScope Runtime AgentApp this benchmark measures.
+
+One ReActAgent per request at the cookbook's defaults, its model pointed at the scripted
+provider (OpenAIChatModel forwards client_kwargs to openai.AsyncClient, so base_url lands
+there), session state in JSONSession files under the run's data directory — the offline,
+restart-surviving option among the session backends the 1.x line ships.
+
+Pinned to agentscope-runtime==1.1.6.post2 with agentscope==1.0.21: the runtime's last
+release before the repository was archived into AgentScope 2.0, and the last 1.x
+agentscope its documented API imports from. Later agentscope releases delete
+agentscope.session and agentscope.pipeline outright.
+"""
+
+import os
+from contextlib import asynccontextmanager
+
+from agentscope.agent import ReActAgent
+from agentscope.formatter import OpenAIChatFormatter
+from agentscope.memory import InMemoryMemory
+from agentscope.model import OpenAIChatModel
+from agentscope.pipeline import stream_printing_messages
+from agentscope.session import JSONSession
+from fastapi import FastAPI
+
+from agentscope_runtime.engine import AgentApp
+from agentscope_runtime.engine.schemas.agent_schemas import AgentRequest
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.session = JSONSession(save_dir=os.environ["BENCH_DATA_DIR"])
+    yield
+
+
+agent_app = AgentApp(app_name="Bench", app_description="bench agent", lifespan=lifespan)
+
+
+@agent_app.query(framework="agentscope")
+async def query_func(self, msgs, request: AgentRequest = None, **kwargs):
+    agent = ReActAgent(
+        name="Bench",
+        model=OpenAIChatModel(
+            # The model the scripted provider advertises; the name travels to the fixture.
+            model_name="gpt-4o-mini",
+            api_key="bench",
+            stream=True,
+            client_kwargs={"base_url": os.environ["BENCH_MODEL_BASE_URL"]},
+        ),
+        sys_prompt="You are a benchmark assistant.",
+        memory=InMemoryMemory(),
+        formatter=OpenAIChatFormatter(),
+    )
+    agent.set_console_output_enabled(enabled=False)
+    await agent_app.state.session.load_session_state(
+        session_id=request.session_id, user_id=request.user_id, agent=agent
+    )
+    async for msg, last in stream_printing_messages(agents=[agent], coroutine_task=agent(msgs)):
+        yield msg, last
+    await agent_app.state.session.save_session_state(
+        session_id=request.session_id, user_id=request.user_id, agent=agent
+    )
+
+
+if __name__ == "__main__":
+    agent_app.run(host="127.0.0.1", port=int(os.environ["BENCH_PORT"]))

--- a/tools/bench/subjects/agentscope-runtime/subject.json
+++ b/tools/bench/subjects/agentscope-runtime/subject.json
@@ -1,0 +1,50 @@
+{
+  "name": "agentscope-runtime",
+  "class": "session-kernel",
+  "version": "agentscope-runtime==1.1.6.post2",
+  "notes": [
+    "Alibaba's Agent-as-a-Service runtime, measured as a running server. Pinned to 1.1.6.post2 with agentscope==1.0.21, and that is the end of the line rather than a snapshot of a moving target: the repository was archived into AgentScope 2.0 (issue #519), and later agentscope releases delete the modules its documented API imports. The same standing Letta holds in this set — a frozen final release of a real product.",
+    "One ReActAgent per request at the cookbook's defaults, model pointed at the scripted provider, session state in JSONSession files under the run's data directory — the offline, restart-surviving backend among the ones the 1.x line ships (the quickstart's fakeredis is in-process and lost on restart).",
+    "Sessions are implicit: the client mints a session_id and the first turn creates it, with no explicit create endpoint at all — so no create probe is declared, because there is no create moment to measure.",
+    "/process answers only as an SSE stream, so the round-trip probe reads its own stream to the terminal completed event; there is no blocking JSON form to time instead.",
+    "No sandboxed tools are configured, so Docker is never touched; tracing stays on the local log handler, and nothing phones home.",
+    "Requires: pip install 'agentscope-runtime==1.1.6.post2' 'agentscope==1.0.21' — provisioning installs it; the launch block assumes python3 can import both."
+  ],
+  "requires": {
+    "linux": false
+  },
+  "probes": {
+    "ttfb": {
+      "definition": "turn submitted to /process until the first content event on its SSE stream — the first model token, after the created and in_progress bookkeeping events that precede any model output. The stream is opened by submitting the turn, so the subscribe cost is inside this number by construction. The probe drains the stream to completion after taking the measurement: hanging up early cancels the handler mid-save and truncates the session's JSON file, poisoning every turn after it"
+    },
+    "round_trip": {
+      "definition": "turn submitted to /process until the stream's terminal response event reports completed, one complete text turn including the session state save behind it"
+    },
+    "throughput": {
+      "definition": "complete text turns per second across N concurrent sessions, unpaced"
+    },
+    "idle": {
+      "definition": "private memory across the whole process tree with no sessions created, sampled for 20s after 10s of settling"
+    },
+    "resident": {
+      "definition": "Private_Clean + Private_Dirty + Private_Hugetlb across the uvicorn process tree, per session held. The runtime builds a fresh agent per request and keeps session state in JSON files, so a near-zero slope is the expected result and is itself the finding"
+    },
+    "persistence": {
+      "definition": "bytes on disk in the run's data directory after N turns of one session, sampled per turn; JSONSession rewrites the session's file with the full history each save, so the cost of turn N is the size of everything before it"
+    }
+  },
+  "launch": {
+    "command": "python3",
+    "args": [
+      "tools/bench/subjects/agentscope-runtime/app.py"
+    ],
+    "env": {
+      "BENCH_PORT": "{port}",
+      "BENCH_MODEL_BASE_URL": "{model_base_url}",
+      "BENCH_DATA_DIR": "{data_dir}"
+    },
+    "base_url": "http://127.0.0.1:{port}",
+    "ready_url": "http://127.0.0.1:{port}/health",
+    "ready_timeout_secs": 120
+  }
+}

--- a/tools/bench/subjects/agno-agentos/server.py
+++ b/tools/bench/subjects/agno-agentos/server.py
@@ -1,0 +1,43 @@
+"""The AgentOS instance this benchmark measures.
+
+One agent at Agno's defaults, its model pointed at the scripted provider. The launch
+environment carries the wiring: AGENT_OS_PORT (which overrides serve() arguments, so it
+is the only reliable way to hand AgentOS the per-run port), BENCH_MODEL_BASE_URL, and
+BENCH_DATA_DIR for the SQLite file. AGNO_TELEMETRY=false is set in the manifest and
+telemetry=False here as well, because the env var alone has not always been honoured.
+"""
+
+import os
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai.like import OpenAILike
+from agno.os import AgentOS
+
+agent = Agent(
+    id="bench-agent",
+    name="Bench Agent",
+    model=OpenAILike(
+        # The model the scripted provider advertises; the name travels to the fixture.
+        id="gpt-4o-mini",
+        base_url=os.environ["BENCH_MODEL_BASE_URL"],
+        api_key="bench",
+    ),
+    db=SqliteDb(db_file=os.path.join(os.environ["BENCH_DATA_DIR"], "agentos.db")),
+    add_history_to_context=True,
+    telemetry=False,
+)
+
+agent_os = AgentOS(agents=[agent], telemetry=False)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        app,
+        host="127.0.0.1",
+        port=int(os.environ["AGENT_OS_PORT"]),
+        access_log=False,
+        log_level="warning",
+    )

--- a/tools/bench/subjects/agno-agentos/subject.json
+++ b/tools/bench/subjects/agno-agentos/subject.json
@@ -1,0 +1,53 @@
+{
+  "name": "agno-agentos",
+  "class": "session-kernel",
+  "version": "agno==3.0.4",
+  "notes": [
+    "Agno's AgentOS: the self-hostable FastAPI runtime around the Agno agent library, measured as a running server the way LangGraph Server and Letta are. The library's own published figures (~3 µs instantiation, ~6.5 KiB per agent) are in-process microbenchmarks on Apple silicon; these probes measure the served product instead, so the two sets of numbers are different measurements and must not be merged.",
+    "One agent at Agno's defaults with a SQLite store under the run's data directory, its OpenAI-like model pointed at the scripted provider through the launch environment (server.py reads BENCH_MODEL_BASE_URL). AGNO_TELEMETRY=false is set in the environment and telemetry=False in both constructors, because the env var alone has not always been honoured.",
+    "Sessions are lazy: any session_id passed to a run is created on first use, and POST /sessions is the explicit form of the same row insert. The create probe measures the explicit form, and its definition says so.",
+    "The run endpoint takes form-encoded bodies, not JSON, and streams by default; the blocking probe sends stream=false explicitly.",
+    "Requires: pip install 'agno[os]==3.0.4' openai — provisioning installs it; the launch block assumes python3 can import agno."
+  ],
+  "requires": {
+    "linux": false
+  },
+  "probes": {
+    "create": {
+      "definition": "POST /sessions (session_type=agent) until the response carries a session id. Agno creates sessions lazily on first run; this is its explicit session create — a database row insert, with the agent itself already resident from boot"
+    },
+    "ttfb": {
+      "definition": "run submitted with stream=true until the first RunContent event on the SSE stream the run itself opens. Like LangGraph Server and Letta, the stream is opened by submitting the turn, so the subscribe cost is inside this number by construction"
+    },
+    "round_trip": {
+      "definition": "run submitted with stream=false until the JSON response carries the completed run with its assistant content, one complete text turn against the session's history"
+    },
+    "throughput": {
+      "definition": "complete text turns per second across N concurrent sessions, unpaced"
+    },
+    "idle": {
+      "definition": "private memory across the whole process tree with no sessions created, sampled for 20s after 10s of settling"
+    },
+    "resident": {
+      "definition": "Private_Clean + Private_Dirty + Private_Hugetlb across the uvicorn process tree, per session held. Agno keeps session state in SQLite rather than in memory, so a near-zero slope is the expected result and is itself the finding: no per-session memory cost, and no session state in memory"
+    },
+    "persistence": {
+      "definition": "bytes on disk in the run's data directory after N turns of one session, sampled per turn; Agno writes the session's history and run records into its SQLite store"
+    }
+  },
+  "launch": {
+    "command": "python3",
+    "args": [
+      "tools/bench/subjects/agno-agentos/server.py"
+    ],
+    "env": {
+      "AGENT_OS_PORT": "{port}",
+      "BENCH_MODEL_BASE_URL": "{model_base_url}",
+      "BENCH_DATA_DIR": "{data_dir}",
+      "AGNO_TELEMETRY": "false"
+    },
+    "base_url": "http://127.0.0.1:{port}",
+    "ready_url": "http://127.0.0.1:{port}/health",
+    "ready_timeout_secs": 120
+  }
+}

--- a/tools/bench/subjects/awaken/build.sh
+++ b/tools/bench/subjects/awaken/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Provisioning: clones Awaken at the pinned tag and builds its starter server.
+# The checkout lives beside this script and is gitignored; the launch block only runs
+# the built binary.
+set -e
+here="$(cd "$(dirname "$0")" && pwd)"
+tag="v0.6.0"
+if [ ! -d "$here/checkout" ]; then
+  git clone --depth 1 --branch "$tag" https://github.com/AwakenWorks/awaken "$here/checkout"
+fi
+cd "$here/checkout"
+cargo build --release -p ai-sdk-starter-agent
+ls -la target/release/ai-sdk-starter-agent

--- a/tools/bench/subjects/awaken/launch.sh
+++ b/tools/bench/subjects/awaken/launch.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Launches the Awaken starter server built by build.sh.
+#
+# OPENAI_API_KEY must be non-empty: without it the starter silently falls back to its
+# built-in scripted executor, and every number would be measured against that instead of
+# the benchmark's own scripted provider. The trailing slash on OPENAI_BASE_URL is
+# load-bearing — the underlying client joins paths with Url::join, and a base without
+# the slash loses its /v1 segment.
+here="$(dirname "$0")"
+export OPENAI_BASE_URL="${BENCH_MODEL_BASE_URL%/}/"
+exec "$here/checkout/target/release/ai-sdk-starter-agent"

--- a/tools/bench/subjects/awaken/subject.json
+++ b/tools/bench/subjects/awaken/subject.json
@@ -1,0 +1,61 @@
+{
+  "name": "awaken",
+  "class": "session-kernel",
+  "version": "awaken v0.6.0 (ai-sdk-starter-agent)",
+  "notes": [
+    "A Rust agent runtime serving AI SDK, AG-UI, A2A, and MCP over one HTTP surface with durable dispatch and replay — the closest architectural shape to Brain in this set. Measured through its protocol-neutral runs API; the subject is the repo's own ai-sdk-starter server, because the project ships no standalone server binary.",
+    "Pinned to v0.6.0, pre-1.0 with monthly breaking releases; the checkout and build happen in provisioning (build.sh), and the launch block only runs the built binary.",
+    "OPENAI_API_KEY is set to a dummy value deliberately: without one the starter silently falls back to its built-in deterministic scripted executor, and every latency would be measured against that instead of the benchmark's scripted provider. The launch script also forces the trailing slash the client's URL joining requires.",
+    "The runs API is SSE-first with no blocking completion form, so the round-trip probe reads its own stream to the run_finish event, and the event journal every frame lands in is part of what the number measures — durable replay is the product.",
+    "Retry policy and round ceiling are left at the starter's documented defaults (2 retries / 500 ms backoff, AGENT_MAX_ROUNDS=8); the scripted provider answers instantly and deterministically, so retries never fire.",
+    "Awaken finalizes a run asynchronously after its stream's run_finish, and until then the thread answers the next submission with a 409. Back-to-back turns therefore wait that window out untimed — the probe's clock restarts on each attempt — so every latency here is the accepted run's, not the previous run's cleanup. The window itself is real per-thread behavior worth knowing about.",
+    "Requires: a Rust toolchain and `bash tools/bench/subjects/awaken/build.sh` in provisioning (network once, for the clone and crates)."
+  ],
+  "requires": {
+    "linux": false
+  },
+  "probes": {
+    "create": {
+      "definition": "POST /v1/threads until the response carries the thread id"
+    },
+    "ttfb": {
+      "definition": "run submitted to /v1/runs until the first text_delta event on the SSE stream the run itself is. The stream is opened by submitting the turn, so the subscribe cost is inside this number by construction"
+    },
+    "round_trip": {
+      "definition": "run submitted to /v1/runs until its run_finish event, one complete text turn including the durable event journal written behind it"
+    },
+    "throughput": {
+      "definition": "complete text turns per second across N concurrent threads, unpaced"
+    },
+    "idle": {
+      "definition": "private memory across the whole process tree with no threads created, sampled for 20s after 10s of settling"
+    },
+    "resident": {
+      "definition": "Private_Clean + Private_Dirty + Private_Hugetlb across the server's process tree, per thread held"
+    },
+    "persistence": {
+      "definition": "bytes on disk in the run's storage directory after N turns of one thread, sampled per turn; Awaken journals every run event durably for replay, which is the write pattern under test"
+    }
+  },
+  "launch": {
+    "command": "bash",
+    "args": [
+      "tools/bench/subjects/awaken/launch.sh"
+    ],
+    "env": {
+      "BENCH_MODEL_BASE_URL": "{model_base_url}",
+      "OPENAI_API_KEY": "bench",
+      "OPENAI_ADAPTER": "openai",
+      "AGENT_MODEL": "gpt-4o-mini",
+      "AGENT_ID": "default",
+      "AWAKEN_HTTP_ADDR": "127.0.0.1:{port}",
+      "AWAKEN_ADMIN_API_BEARER_TOKEN": "bench",
+      "AWAKEN_STORAGE_DIR": "{data_dir}",
+      "AWAKEN_SEED_PROFILE": "minimal",
+      "AWAKEN_ALLOW_DEV_FILE_COORDINATOR": "true"
+    },
+    "base_url": "http://127.0.0.1:{port}",
+    "ready_url": "http://127.0.0.1:{port}/health",
+    "ready_timeout_secs": 120
+  }
+}

--- a/tools/bench/subjects/mastra/app/package.json
+++ b/tools/bench/subjects/mastra/app/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mastra-bench-subject",
+  "private": true,
+  "type": "module",
+  "description": "The Mastra server this benchmark measures: one agent at defaults, model pointed at the scripted provider.",
+  "scripts": {
+    "build": "mastra build"
+  },
+  "dependencies": {
+    "@mastra/core": "1.63.2",
+    "@mastra/libsql": "1.22.2",
+    "@mastra/memory": "1.28.1",
+    "mastra": "1.27.2",
+    "zod": "4.5.4"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "5.9.2"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/tools/bench/subjects/mastra/app/src/mastra/index.ts
+++ b/tools/bench/subjects/mastra/app/src/mastra/index.ts
@@ -1,0 +1,36 @@
+// The Mastra server this benchmark measures.
+//
+// One agent at Mastra's defaults, its model pointed at the scripted provider through
+// Mastra's own model router (`custom/<name>` with an explicit base URL), so the calls
+// land on the fixture's /chat/completions. Storage is explicit because Mastra ships no
+// default persistent store: a LibSQL file under the run's data directory, which is what
+// the persistence probe measures. MASTRA_TELEMETRY_DISABLED=1 travels in the launch
+// environment.
+import { Mastra } from '@mastra/core/mastra';
+import { Agent } from '@mastra/core/agent';
+import { Memory } from '@mastra/memory';
+import { LibSQLStore } from '@mastra/libsql';
+
+const benchAgent = new Agent({
+  id: 'bench-agent',
+  name: 'bench-agent',
+  instructions: 'You are a benchmark assistant.',
+  model: {
+    id: 'custom/gpt-4o-mini',
+    url: process.env.BENCH_MODEL_BASE_URL!,
+    apiKey: 'bench',
+  },
+  memory: new Memory({ options: { lastMessages: 20 } }),
+});
+
+export const mastra = new Mastra({
+  agents: { benchAgent },
+  storage: new LibSQLStore({
+    id: 'bench-storage',
+    url: `file:${process.env.BENCH_DATA_DIR}/mastra.db`,
+  }),
+  server: {
+    port: Number(process.env.BENCH_PORT),
+    host: '127.0.0.1',
+  },
+});

--- a/tools/bench/subjects/mastra/app/tsconfig.json
+++ b/tools/bench/subjects/mastra/app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tools/bench/subjects/mastra/launch.sh
+++ b/tools/bench/subjects/mastra/launch.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Launches the built Mastra production server. Provisioning runs `npm install` and
+# `npm run build` in app/ first; the build bundles a Hono server into .mastra/output.
+here="$(dirname "$0")"
+cd "$here/app" || exit 1
+exec node .mastra/output/index.mjs

--- a/tools/bench/subjects/mastra/subject.json
+++ b/tools/bench/subjects/mastra/subject.json
@@ -1,0 +1,54 @@
+{
+  "name": "mastra",
+  "class": "session-kernel",
+  "version": "@mastra/core@1.63.2",
+  "notes": [
+    "Mastra's production server (`mastra build` output, a bundled Hono app run with plain node), measured as a running server the way LangGraph Server, Letta, AgentOS, and VoltAgent are. The dev server with its Studio playground is deliberately not the subject.",
+    "One agent at the framework's defaults, its model pointed at the scripted provider through Mastra's own model router (`custom/<name>` with an explicit base URL), so requests are plain chat-completions against the fixture.",
+    "Storage is explicit because Mastra ships no default persistent store — memory features refuse to run without one — so the closest thing to a default is the LibSQL file store from Mastra's own quickstart, under the run's data directory. Threads accumulate there, which is what the persistence probe measures; the resident probe's near-zero slope is likewise expected and is itself the finding.",
+    "A thread is the unit of work: memory is scoped by thread + resource, created explicitly through the memory API so the create probe measures the same moment it does elsewhere.",
+    "MASTRA_TELEMETRY_DISABLED=1 is set in the launch environment; the built server runs no OTEL instrumentation unless launched with its instrumentation preload, which this subject is not.",
+    "Requires: node >= 22.13 and `npm install && npm run build` in tools/bench/subjects/mastra/app — provisioning runs both (the build needs the network once); the launch block only runs node."
+  ],
+  "requires": {
+    "linux": false
+  },
+  "probes": {
+    "create": {
+      "definition": "POST /api/memory/threads until the response carries the thread id — the explicit form of the thread Mastra would otherwise create lazily on first use"
+    },
+    "ttfb": {
+      "definition": "turn submitted to /api/agents/{id}/stream until the first text-delta chunk on its SSE stream. As with LangGraph Server, Letta, AgentOS, and VoltAgent, the stream is opened by submitting the turn, so the subscribe cost is inside this number by construction"
+    },
+    "round_trip": {
+      "definition": "turn submitted to /api/agents/{id}/generate until the JSON response carries non-empty assistant text, one complete turn against the thread's history"
+    },
+    "throughput": {
+      "definition": "complete text turns per second across N concurrent threads, unpaced"
+    },
+    "idle": {
+      "definition": "private memory across the whole process tree with no threads created, sampled for 20s after 10s of settling"
+    },
+    "resident": {
+      "definition": "Private_Clean + Private_Dirty + Private_Hugetlb across the node process tree, per thread held. Mastra keeps thread state in LibSQL rather than in memory, so a near-zero slope is the expected result and is itself the finding"
+    },
+    "persistence": {
+      "definition": "bytes on disk in the run's data directory after N turns of one thread, sampled per turn; Mastra writes messages and thread metadata into its LibSQL store"
+    }
+  },
+  "launch": {
+    "command": "bash",
+    "args": [
+      "tools/bench/subjects/mastra/launch.sh"
+    ],
+    "env": {
+      "BENCH_PORT": "{port}",
+      "BENCH_MODEL_BASE_URL": "{model_base_url}",
+      "BENCH_DATA_DIR": "{data_dir}",
+      "MASTRA_TELEMETRY_DISABLED": "1"
+    },
+    "base_url": "http://127.0.0.1:{port}",
+    "ready_url": "http://127.0.0.1:{port}/health",
+    "ready_timeout_secs": 120
+  }
+}

--- a/tools/bench/subjects/restate/app/package.json
+++ b/tools/bench/subjects/restate/app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "restate-bench-subject",
+  "private": true,
+  "type": "module",
+  "description": "The agent-session service this benchmark runs on Restate: their published Durable Sessions pattern, model pointed at the scripted provider.",
+  "dependencies": {
+    "@restatedev/restate-sdk": "1.16.2",
+    "@restatedev/vercel-ai-middleware": "0.4.0",
+    "@ai-sdk/openai": "4.0.17",
+    "ai": "7.0.2"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2",
+    "typescript": "5.9.2"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/tools/bench/subjects/restate/app/src/agent.ts
+++ b/tools/bench/subjects/restate/app/src/agent.ts
@@ -1,0 +1,37 @@
+// The agent-session service this benchmark runs on Restate.
+//
+// This is harness code on Restate's substrate — Restate ships no agent — and it
+// deviates from their published "Durable Sessions" pattern in nothing but the model's
+// base URL: a Virtual Object keyed by session id, history in object state through
+// ctx.get/set, the model call wrapped in their own durableCalls middleware so every
+// LLM call is journaled and replayed rather than re-issued. The manifest says all of
+// this, because a number measured on a harness has to say who wrote the harness.
+import * as restate from "@restatedev/restate-sdk";
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateText, wrapLanguageModel, type ModelMessage } from "ai";
+import { durableCalls } from "@restatedev/vercel-ai-middleware";
+
+const provider = createOpenAI({
+  baseURL: process.env.BENCH_MODEL_BASE_URL!,
+  apiKey: "bench",
+});
+
+const agentSession = restate.object({
+  name: "AgentSession",
+  handlers: {
+    send: async (ctx: restate.ObjectContext, request: { message: string }) => {
+      const model = wrapLanguageModel({
+        // .chat pins the chat-completions dialect the scripted provider speaks.
+        model: provider.chat("gpt-4o-mini"),
+        middleware: durableCalls(ctx, { maxRetryAttempts: 3 }),
+      });
+      const history = (await ctx.get<ModelMessage[]>("messages")) ?? [];
+      history.push({ role: "user", content: request.message });
+      const result = await generateText({ model, messages: history });
+      ctx.set("messages", [...history, ...result.response.messages]);
+      return result.text;
+    },
+  },
+});
+
+restate.serve({ services: [agentSession], port: 9080 });

--- a/tools/bench/subjects/restate/build.sh
+++ b/tools/bench/subjects/restate/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Provisioning: downloads restate-server at the pinned version and installs the harness
+# service's dependencies. The binary and node_modules live beside this script and are
+# gitignored; the launch block only runs what this built.
+set -e
+here="$(cd "$(dirname "$0")" && pwd)"
+version="1.7.8"
+arch="$(uname -m)"
+if [ ! -x "$here/bin/restate-server" ]; then
+  mkdir -p "$here/bin"
+  curl -fsSL "https://restate.gateway.scarf.sh/v${version}/restate-server-${arch}-unknown-linux-musl.tar.xz" \
+    | tar -xJ -C "$here/bin" --strip-components=1
+fi
+"$here/bin/restate-server" --version
+cd "$here/app" && npm install --no-audit --no-fund

--- a/tools/bench/subjects/restate/launch.sh
+++ b/tools/bench/subjects/restate/launch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Launches the harness service (port 9080) beside restate-server. Both live in the
+# process group the runner signals on teardown, so neither outlives the measurement.
+here="$(dirname "$0")"
+"$here/app/node_modules/.bin/tsx" "$here/app/src/agent.ts" &
+export RESTATE_BASE_DIR="${BENCH_DATA_DIR}/restate-data"
+export RESTATE_INGRESS__BIND_ADDRESS="127.0.0.1:${BENCH_PORT}"
+export DO_NOT_TRACK=1
+exec "$here/bin/restate-server"

--- a/tools/bench/subjects/restate/subject.json
+++ b/tools/bench/subjects/restate/subject.json
@@ -1,0 +1,48 @@
+{
+  "name": "restate",
+  "class": "session-kernel",
+  "version": "restate-server 1.7.8",
+  "notes": [
+    "A durable-execution engine, not an agent runtime: restate-server journals and drives handlers that live in a user service, and the agent-session service measured here is the benchmark's own harness code — a faithful copy of Restate's published Durable Sessions pattern (Virtual Object keyed by session id, history in object state, the model call wrapped in their durableCalls middleware), deviating from their example in nothing but the model's base URL. A number measured on a harness has to say who wrote the harness; this one does.",
+    "Two processes under one launch: the harness service on its fixed port 9080, and restate-server with its ingress on the run's port. The driver registers the deployment through the admin API before anything is timed.",
+    "Sessions are implicit — a Virtual Object exists the moment its key is first invoked, so there is no create moment to measure and no create probe is declared.",
+    "No first-byte probe either: ingress answers at handler completion, and Restate's own docs say token streaming is not yet supported. Reporting ttfb through their pubsub add-on would benchmark our SSE relay, not Restate.",
+    "The durability tax is the product: every state read, write, and journaled model call is fsynced per step, and concurrent sends to one session queue on its single writer. The round-trip number includes all of that by design, and the comparison is exactly-once recovery against Brain's replayable journal.",
+    "DO_NOT_TRACK=1 is set; the admin port is Restate's default 9070, so two subjects of this manifest cannot share a host.",
+    "Requires: `bash tools/bench/subjects/restate/build.sh` in provisioning (downloads the pinned server binary, installs the service's npm dependencies; network once)."
+  ],
+  "requires": {
+    "linux": true
+  },
+  "probes": {
+    "round_trip": {
+      "definition": "POST /restate/call/AgentSession/{session}/send on the ingress until the handler's reply returns — one complete text turn, including the invocation journal, the state read and write, and the journaled model call behind it"
+    },
+    "throughput": {
+      "definition": "complete text turns per second across N concurrent sessions, unpaced; one session's turns serialize on its Virtual Object by design, so concurrency comes from session count"
+    },
+    "idle": {
+      "definition": "private memory across both processes' trees with no sessions invoked, sampled for 20s after 10s of settling"
+    },
+    "resident": {
+      "definition": "Private_Clean + Private_Dirty + Private_Hugetlb across the restate-server and service process trees, per session held; object state lives in RocksDB rather than in memory, so a near-zero slope is the expected result and is itself the finding"
+    },
+    "persistence": {
+      "definition": "bytes on disk under the run's restate-data directory after N turns of one session, sampled per turn; the invocation journal and per-object state both land in RocksDB there"
+    }
+  },
+  "launch": {
+    "command": "bash",
+    "args": [
+      "tools/bench/subjects/restate/launch.sh"
+    ],
+    "env": {
+      "BENCH_PORT": "{port}",
+      "BENCH_DATA_DIR": "{data_dir}",
+      "BENCH_MODEL_BASE_URL": "{model_base_url}"
+    },
+    "base_url": "http://127.0.0.1:{port}",
+    "ready_url": "http://127.0.0.1:{port}/restate/health",
+    "ready_timeout_secs": 120
+  }
+}

--- a/tools/bench/subjects/temporal/build.sh
+++ b/tools/bench/subjects/temporal/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Provisioning: downloads the Temporal CLI at the pinned version and builds the harness
+# worker's venv. Both live beside this script and are gitignored; the launch block only
+# runs what this built.
+set -e
+here="$(cd "$(dirname "$0")" && pwd)"
+version="1.8.2"
+case "$(uname -m)" in
+  x86_64) arch="amd64" ;;
+  aarch64) arch="arm64" ;;
+  *) echo "unsupported arch" >&2; exit 1 ;;
+esac
+if [ ! -x "$here/bin/temporal" ]; then
+  mkdir -p "$here/bin"
+  curl -fsSL "https://github.com/temporalio/cli/releases/download/v${version}/temporal_cli_${version}_linux_${arch}.tar.gz" \
+    | tar -xz -C "$here/bin"
+fi
+"$here/bin/temporal" --version
+if [ ! -x "$here/venv/bin/python" ]; then
+  python3 -m venv "$here/venv"
+fi
+"$here/venv/bin/pip" install -q "temporalio[openai-agents,opentelemetry]==1.32.0"
+"$here/venv/bin/python" -c "import temporalio.contrib.openai_agents; print('worker deps ok')"

--- a/tools/bench/subjects/temporal/launch.sh
+++ b/tools/bench/subjects/temporal/launch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Launches the Temporal dev server beside the harness worker and its shim. Both live in
+# the process group the runner signals on teardown, so neither outlives the measurement.
+here="$(dirname "$0")"
+"$here/bin/temporal" server start-dev \
+  --port 7233 \
+  --db-filename "${BENCH_DATA_DIR}/temporal.db" \
+  --headless &
+exec "$here/venv/bin/python" "$here/worker.py"

--- a/tools/bench/subjects/temporal/subject.json
+++ b/tools/bench/subjects/temporal/subject.json
@@ -1,0 +1,51 @@
+{
+  "name": "temporal",
+  "class": "session-kernel",
+  "version": "temporal CLI 1.8.2 dev server, temporalio 1.32.0",
+  "notes": [
+    "A durable-execution engine, not an agent runtime: Temporal runs agent loops as replayed workflows on workers, and the session measured here is the benchmark's own harness — one long-running workflow per session, messages as workflow updates whose result is the reply — mirroring the pattern of Temporal's own openai_agents customer_service sample, with the model call running as an activity through their official OpenAIAgentsPlugin pointed at the scripted provider. A number measured on a harness has to say who wrote the harness; this one does.",
+    "The runner drives a stdlib HTTP shim living in the worker process, because Temporal's client is an SDK rather than an HTTP surface. The shim's cost — one thread hop onto the client's event loop per request — is a fraction of a millisecond and is inside every number.",
+    "The subject is the single-binary dev server (`temporal server start-dev`, SQLite on the run's data directory, UI disabled). Temporal says it is not intended for production; it is also far lighter than a production Cassandra deployment, so this cuts both ways and the writeup must say so.",
+    "Every turn pays the substrate's own documented costs — roughly 50 ms activity scheduling round-trip plus two workflow tasks — which is the fair comparison point: durability by replayed history against Brain's journaled effects.",
+    "No first-byte probe: an update returns one complete reply, and the integration's experimental streaming publishes into a workflow-hosted stream rather than to an external caller.",
+    "The throughput probe is declared but timed out at 64-way concurrency on the dev server — its default dynamic-config RPS caps throttle exactly this shape of load, as Temporal's own worker-performance docs describe — so the 2026-08-31 run records it as a skip. Raising the dev server's caps to make the number exist would measure our tuning, not their defaults.",
+    "Requires: `bash tools/bench/subjects/temporal/build.sh` in provisioning (downloads the pinned CLI, builds the worker venv; network once)."
+  ],
+  "requires": {
+    "linux": false
+  },
+  "probes": {
+    "create": {
+      "definition": "start_workflow through the shim until the workflow execution is started — Temporal's own create moment for a session, a durable write to its store"
+    },
+    "round_trip": {
+      "definition": "execute_update through the shim until the update's reply returns — one complete text turn: update task, model activity against the scripted provider, update result, and the replayed history written behind all three"
+    },
+    "throughput": {
+      "definition": "complete text turns per second across N concurrent session workflows, unpaced"
+    },
+    "idle": {
+      "definition": "private memory across the dev server's and worker's process trees with no workflows started, sampled for 20s after 10s of settling"
+    },
+    "resident": {
+      "definition": "Private_Clean + Private_Dirty + Private_Hugetlb across both process trees, per started session workflow held; the worker's sticky cache keeps live workflows in memory, which is what the slope measures"
+    },
+    "persistence": {
+      "definition": "bytes on disk in the dev server's SQLite file after N turns of one session workflow, sampled per turn; every update and activity lands in replayed history, so the cost of turn N includes the history before it"
+    }
+  },
+  "launch": {
+    "command": "bash",
+    "args": [
+      "tools/bench/subjects/temporal/launch.sh"
+    ],
+    "env": {
+      "BENCH_PORT": "{port}",
+      "BENCH_DATA_DIR": "{data_dir}",
+      "BENCH_MODEL_BASE_URL": "{model_base_url}"
+    },
+    "base_url": "http://127.0.0.1:{port}",
+    "ready_url": "http://127.0.0.1:{port}/health",
+    "ready_timeout_secs": 180
+  }
+}

--- a/tools/bench/subjects/temporal/worker.py
+++ b/tools/bench/subjects/temporal/worker.py
@@ -1,0 +1,136 @@
+"""The agent-session worker this benchmark runs on Temporal, plus the HTTP shim the
+runner drives.
+
+This is harness code on Temporal's substrate — Temporal ships no agent-session server —
+mirroring the pattern of their own openai_agents/customer_service sample: one
+long-running workflow per session, messages arriving as workflow updates whose result is
+the reply, the model call running as an activity through their official
+OpenAIAgentsPlugin. The plugin's model provider points at the scripted provider
+(chat-completions dialect, not the Responses API).
+
+The shim is a stdlib HTTP server hopping each request onto the client's event loop; its
+cost is a fraction of a millisecond and it is our code, which the manifest says.
+"""
+
+import asyncio
+import json
+import os
+import threading
+import time
+from datetime import timedelta
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from agents import Agent, Runner
+from agents.models.openai_provider import OpenAIProvider
+from openai import AsyncOpenAI
+from temporalio import workflow
+from temporalio.client import Client
+from temporalio.contrib.openai_agents import ModelActivityParameters, OpenAIAgentsPlugin
+from temporalio.worker import Worker
+
+TASK_QUEUE = "bench"
+
+
+@workflow.defn
+class SessionWorkflow:
+    def __init__(self) -> None:
+        self.history: list = []
+
+    @workflow.run
+    async def run(self) -> None:
+        await workflow.wait_condition(
+            lambda: workflow.info().is_continue_as_new_suggested()
+            and workflow.all_handlers_finished()
+        )
+        workflow.continue_as_new()
+
+    @workflow.update
+    async def send_message(self, text: str) -> str:
+        agent = Agent(
+            name="bench",
+            instructions="You are a benchmark assistant.",
+            model="gpt-4o-mini",
+        )
+        self.history.append({"role": "user", "content": text})
+        result = await Runner.run(agent, self.history)
+        self.history = result.to_input_list()
+        return result.final_output or ""
+
+
+async def main() -> None:
+    plugin = OpenAIAgentsPlugin(
+        model_params=ModelActivityParameters(
+            start_to_close_timeout=timedelta(seconds=30)
+        ),
+        model_provider=OpenAIProvider(
+            openai_client=AsyncOpenAI(
+                base_url=os.environ["BENCH_MODEL_BASE_URL"], api_key="bench"
+            ),
+            use_responses=False,
+        ),
+    )
+    # The dev server boots beside this process; wait it out rather than racing it.
+    client = None
+    for _ in range(60):
+        try:
+            client = await Client.connect("127.0.0.1:7233", plugins=[plugin])
+            break
+        except Exception:  # noqa: BLE001 — connection refused while the server boots
+            await asyncio.sleep(0.5)
+    if client is None:
+        raise RuntimeError("the Temporal dev server never became reachable")
+    loop = asyncio.get_running_loop()
+
+    class Shim(BaseHTTPRequestHandler):
+        def log_message(self, *args) -> None:
+            pass
+
+        def reply(self, code: int, payload: dict) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(code)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:
+            self.reply(200, {"status": "ok"})
+
+        def do_POST(self) -> None:
+            length = int(self.headers.get("content-length", "0"))
+            request = json.loads(self.rfile.read(length) or b"{}")
+            try:
+                if self.path == "/create":
+                    session_id = f"bench-{time.time_ns():x}"
+                    future = asyncio.run_coroutine_threadsafe(
+                        client.start_workflow(
+                            SessionWorkflow.run, id=session_id, task_queue=TASK_QUEUE
+                        ),
+                        loop,
+                    )
+                    future.result(timeout=30)
+                    return self.reply(200, {"id": session_id})
+                if self.path == "/send":
+                    future = asyncio.run_coroutine_threadsafe(
+                        send(request["id"], request["message"]), loop
+                    )
+                    return self.reply(200, {"text": future.result(timeout=30)})
+                return self.reply(404, {"error": f"no route {self.path}"})
+            except Exception as error:  # noqa: BLE001 — the driver reads the body
+                return self.reply(500, {"error": str(error)})
+
+    async def send(session_id: str, message: str) -> str:
+        handle = client.get_workflow_handle_for(SessionWorkflow.run, session_id)
+        return await handle.execute_update(SessionWorkflow.send_message, message)
+
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", int(os.environ["BENCH_PORT"])), Shim
+    )
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    worker = Worker(client, task_queue=TASK_QUEUE, workflows=[SessionWorkflow])
+    await worker.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tools/bench/subjects/voltagent/app/package.json
+++ b/tools/bench/subjects/voltagent/app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "voltagent-bench-subject",
+  "private": true,
+  "type": "module",
+  "description": "The VoltAgent server this benchmark measures: one agent at defaults, model pointed at the scripted provider.",
+  "dependencies": {
+    "@voltagent/core": "2.10.0",
+    "@voltagent/server-hono": "2.0.14",
+    "@voltagent/logger": "2.0.2",
+    "@ai-sdk/openai-compatible": "2.0.74",
+    "ai": "6.0.272",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "tsx": "4.19.2",
+    "typescript": "5.9.2"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/tools/bench/subjects/voltagent/app/server.ts
+++ b/tools/bench/subjects/voltagent/app/server.ts
@@ -1,0 +1,33 @@
+// The VoltAgent server this benchmark measures.
+//
+// One agent at VoltAgent's defaults — in-memory storage, because that is what the
+// framework ships — its model pointed at the scripted provider through the launch
+// environment. The provider goes through @ai-sdk/openai-compatible's chatModel so the
+// requests land on the fixture's /chat/completions rather than the Responses API that
+// plain `openai(...)` would call. No VoltOps keys are set, so nothing phones home.
+import { Agent, VoltAgent } from "@voltagent/core";
+import { honoServer } from "@voltagent/server-hono";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+const scripted = createOpenAICompatible({
+  name: "scripted",
+  baseURL: process.env.BENCH_MODEL_BASE_URL!,
+  apiKey: "bench",
+});
+
+const agent = new Agent({
+  name: "bench-agent",
+  instructions: "You are a benchmark assistant.",
+  model: scripted.chatModel("gpt-4o-mini"),
+});
+
+new VoltAgent({
+  agents: { agent },
+  server: honoServer({
+    port: Number(process.env.BENCH_PORT),
+    hostname: "127.0.0.1",
+    configureApp: (app) => {
+      app.get("/health", (c) => c.json({ status: "ok" }));
+    },
+  }),
+});

--- a/tools/bench/subjects/voltagent/launch.sh
+++ b/tools/bench/subjects/voltagent/launch.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Launches the VoltAgent bench subject with the tsx the app's own lockfile installed.
+here="$(dirname "$0")"
+exec "$here/app/node_modules/.bin/tsx" "$here/app/server.ts"

--- a/tools/bench/subjects/voltagent/subject.json
+++ b/tools/bench/subjects/voltagent/subject.json
@@ -1,0 +1,50 @@
+{
+  "name": "voltagent",
+  "class": "session-kernel",
+  "version": "@voltagent/core@2.10.0",
+  "notes": [
+    "VoltAgent's Hono server, measured as a running server the way LangGraph Server, Letta, and AgentOS are. One agent at the framework's defaults, its model pointed at the scripted provider through @ai-sdk/openai-compatible so the calls land on /chat/completions.",
+    "Run at defaults means in-memory storage: VoltAgent v2 ships InMemoryStorageAdapter unless an adapter is configured, so sessions cost memory rather than disk here — the resident probe is the interesting one, and no persistence probe is declared because the default writes nothing durable to measure.",
+    "A conversation is the unit of work: memory is scoped by userId + conversationId, created explicitly through the memory API so the create probe measures the same moment it does elsewhere.",
+    "Request options are pinned in the driver (temperature 0, maxOutputTokens 512, maxSteps 5) because the server fills schema defaults for anything unstated, and an unstated default is still configuration.",
+    "No VoltOps keys are set, so the server-side VoltOps exporter never activates; observability stays local.",
+    "Requires: node >= 20 and `npm ci` in tools/bench/subjects/voltagent/app — provisioning installs it; the launch block runs the app with tsx."
+  ],
+  "requires": {
+    "linux": false
+  },
+  "probes": {
+    "create": {
+      "definition": "POST /api/memory/conversations until the response carries the conversation id — the explicit form of the conversation VoltAgent would otherwise create lazily on first use"
+    },
+    "ttfb": {
+      "definition": "turn submitted to /agents/{id}/stream until the first text-delta part on its SSE stream. As with LangGraph Server, Letta, and AgentOS, the stream is opened by submitting the turn, so the subscribe cost is inside this number by construction"
+    },
+    "round_trip": {
+      "definition": "turn submitted to /agents/{id}/text until the JSON response carries success with non-empty text, one complete turn against the conversation's history"
+    },
+    "throughput": {
+      "definition": "complete text turns per second across N concurrent conversations, unpaced"
+    },
+    "idle": {
+      "definition": "private memory across the whole process tree with no conversations created, sampled for 20s after 10s of settling"
+    },
+    "resident": {
+      "definition": "Private_Clean + Private_Dirty + Private_Hugetlb across the node process tree, per conversation held. VoltAgent's default storage is in memory, so the slope is the cost of a conversation's history living in the process"
+    }
+  },
+  "launch": {
+    "command": "bash",
+    "args": [
+      "tools/bench/subjects/voltagent/launch.sh"
+    ],
+    "env": {
+      "BENCH_PORT": "{port}",
+      "BENCH_MODEL_BASE_URL": "{model_base_url}",
+      "VOLTAGENT_TELEMETRY_DISABLED": "1"
+    },
+    "base_url": "http://127.0.0.1:{port}",
+    "ready_url": "http://127.0.0.1:{port}/health",
+    "ready_timeout_secs": 120
+  }
+}


### PR DESCRIPTION
The 2026-08-31/09-01 publication run, consolidated:

- **Seven new bench subjects** with drivers + subject.json: VoltAgent, Mastra, Agno AgentOS, AgentScope Runtime, Awaken, Restate, Temporal (Golem deferred — bespoke deploy lifecycle; Letta driver pre-existed).
- **Brain driver wire fix**: send now posts the #118 `{"input":{"message":…}}` record (the old shape broke every brain bench turn post-#118).
- **README charts rebuilt** from the consolidated run: thirteen subjects, every row measured on the same c7g.xlarge at pinned versions, log-scaled bars, new journal-growth chart. The cold-start chart is removed — no current probe measures it and the old figures predate the instance-type mislabel discovery.
- Legacy subjects remeasured at their pins on the same box: zeroclaw v0.8.4 (2.2/10.6/53 ms), openclaw 2026.7.1-2 (5.4 ms/1.33 s/3.33 s), openfang acf2587e (9.8/70/128 ms), langgraph-api 0.13.0 (0.66/207 ms/1.22 s).
- Known measurement issues stay out of the charts: brain throughput at 64-way is junk (#125), rt degrades with accumulated sessions (#124), the resident probe refuses subjects whose per-session cost sits below host drift (footnote, not bars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)