### PR TITLE
release: @aexhq/brain 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Carries the dispatch-channels cut (#130): served tools over Brain-terminated
channels, share keys, tool()/env-placement surface, callback hosting removed.
All three contract digests moved, so the bump is breaking by pre-1.0
convention.
