### PR TITLE
perf: warm per-session instances, state handed back in the guest's own bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ VoltAgent  █                                       4.3 ms
 Agno       ███████                                  13 ms
 Mastra     █████████                                20 ms
 Restate    ███████████                              31 ms
-Brain      ██████████████                           51 ms ★
+Brain      █████████████                            40 ms ★
 ZeroClaw   ██████████████                           53 ms
 OpenFang   ███████████████████                     128 ms
 Temporal   ████████████████████                    174 ms
@@ -57,7 +57,7 @@ VoltAgent  █                                       6.6 ms
 ZeroClaw   ████                                     11 ms
 Mastra     ████                                     11 ms
 Agno       ███████                                  16 ms
-Brain      ██████████████                           51 ms ★
+Brain      ████████████                             40 ms ★
 OpenFang   ████████████████                         70 ms
 LangGraph  ██████████████████████                  207 ms
 AgentScope █████████████████████████               332 ms

--- a/crates/brain-loophost/examples/activate-package.rs
+++ b/crates/brain-loophost/examples/activate-package.rs
@@ -19,9 +19,12 @@ fn main() -> Result<(), String> {
             .collect(),
     )?;
     let admitted = engine.admit(&package)?;
+    let warm = brain_loophost::WarmInstances::default();
     let output = admitted.activate(
         engine.engine(),
         engine.limits(),
+        &warm,
+        "ses_example",
         ActivationInput {
             context: ContextEnvelope {
                 protocol_version: "agentloop/v1".into(),

--- a/crates/brain-loophost/src/client.rs
+++ b/crates/brain-loophost/src/client.rs
@@ -43,6 +43,7 @@ impl WorkerClient {
     /// once rather than once to measure and once to send.
     pub async fn activate(
         &self,
+        session: String,
         digest: AgentloopIdentity,
         input: ActivationInput,
         max_input_bytes: usize,
@@ -51,6 +52,7 @@ impl WorkerClient {
             .call_bounded(
                 WorkerRequest::Activate {
                     digest,
+                    session,
                     input: Box::new(input),
                 },
                 max_input_bytes,

--- a/crates/brain-loophost/src/lib.rs
+++ b/crates/brain-loophost/src/lib.rs
@@ -10,7 +10,7 @@ mod wire;
 
 pub use limits::LoopLimits;
 pub use package::{AgentloopManifest, AgentloopPackage};
-pub use runtime::{AdmissionEngine, AdmittedAgentloop};
+pub use runtime::{AdmissionEngine, AdmittedAgentloop, WarmInstances};
 pub use service::WorkerService;
 pub use supervisor::WorkerPool;
 pub use wire::{WorkerRequest, WorkerResponse};

--- a/crates/brain-loophost/src/runtime.rs
+++ b/crates/brain-loophost/src/runtime.rs
@@ -102,33 +102,99 @@ impl AdmissionEngine {
     }
 }
 
+/// Warm instances, keyed by session and component: the guest that answered a session's
+/// last activation, kept alive so the next one skips instantiation — and, for a runtime
+/// that caches its own parsed state, re-reading the whole conversation.
+///
+/// This is a cache, not a contract: an entry can vanish at any moment (eviction, a trap,
+/// a worker restart), so a correct agentloop must keep everything it needs in the state
+/// the activation contract carries. That has always been the documented model; a loop
+/// that hoards data in module scope was relying on nothing.
+#[derive(Default)]
+pub struct WarmInstances {
+    entries: std::sync::Mutex<Vec<WarmEntry>>,
+}
+
+/// Sessions kept warm at once. Each entry is a live JS engine whose heap holds one
+/// conversation, so this bounds worker memory the way `running` bounds instances.
+const WARM_SESSIONS: usize = 8;
+
+struct WarmEntry {
+    session: String,
+    digest: AgentloopIdentity,
+    store: Store<StoreLimits>,
+    bindings: bindings::Agentloop,
+}
+
+impl WarmInstances {
+    fn take(&self, session: &str, digest: &AgentloopIdentity) -> Option<WarmEntry> {
+        let mut entries = self.entries.lock().ok()?;
+        let at = entries
+            .iter()
+            .position(|entry| entry.session == session && &entry.digest == digest)?;
+        Some(entries.remove(at))
+    }
+
+    fn keep(&self, entry: WarmEntry) {
+        let Ok(mut entries) = self.entries.lock() else {
+            return;
+        };
+        entries.retain(|kept| kept.session != entry.session);
+        if entries.len() >= WARM_SESSIONS {
+            entries.remove(0);
+        }
+        entries.push(entry);
+    }
+}
+
 impl AdmittedAgentloop {
     pub fn activate(
         &self,
         engine: &Engine,
         limits: &LoopLimits,
+        warm: &WarmInstances,
+        session: &str,
         input: ActivationInput,
     ) -> Result<ActivationOutput, String> {
-        let store_limits = StoreLimitsBuilder::new()
-            .memory_size(limits.linear_memory_bytes)
-            .instances(1)
-            .build();
-        let mut store = Store::new(engine, store_limits);
-        store.limiter(|limits| limits);
-        // The guest's own wall-clock bound. Until this was driven, `epoch_deadline(1)`
-        // could never be reached — nothing advanced the epoch — so the only limit on an
-        // activation was the supervisor's IPC timeout, which abandons the worker and
-        // every warm instance in it. A trap here costs one instance.
-        store.set_epoch_deadline(epoch_deadline_ticks(limits.wall_time));
-        let linker = Linker::<StoreLimits>::new(engine);
-        let bindings = bindings::Agentloop::instantiate(&mut store, &self.component, &linker)
-            .map_err(|error| error.to_string())?;
+        let mut entry = match warm.take(session, &self.digest) {
+            Some(entry) => entry,
+            None => {
+                let store_limits = StoreLimitsBuilder::new()
+                    .memory_size(limits.linear_memory_bytes)
+                    .instances(1)
+                    .build();
+                let mut store = Store::new(engine, store_limits);
+                store.limiter(|limits| limits);
+                let linker = Linker::<StoreLimits>::new(engine);
+                let bindings =
+                    bindings::Agentloop::instantiate(&mut store, &self.component, &linker)
+                        .map_err(|error| error.to_string())?;
+                WarmEntry {
+                    session: session.to_owned(),
+                    digest: self.digest.clone(),
+                    store,
+                    bindings,
+                }
+            }
+        };
+        // The guest's own wall-clock bound, re-armed per activation. Until this was
+        // driven, `epoch_deadline(1)` could never be reached — nothing advanced the
+        // epoch — so the only limit on an activation was the supervisor's IPC timeout,
+        // which abandons the worker and every warm instance in it. A trap here costs
+        // one instance: the entry is dropped rather than kept, because a trapped guest's
+        // heap is not a state anyone can vouch for.
+        entry
+            .store
+            .set_epoch_deadline(epoch_deadline_ticks(limits.wall_time));
         let input = to_wit_input(input)?;
-        let output = bindings
-            .call_step(&mut store, &input)
+        let output = entry
+            .bindings
+            .call_step(&mut entry.store, &input)
             .map_err(activation_error)?
             .map_err(|error| format!("{}: {}", error.code, error.message))?;
-        from_wit_output(output)
+        let output = from_wit_output(output)?;
+        warm.keep(entry);
+        Ok(output)
     }
 }
 

--- a/crates/brain-loophost/src/runtime.rs
+++ b/crates/brain-loophost/src/runtime.rs
@@ -124,6 +124,17 @@ struct WarmEntry {
     digest: AgentloopIdentity,
     store: Store<StoreLimits>,
     bindings: bindings::Agentloop,
+    /// The state the guest returned last activation: its parsed value beside the exact
+    /// bytes the guest produced. The kernel round-trips state through `serde_json::Value`,
+    /// which re-serializes with different bytes (sorted keys), so without this the guest's
+    /// own byte-equality cache could never hit. When the incoming value is structurally
+    /// equal to what the guest returned, it is handed back verbatim.
+    last_state: Option<LastState>,
+}
+
+struct LastState {
+    value: serde_json::Value,
+    raw: String,
 }
 
 impl WarmInstances {
@@ -174,6 +185,7 @@ impl AdmittedAgentloop {
                     digest: self.digest.clone(),
                     store,
                     bindings,
+                    last_state: None,
                 }
             }
         };
@@ -186,13 +198,23 @@ impl AdmittedAgentloop {
         entry
             .store
             .set_epoch_deadline(epoch_deadline_ticks(limits.wall_time));
-        let input = to_wit_input(input)?;
+        let state_json = match (&entry.last_state, &input.context.state) {
+            (Some(last), Some(state)) if &last.value == state => Some(last.raw.clone()),
+            (_, Some(state)) => Some(serde_json::to_string(state).map_err(|e| e.to_string())?),
+            _ => None,
+        };
+        let input = to_wit_input(input, state_json)?;
         let output = entry
             .bindings
             .call_step(&mut entry.store, &input)
             .map_err(activation_error)?
             .map_err(|error| format!("{}: {}", error.code, error.message))?;
+        let raw_state = output.context.state_json.clone();
         let output = from_wit_output(output)?;
+        entry.last_state = match (raw_state, output.context.state.clone()) {
+            (Some(raw), Some(value)) => Some(LastState { value, raw }),
+            _ => None,
+        };
         warm.keep(entry);
         Ok(output)
     }
@@ -243,6 +265,7 @@ fn epoch_deadline_ticks(budget: Duration) -> u64 {
 
 fn to_wit_input(
     input: ActivationInput,
+    state_json: Option<String>,
 ) -> Result<bindings::aex::agentloop::types::ActivationInput, String> {
     use bindings::aex::agentloop::types as wit;
     let observation = match input.observation {
@@ -268,12 +291,7 @@ fn to_wit_input(
             protocol_version: input.context.protocol_version,
             items_json: serde_json::to_string(&input.context.items)
                 .map_err(|error| error.to_string())?,
-            state_json: input
-                .context
-                .state
-                .map(|state| serde_json::to_string(&state))
-                .transpose()
-                .map_err(|error| error.to_string())?,
+            state_json,
         },
         observation,
         configuration_json: serde_json::to_string(&input.configuration)

--- a/crates/brain-loophost/src/service.rs
+++ b/crates/brain-loophost/src/service.rs
@@ -16,7 +16,9 @@ use std::{
 
 use tokio::sync::Semaphore;
 
-use crate::{AdmissionEngine, AdmittedAgentloop, LoopLimits, WorkerRequest, WorkerResponse};
+use crate::{
+    AdmissionEngine, AdmittedAgentloop, LoopLimits, WarmInstances, WorkerRequest, WorkerResponse,
+};
 
 pub struct WorkerService {
     engine: Arc<AdmissionEngine>,
@@ -26,6 +28,9 @@ pub struct WorkerService {
     /// rather than being refused: the supervisor already refused everything beyond its
     /// own queue, so whatever reaches this point is worth a slot.
     running: Semaphore,
+    /// Warm instances, one per recently active session, so a turn's activations do not
+    /// pay instantiation and state re-parsing for a conversation this worker just held.
+    warm: Arc<WarmInstances>,
 }
 
 impl WorkerService {
@@ -35,6 +40,7 @@ impl WorkerService {
             engine: Arc::new(AdmissionEngine::new(limits, allowed_imports)?),
             admitted: RwLock::new(HashMap::new()),
             running,
+            warm: Arc::new(WarmInstances::default()),
         })
     }
 
@@ -56,8 +62,13 @@ impl WorkerService {
         match request {
             WorkerRequest::Ping => WorkerResponse::Pong,
             WorkerRequest::Admit { package_json } => self.admit(package_json).await,
-            WorkerRequest::Activate { digest, input } => {
-                self.activate(digest.as_str().to_owned(), *input).await
+            WorkerRequest::Activate {
+                digest,
+                session,
+                input,
+            } => {
+                self.activate(digest.as_str().to_owned(), session, *input)
+                    .await
             }
         }
     }
@@ -86,6 +97,7 @@ impl WorkerService {
     async fn activate(
         &self,
         digest: String,
+        session: String,
         input: brain_protocol::ActivationInput,
     ) -> WorkerResponse {
         let component = self
@@ -105,10 +117,11 @@ impl WorkerService {
             return failed("activation_failed", "the worker is shutting down".into());
         };
         let engine = self.engine.clone();
+        let warm = self.warm.clone();
         // Wasmtime executes synchronously. Left on a runtime thread it blocks every other
         // connection this worker is serving for as long as the guest runs.
         let activated = tokio::task::spawn_blocking(move || {
-            component.activate(engine.engine(), engine.limits(), input)
+            component.activate(engine.engine(), engine.limits(), &warm, &session, input)
         })
         .await;
         match activated {
@@ -170,6 +183,7 @@ mod tests {
                 service.clone().handle(WorkerRequest::Ping),
                 service.clone().handle(WorkerRequest::Ping),
                 service.clone().handle(WorkerRequest::Activate {
+                    session: "ses_test".into(),
                     digest: brain_protocol::AgentloopIdentity::new("agl_missing"),
                     input: Box::new(input()),
                 }),

--- a/crates/brain-loophost/src/supervisor.rs
+++ b/crates/brain-loophost/src/supervisor.rs
@@ -88,6 +88,7 @@ impl WorkerPool {
 
     pub async fn activate(
         &self,
+        session: String,
         digest: AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, String> {
@@ -117,7 +118,7 @@ impl WorkerPool {
             }
         }
         let client = WorkerClient::new(&self.socket);
-        let call = client.activate(digest, input, self.limits.activation_input_bytes);
+        let call = client.activate(session, digest, input, self.limits.activation_input_bytes);
         // The guest is stopped by its own epoch deadline at `wall_time`, which costs one
         // instance. This timeout is the backstop for what an epoch cannot interrupt — a
         // worker blocked in a host call, a crashed worker, a socket that never answers —

--- a/crates/brain-loophost/src/wire.rs
+++ b/crates/brain-loophost/src/wire.rs
@@ -15,6 +15,8 @@ pub enum WorkerRequest {
     },
     Activate {
         digest: AgentloopIdentity,
+        /// Cache key for a warm instance; never handed to the guest.
+        session: String,
         input: Box<ActivationInput>,
     },
 }

--- a/crates/brain-loophost/tests/worker_process.rs
+++ b/crates/brain-loophost/tests/worker_process.rs
@@ -22,6 +22,7 @@ async fn real_worker_admits_and_activates_the_typescript_diagnostic_loop() {
     let digest = pool.admit(package).await.unwrap();
     let output = pool
         .activate(
+            "ses_worker_test".into(),
             digest,
             ActivationInput {
                 context: ContextEnvelope {
@@ -81,7 +82,7 @@ async fn concurrent_activations_all_reach_the_agentloop() {
         let pool = pool.clone();
         let digest = digest.clone();
         activations.push(tokio::spawn(async move {
-            pool.activate(digest, activation(index)).await
+            pool.activate(format!("ses_{index}"), digest, activation(index)).await
         }));
     }
 

--- a/crates/brain-loophost/tests/worker_process.rs
+++ b/crates/brain-loophost/tests/worker_process.rs
@@ -82,7 +82,8 @@ async fn concurrent_activations_all_reach_the_agentloop() {
         let pool = pool.clone();
         let digest = digest.clone();
         activations.push(tokio::spawn(async move {
-            pool.activate(format!("ses_{index}"), digest, activation(index)).await
+            pool.activate(format!("ses_{index}"), digest, activation(index))
+                .await
         }));
     }
 

--- a/crates/brain-server/src/service.rs
+++ b/crates/brain-server/src/service.rs
@@ -645,11 +645,12 @@ pub struct WorkerLoopExecutor(pub Arc<WorkerPool>);
 impl LoopExecutor for WorkerLoopExecutor {
     async fn activate(
         &self,
+        session: &brain_protocol::SessionId,
         agentloop: &AgentloopIdentity,
         input: brain_protocol::ActivationInput,
     ) -> Result<brain_protocol::ActivationOutput, KernelError> {
         self.0
-            .activate(agentloop.clone(), input)
+            .activate(session.as_str().to_owned(), agentloop.clone(), input)
             .await
             .map_err(KernelError::Executor)
     }

--- a/crates/brain/src/agentloop.rs
+++ b/crates/brain/src/agentloop.rs
@@ -1,12 +1,15 @@
 use async_trait::async_trait;
-use brain_protocol::{ActivationInput, ActivationOutput, AgentloopIdentity};
+use brain_protocol::{ActivationInput, ActivationOutput, AgentloopIdentity, SessionId};
 
 use crate::KernelError;
 
 #[async_trait]
 pub trait LoopExecutor: Send + Sync + 'static {
+    /// Runs one activation. The session names which conversation this is so an executor
+    /// may keep a warm instance per session; it must never reach the guest.
     async fn activate(
         &self,
+        session: &SessionId,
         agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError>;

--- a/crates/brain/src/session/actor.rs
+++ b/crates/brain/src/session/actor.rs
@@ -199,8 +199,9 @@ impl SessionActor {
             )?;
             let loop_executor = self.loop_executor.clone();
             let agentloop_identity = self.sealed.agentloop_identity.clone();
+            let session_id = self.row.session_id.clone();
             let output = match self
-                .interruptible(loop_executor.activate(&agentloop_identity, activation))
+                .interruptible(loop_executor.activate(&session_id, &agentloop_identity, activation))
                 .await
             {
                 Err(()) => return self.cancel_turn(),
@@ -698,7 +699,11 @@ impl SessionActor {
         };
         let output = self
             .loop_executor
-            .activate(&self.sealed.agentloop_identity, activation)
+            .activate(
+                &self.row.session_id,
+                &self.sealed.agentloop_identity,
+                activation,
+            )
             .await?;
         if output.context.protocol_version != self.context.protocol_version {
             return Err(KernelError::InvalidState(

--- a/crates/brain/tests/journal_growth.rs
+++ b/crates/brain/tests/journal_growth.rs
@@ -55,6 +55,7 @@ struct GrowingLoop {
 impl LoopExecutor for GrowingLoop {
     async fn activate(
         &self,
+        _session: &brain_protocol::SessionId,
         _agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError> {
@@ -534,6 +535,7 @@ struct ResendingLoop {
 impl LoopExecutor for ResendingLoop {
     async fn activate(
         &self,
+        _session: &brain_protocol::SessionId,
         _agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError> {
@@ -644,6 +646,7 @@ struct AskOnce;
 impl LoopExecutor for AskOnce {
     async fn activate(
         &self,
+        _session: &brain_protocol::SessionId,
         _agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError> {

--- a/crates/brain/tests/kernel.rs
+++ b/crates/brain/tests/kernel.rs
@@ -30,6 +30,7 @@ struct ScriptedLoop {
 impl LoopExecutor for ScriptedLoop {
     async fn activate(
         &self,
+        _session: &brain_protocol::SessionId,
         _agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError> {
@@ -109,6 +110,7 @@ struct ToolLoop;
 impl LoopExecutor for ToolLoop {
     async fn activate(
         &self,
+        _session: &brain_protocol::SessionId,
         _agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError> {
@@ -608,6 +610,7 @@ struct RecordsHistory {
 impl LoopExecutor for RecordsHistory {
     async fn activate(
         &self,
+        _session: &brain_protocol::SessionId,
         _agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError> {
@@ -822,6 +825,7 @@ struct OrdinaryTurn;
 impl LoopExecutor for OrdinaryTurn {
     async fn activate(
         &self,
+        _session: &brain_protocol::SessionId,
         _agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError> {
@@ -981,6 +985,7 @@ struct OneToolTurn {
 impl LoopExecutor for OneToolTurn {
     async fn activate(
         &self,
+        _session: &brain_protocol::SessionId,
         _agentloop: &AgentloopIdentity,
         input: ActivationInput,
     ) -> Result<ActivationOutput, KernelError> {

--- a/crates/brain/tests/turn_scaling.rs
+++ b/crates/brain/tests/turn_scaling.rs
@@ -1,0 +1,178 @@
+//! Reproduces brain#124: turn round-trip degrading as sessions accumulate.
+//!
+//! Pure kernel, scripted executors — if latency scales with resident session count
+//! here, the cost is in the kernel or journal, not the HTTP or loophost layers.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use brain::{Kernel, KernelConfig, KernelError, LoopExecutor, ModelExecutor, ToolExecutor};
+use brain_protocol::{
+    ActivationInput, ActivationOutput, AgentloopIdentity, Decision, Identity, MessageRequest,
+    ModelBinding, ModelPresentation, ModelRequest, ModelResult, ModelStreamEvent, Observation,
+    OperationId, Outcome, ResolvedSessionRequest, SealedSessionConfig, ToolCancellation,
+    ToolDispatch,
+};
+use brain_telemetry::telemetry_channel;
+
+struct OneModelTurn;
+
+#[async_trait]
+impl LoopExecutor for OneModelTurn {
+    async fn activate(
+        &self,
+        _session: &brain_protocol::SessionId,
+        _agentloop: &AgentloopIdentity,
+        input: ActivationInput,
+    ) -> Result<ActivationOutput, KernelError> {
+        let decision = match input.observation {
+            Observation::ModelCompleted { .. } => Decision::Finish { result: None },
+            _ => Decision::Model {
+                request: ModelRequest {
+                    messages: vec![brain_protocol::Message::user_text("hello")],
+                    response_format: None,
+                    max_output_tokens: Some(16),
+                },
+            },
+        };
+        Ok(ActivationOutput {
+            context: input.context,
+            decision,
+        })
+    }
+}
+
+struct InstantModel;
+
+#[async_trait]
+impl ModelExecutor for InstantModel {
+    async fn execute(
+        &self,
+        _operation_id: &OperationId,
+        _request_digest: &Identity,
+        _binding: &ModelBinding,
+        _presentation: &ModelPresentation,
+        _request: ModelRequest,
+        _on_event: &mut (dyn FnMut(ModelStreamEvent) + Send),
+    ) -> Result<ModelResult, KernelError> {
+        Ok(ModelResult {
+            message: brain_protocol::Message::assistant(vec![brain_protocol::ContentBlock::text(
+                "hi",
+            )]),
+            stop_reason: brain_protocol::StopReason::EndTurn,
+            usage: brain_protocol::Usage::default(),
+        })
+    }
+}
+
+struct NoTools;
+
+#[async_trait]
+impl ToolExecutor for NoTools {
+    async fn execute(&self, _dispatch: ToolDispatch) -> Result<Outcome, KernelError> {
+        unreachable!()
+    }
+    async fn cancel(&self, _cancellation: ToolCancellation) -> Result<(), KernelError> {
+        unreachable!()
+    }
+}
+
+fn sealed() -> SealedSessionConfig {
+    SealedSessionConfig {
+        agentloop_identity: AgentloopIdentity::new("a".repeat(64)),
+        brain_configuration: serde_json::json!({}),
+        model: ModelBinding {
+            binding_id: "gateway".into(),
+            model: "openai/test".into(),
+        },
+        presentation: ModelPresentation {
+            system: "test".into(),
+            tools: Vec::new(),
+            response_format: None,
+        },
+        environments: Vec::new(),
+        tool_bindings: Vec::new(),
+    }
+}
+
+fn resolved(sealed: &SealedSessionConfig) -> ResolvedSessionRequest {
+    ResolvedSessionRequest {
+        history: Vec::new(),
+        agentloop_identity: sealed.agentloop_identity.clone(),
+        brain_configuration: sealed.brain_configuration.clone(),
+        model: sealed.model.clone(),
+        presentation: sealed.presentation.clone(),
+        environments: Vec::new(),
+        tool_bindings: Vec::new(),
+    }
+}
+
+/// Run turns at several accumulated-session counts and print the medians. Marked
+/// ignored: it is a measurement, not an assertion — run with
+/// `cargo test -p brain --test turn_scaling -- --ignored --nocapture`.
+#[tokio::test]
+#[ignore]
+async fn turn_latency_versus_resident_sessions() {
+    let data_dir = std::env::temp_dir().join(format!("brain-scaling-{}", rand::random::<u64>()));
+    std::fs::create_dir(&data_dir).unwrap();
+    let (publisher, _worker) = telemetry_channel();
+    let kernel = Kernel::open(
+        KernelConfig {
+            data_dir: data_dir.clone(),
+            max_decisions_per_turn: 8,
+            tool_deadline_ms: brain::DEFAULT_TOOL_DEADLINE_MS,
+            loop_executor: Arc::new(OneModelTurn),
+            model_executor: Arc::new(InstantModel),
+            tool_executor: Arc::new(NoTools),
+        },
+        publisher,
+    )
+    .unwrap();
+
+    let mut created = 0_u64;
+    for checkpoint in [10_u64, 250, 500, 1000, 2000, 4000] {
+        // Accumulate sessions, one settled turn each, like the bench box does.
+        while created < checkpoint {
+            let handle = kernel
+                .begin_session(&resolved(&sealed()))
+                .unwrap()
+                .complete(sealed())
+                .unwrap();
+            handle
+                .message(MessageRequest {
+                    input: "warm".into(),
+                })
+                .await
+                .unwrap();
+            created += 1;
+        }
+        // Measure fresh turns on one new session at this population.
+        let probe = kernel
+            .begin_session(&resolved(&sealed()))
+            .unwrap()
+            .complete(sealed())
+            .unwrap();
+        created += 1;
+        let mut samples = Vec::with_capacity(100);
+        for turn in 0..100 {
+            let started = Instant::now();
+            probe
+                .message(MessageRequest {
+                    input: format!("turn {turn}").into(),
+                })
+                .await
+                .unwrap();
+            samples.push(started.elapsed().as_secs_f64() * 1000.0);
+        }
+        samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        println!(
+            "sessions={:>5}  turn p50={:.3} ms  p90={:.3} ms  max={:.3} ms",
+            created, samples[50], samples[90], samples[99],
+        );
+    }
+
+    drop(kernel);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let _ = std::fs::remove_dir_all(data_dir);
+}

--- a/packages/brain-sdk/src/build.ts
+++ b/packages/brain-sdk/src/build.ts
@@ -244,15 +244,24 @@ const encodeDecision = (decision) => {
     default: throw new Error("unknown Agentloop action " + decision.type);
   }
 };
+// The state this instance produced last activation, kept beside its serialized form.
+// When the host keeps the instance warm across a session's activations, the incoming
+// state is byte-identical to what step just returned, and handing back the same object
+// lets the runtime skip re-reading a conversation it already holds. A cold instance
+// misses and parses — the cache is an optimization, never a source of truth.
+let warm = { stateJson: undefined, state: undefined };
 export function step(input) {
+  const incoming = input.context.stateJson;
   const output = activateAgentloop(definition, {
-    context: { state: input.context.stateJson === undefined ? undefined : JSON.parse(input.context.stateJson) },
+    context: { state: incoming === undefined ? undefined : incoming === warm.stateJson ? warm.state : JSON.parse(incoming) },
     observation: decodeObservation(input.observation),
     configuration: JSON.parse(input.configurationJson),
     runtime: { logicalTimeMs: input.runtime.logicalTimeMs },
   });
+  const stateJson = JSON.stringify(output.context.state);
+  warm = { stateJson, state: output.context.state };
   return {
-    context: { protocolVersion: output.context.protocolVersion, itemsJson: JSON.stringify(output.context.items), stateJson: JSON.stringify(output.context.state) },
+    context: { protocolVersion: output.context.protocolVersion, itemsJson: JSON.stringify(output.context.items), stateJson },
     decision: encodeDecision(output.decision),
   };
 }

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -825,7 +825,13 @@ export function activateAgentloop(factory: unknown, input: AgentloopInput): { re
   const handler = handlers.get(input.observation.type);
   const action = handler === undefined ? defaultAction(input.observation.type) : handler(input.observation as never, turn(input.runtime.logicalTimeMs));
   if (isPromise(action)) throw new TypeError("Agentloop handlers must be synchronous");
-  for (let index = 0; index < schemas.length; index += 1) slots[index] = schemas[index]!.parse(slots[index]);
+  // Re-validating every slot on every activation cost O(conversation) three times per
+  // turn. Mid-turn continuations skip it: the state is never persisted before the turn
+  // ends, and the next activation receives it by identity, so a handler that corrupts
+  // its state is still caught — at the turn's terminal decision instead of immediately.
+  if (action.type !== "model" && action.type !== "tools") {
+    for (let index = 0; index < schemas.length; index += 1) slots[index] = schemas[index]!.parse(slots[index]);
+  }
   if (action.type === "reply") return output(slots, true, action.input, { type: "emit", event: { type: "assistant_message", message: action.input.message } });
   return output(slots, false, undefined, action);
 }

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -786,9 +786,17 @@ export function endEnvironment(value: Environment): void {
   if (metadata !== undefined) metadata.ended = true;
 }
 
+/// The exact state object the previous activation returned. Incoming state that is
+/// reference-identical to it was validated by this runtime on its way out, so the slot
+/// schemas need not re-parse a conversation that only ever grows — the check that cost
+/// O(history) per activation. Anything else (a cold instance, a host that re-read the
+/// journal) misses and takes the full validation path.
+let warmState: unknown;
+
 export function activateAgentloop(factory: unknown, input: AgentloopInput): { readonly context: { readonly protocolVersion: "agentloop/v1"; readonly items: readonly unknown[]; readonly state: unknown }; readonly decision: Exclude<AgentloopAction, { type: "reply" }> } {
   const source = sourceOf(factory as ExtensionFactory, "agentloop") as AgentloopSource;
   const options = source.options === undefined ? requireEmptyConfiguration(input.configuration) : source.options.parse(input.configuration);
+  const trusted = input.context.state !== undefined && input.context.state === warmState;
   const envelope = parseStateEnvelope(input.context.state);
   if (input.observation.type === "emitted" && Object.hasOwn(envelope, "pendingReply")) return output(envelope.slots, false, undefined, { type: "finish", result: envelope.pendingReply });
   const handlers = new Map<string, AgentloopHandler<never>>();
@@ -804,7 +812,9 @@ export function activateAgentloop(factory: unknown, input: AgentloopInput): { re
     state(schema, initial) {
       const index = schemas.length;
       schemas.push(schema);
-      const value = index < envelope.slots.length ? schema.parse(envelope.slots[index]) : schema.parse(initial());
+      const value = index < envelope.slots.length
+        ? (trusted ? envelope.slots[index] as ReturnType<typeof schema.parse> : schema.parse(envelope.slots[index]))
+        : schema.parse(initial());
       slots.push(value);
       return value;
     },
@@ -834,7 +844,9 @@ function turn(logicalTimeMs: bigint): AgentloopTurn {
 }
 
 function output(slots: readonly unknown[], hasPendingReply: boolean, pendingReply: unknown, decision: Exclude<AgentloopAction, { type: "reply" }>) {
-  return { context: { protocolVersion: "agentloop/v1" as const, items: [], state: { version: 1, slots, ...(hasPendingReply ? { pendingReply } : {}) } }, decision };
+  const state = { version: 1, slots, ...(hasPendingReply ? { pendingReply } : {}) };
+  warmState = state;
+  return { context: { protocolVersion: "agentloop/v1" as const, items: [], state }, decision };
 }
 
 function defaultAction(type: AgentloopInput["observation"]["type"]): Exclude<AgentloopAction, { type: "reply" }> {


### PR DESCRIPTION
## The finding (what brain#124 actually was)

Turn round-trip does not degrade with accumulated *sessions* — kernel-level and full-stack sweeps are flat from 11 to 4,001 resident sessions. It degrades with accumulated *turns in one conversation*: 15 ms at turn 0 → 77 ms at turn 900, perfectly linear (+7.8 ms/100 turns, measured on c7g.xlarge). The rt probe drives 900 turns into one session, so its p50 lands mid-conversation — that is the published 52 ms. Server-side journal timestamps during the same probe show early turns executing back-to-back at ~12 ms.

The linear term was the per-activation cost of re-reading a conversation that only grows: a fresh Store+instantiate per activation, the shim JSON-parsing the whole state, and the runtime zod-validating every slot on the way in *and* out — ×3 activations per turn.

## The fix

- The worker keeps up to eight warm instances keyed by session (the `Activate` frame carries the session id; the guest never sees it). A trap drops the entry; any miss takes the cold path.
- The warm entry keeps the raw state string the guest produced beside its parsed value; when the kernel hands back a structurally equal value, the guest receives its own bytes verbatim (the kernel's `serde_json::Value` round-trip re-serializes with different bytes, which silently defeated byte-equality caching).
- The shim and runtime trust state that is byte/reference-identical to their own last output, skipping the parse and the input-side validation; slot re-validation runs at the turn's terminal decision instead of on every mid-turn continuation (state is never persisted mid-turn, and corruption is still caught — one activation later).

The cache is an optimization, never a contract: a correct agentloop keeps everything in the state the activation carries, which has always been the documented model.

## Measured (c7g.xlarge, scripted model, example loop)

| conversation turn | before | after |
|---|---|---|
| 0–99 | 15.1 ms | 9.2 ms |
| 400–499 | 46.1 ms | 35.9 ms |
| 800–899 | 77.3 ms | 62.0 ms |

Base −39%, slope −15%. The remaining linear term is the context shuttle itself — the server↔worker wire re-serializes the full context each activation leg, the guest still stringifies per activation, and the intent identity hashes the whole input; eliminating those means context residency in the worker (sent once per turn, returned once), which is a contract-level redesign filed as a follow-up rather than rushed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)