### PR TITLE
bench: cold start and recovery probes, separable first token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .env.*
 /.worktrees
 tests/release/built/
+.claude/

--- a/tools/bench/runner/src/fixtures.rs
+++ b/tools/bench/runner/src/fixtures.rs
@@ -88,6 +88,12 @@ impl Fixture {
             .unwrap_or_default()
     }
 
+    /// The shared per-call record itself, for probes that outlive one borrow of the
+    /// fixture — recovery reads the latest call's transcript length through it.
+    pub fn timings_handle(&self) -> Arc<Mutex<Vec<CallTiming>>> {
+        Arc::clone(&self.timings)
+    }
+
     /// Stops the fixture. Takes `&self` so a driver can hold a shared handle to it.
     pub fn shutdown(&self) {
         self.handle.abort();

--- a/tools/bench/runner/src/launch.rs
+++ b/tools/bench/runner/src/launch.rs
@@ -67,13 +67,40 @@ pub async fn start(
     model_base_url: &str,
     environment_base_url: &str,
 ) -> Result<Running> {
+    start_in(
+        launch,
+        subject,
+        run_id,
+        model_base_url,
+        environment_base_url,
+        None,
+    )
+    .await
+}
+
+/// Like [`start`], but the caller may supply the data directory. `Some(dir)` reuses it
+/// as-is — the recovery probe's whole point — while `None` gets the usual fresh one.
+pub async fn start_in(
+    launch: &Launch,
+    subject: &str,
+    run_id: &str,
+    model_base_url: &str,
+    environment_base_url: &str,
+    reuse_data_dir: Option<PathBuf>,
+) -> Result<Running> {
     let port = free_port()?;
-    let data_dir = std::env::temp_dir().join(format!("brain-bench-{run_id}-{subject}"));
-    // Removed first in case a previous interrupted run left one behind: on spot capacity
-    // the teardown does not always get to run.
-    let _ = std::fs::remove_dir_all(&data_dir);
-    std::fs::create_dir_all(&data_dir)
-        .with_context(|| format!("creating data directory {}", data_dir.display()))?;
+    let data_dir = match reuse_data_dir {
+        Some(existing) => existing,
+        None => {
+            let fresh = std::env::temp_dir().join(format!("brain-bench-{run_id}-{subject}"));
+            // Removed first in case a previous interrupted run left one behind: on spot
+            // capacity the teardown does not always get to run.
+            let _ = std::fs::remove_dir_all(&fresh);
+            std::fs::create_dir_all(&fresh)
+                .with_context(|| format!("creating data directory {}", fresh.display()))?;
+            fresh
+        }
+    };
 
     let placeholders = Placeholders {
         port,
@@ -179,6 +206,20 @@ impl Running {
             }
             text[start..].to_owned()
         })
+    }
+
+    /// Kills the subject the way a crash does — no grace, no flush — and keeps its data
+    /// directory, so a relaunch can find out what survived. The recovery probe's kill.
+    pub async fn kill_hard(&mut self) {
+        #[cfg(unix)]
+        {
+            // Signal the whole group, so loop workers and other children go too.
+            unsafe {
+                libc::kill(-(self.pid as i32), libc::SIGKILL);
+            }
+        }
+        let _ = self.child.kill().await;
+        let _ = self.child.wait().await;
     }
 
     /// Stops the subject and removes its data directory.

--- a/tools/bench/runner/src/main.rs
+++ b/tools/bench/runner/src/main.rs
@@ -453,6 +453,34 @@ async fn run(cli: Cli) -> Result<()> {
                     // Each probe gets what is left of the run budget, so one hung subject
                     // cannot eat the whole thing waiting on a client timeout per sample.
                     deadline,
+                    // The launch-lifecycle probes start and kill their own instances, so
+                    // they only run for subjects the runner launches itself.
+                    relaunch: entry.launch.as_ref().map(|launch| {
+                        let name = entry.name.clone();
+                        let agentloop = agentloop.clone();
+                        let environment = std::sync::Arc::clone(&environment);
+                        let model_base_url = provider.base_url.clone();
+                        probes::Relaunch {
+                            launch: launch.clone(),
+                            subject: entry.name.clone(),
+                            run_id: writer.run_id().to_owned(),
+                            model_base_url: provider.base_url.clone(),
+                            environment_base_url: environment.base_url.clone(),
+                            provider_timings: provider.timings_handle(),
+                            make_driver: std::sync::Arc::new(move |base_url: String| {
+                                let bench = drivers::Bench {
+                                    base_url,
+                                    agentloop_package: agentloop.clone(),
+                                    pid: None,
+                                    environment: std::sync::Arc::clone(&environment),
+                                    model_base_url: model_base_url.clone(),
+                                };
+                                drivers::for_subject(&name, &bench)?.ok_or_else(|| {
+                                    anyhow::anyhow!("no driver implemented for this subject")
+                                })
+                            }),
+                        }
+                    }),
                 };
                 let step = probes::measure(subject_driver.as_ref(), entry, probe, &context);
                 let point = tokio::select! {

--- a/tools/bench/runner/src/probes.rs
+++ b/tools/bench/runner/src/probes.rs
@@ -45,6 +45,9 @@ pub struct Context_ {
     /// The probe is abandoned past this instant, so one hung subject cannot eat a run's
     /// whole budget. Without it a stuck request costs `samples` × the client timeout.
     pub deadline: Instant,
+    /// Launch access for the probes that restart the subject themselves; `None` for a
+    /// subject someone else runs.
+    pub relaunch: Option<Relaunch>,
 }
 
 pub fn probe_list(entry: &subject::Subject, wanted: &[String]) -> Vec<Probe> {
@@ -90,6 +93,8 @@ pub async fn measure(
         Probe::ToolDispatch | Probe::Create | Probe::Ttfb | Probe::RoundTrip => {
             latency(subject_driver, probe, context, &mut notes).await?
         }
+        Probe::ColdStart => cold_start(context, &mut notes).await?,
+        Probe::Recovery => recovery(context, &mut notes).await?,
         other => anyhow::bail!("{} has no runner yet", other.as_str()),
     };
 
@@ -212,6 +217,23 @@ async fn latency(
             measured.len(),
             context.samples
         ));
+    }
+    // With the scripted provider's first token deliberately delayed, first-byte latency
+    // is separable from turn completion; the delay is the fixture's, not the subject's,
+    // so it comes back out of every sample.
+    if probe == Probe::Ttfb {
+        if let Some(delay_ms) = std::env::var("BENCH_FIRST_TOKEN_DELAY_MS")
+            .ok()
+            .and_then(|value| value.parse::<f64>().ok())
+            .filter(|value| *value > 0.0)
+        {
+            for sample in &mut measured {
+                *sample = (*sample - delay_ms).max(0.0);
+            }
+            notes.push(format!(
+                "scripted first token delayed {delay_ms} ms; subtracted from every sample"
+            ));
+        }
     }
     let mut measured = stats::drop_warmup(measured, 0.1);
     let percentiles = stats::summarize(&mut measured);
@@ -584,4 +606,176 @@ fn spread(readings: &[crate::schema::Reading]) -> f64 {
     let high = values.clone().fold(f64::MIN, f64::max);
     let low = values.fold(f64::MAX, f64::min);
     if high < low { 0.0 } else { high - low }
+}
+
+/// Everything the launch-lifecycle probes need to start, kill, and restart the subject
+/// themselves. `None` when the operator pointed the runner at something already running,
+/// which those probes then refuse — honestly, with a reason.
+pub struct Relaunch {
+    pub launch: subject::Launch,
+    pub subject: String,
+    pub run_id: String,
+    pub model_base_url: String,
+    pub environment_base_url: String,
+    /// The scripted provider's per-call record; `messages` on the latest entry is how
+    /// many transcript messages the subject actually sent the model — the recovery
+    /// probe's proof that a survived session still remembers its conversation.
+    pub provider_timings: std::sync::Arc<std::sync::Mutex<Vec<crate::fixtures::CallTiming>>>,
+    /// Builds a driver against a freshly launched instance's base URL. Each launch gets
+    /// its own: drivers pin their base URL at construction.
+    #[allow(clippy::type_complexity)]
+    pub make_driver: std::sync::Arc<dyn Fn(String) -> Result<Box<dyn Driver>> + Send + Sync>,
+}
+
+/// Launch on a fresh data directory, until the first turn is served.
+///
+/// The redeploy definition: process artifact caches persist across samples (they live
+/// outside the data directory), session data does not. One-time installation — an
+/// agentloop upload, a project — is `prepare` and stays untimed, matching the create
+/// probe's "already admitted" convention. Kept short on purpose: ten samples, one turn
+/// each.
+async fn cold_start(context: &Context_, notes: &mut Vec<String>) -> Result<Outcome> {
+    let relaunch = context
+        .relaunch
+        .as_ref()
+        .context("cold start needs a subject the runner launches itself; --base-url cannot answer it")?;
+    let samples = context.samples.clamp(3, 10);
+    let mut measured = Vec::with_capacity(samples);
+    for index in 0..samples {
+        if Instant::now() >= context.deadline {
+            notes.push(format!(
+                "probe abandoned at the wall-clock deadline after {} of {samples} samples",
+                measured.len()
+            ));
+            break;
+        }
+        let booted = Instant::now();
+        let mut running = crate::launch::start_in(
+            &relaunch.launch,
+            &relaunch.subject,
+            &format!("{}-cold{index}", relaunch.run_id),
+            &relaunch.model_base_url,
+            &relaunch.environment_base_url,
+            None,
+        )
+        .await?;
+        let ready_ms = booted.elapsed().as_secs_f64() * 1_000.0;
+        let mut driver = (relaunch.make_driver)(running.base_url.clone())?;
+        // Installation is not a redeploy cost; the clock pauses for it.
+        driver.prepare().await?;
+        let serving = Instant::now();
+        let unit = driver.create().await?;
+        driver.round_trip_ms(&unit).await?;
+        measured.push(ready_ms + serving.elapsed().as_secs_f64() * 1_000.0);
+        running.stop().await;
+    }
+    let percentiles = stats::summarize(&mut measured);
+    let value = percentiles
+        .p50_ms
+        .context("too few samples to report a median")?;
+    notes.push("launch to first turn served on a fresh data directory; installation (prepare) untimed".to_owned());
+    Ok(Outcome {
+        value,
+        unit: "ms".to_owned(),
+        n: measured.len(),
+        percentiles,
+        resident_kind: None,
+        latency: true,
+    })
+}
+
+/// Turns one conversation deep, kill -9, relaunch on the same data, and time until the
+/// *same session* serves the next turn — with the model's own transcript as proof the
+/// history survived. A subject that comes back without the conversation is a recorded
+/// refusal, not a bar: that is the result.
+async fn recovery(context: &Context_, notes: &mut Vec<String>) -> Result<Outcome> {
+    let relaunch = context
+        .relaunch
+        .as_ref()
+        .context("recovery needs a subject the runner launches itself; --base-url cannot answer it")?;
+    /// Deep enough that lost history is unmistakable, short enough that the warmup is
+    /// seconds — per the no-long-benchmarks rule.
+    const WARM_TURNS: usize = 50;
+    let samples = context.samples.clamp(2, 5);
+    let mut measured = Vec::with_capacity(samples);
+    for index in 0..samples {
+        if Instant::now() >= context.deadline {
+            notes.push(format!(
+                "probe abandoned at the wall-clock deadline after {} of {samples} samples",
+                measured.len()
+            ));
+            break;
+        }
+        let mut before = crate::launch::start_in(
+            &relaunch.launch,
+            &relaunch.subject,
+            &format!("{}-recovery{index}", relaunch.run_id),
+            &relaunch.model_base_url,
+            &relaunch.environment_base_url,
+            None,
+        )
+        .await?;
+        let data_dir = before.data_dir.clone();
+        let mut warm_driver = (relaunch.make_driver)(before.base_url.clone())?;
+        warm_driver.prepare().await?;
+        let unit = warm_driver.create().await?;
+        for _ in 0..WARM_TURNS {
+            warm_driver.round_trip_ms(&unit).await?;
+        }
+        before.kill_hard().await;
+
+        let killed = Instant::now();
+        let mut after = crate::launch::start_in(
+            &relaunch.launch,
+            &relaunch.subject,
+            &format!("{}-recovered{index}", relaunch.run_id),
+            &relaunch.model_base_url,
+            &relaunch.environment_base_url,
+            Some(data_dir),
+        )
+        .await
+        .context("the subject did not come back up on its own data")?;
+        let ready_ms = killed.elapsed().as_secs_f64() * 1_000.0;
+        let mut driver = (relaunch.make_driver)(after.base_url.clone())?;
+        driver.prepare().await?;
+        let serving = Instant::now();
+        let served = driver.round_trip_ms(&unit).await;
+        let serve_ms = serving.elapsed().as_secs_f64() * 1_000.0;
+        let survived = relaunch
+            .provider_timings
+            .lock()
+            .ok()
+            .and_then(|timings| timings.last().map(|timing| timing.messages))
+            .unwrap_or(0);
+        after.stop().await;
+        match served {
+            Err(error) => {
+                anyhow::bail!(
+                    "the subject restarted but the conversation was lost: turn on the surviving session failed: {error:#}"
+                );
+            }
+            Ok(_) if survived < WARM_TURNS => {
+                anyhow::bail!(
+                    "the subject served the turn without its history: the model saw {survived} messages after {WARM_TURNS} prior turns"
+                );
+            }
+            Ok(_) => measured.push(ready_ms + serve_ms),
+        }
+    }
+    let percentiles = stats::summarize(&mut measured);
+    let value = percentiles
+        .p50_ms
+        .context("too few samples to report a median")?;
+    notes.push(format!(
+        "kill -9 after {} turns, relaunch on the same data, until the same session served a turn whose model request carried its history",
+        50
+    ));
+    Ok(Outcome {
+        value,
+        unit: "ms".to_owned(),
+        n: measured.len(),
+        percentiles,
+        resident_kind: None,
+        latency: true,
+    })
 }

--- a/tools/bench/runner/src/schema.rs
+++ b/tools/bench/runner/src/schema.rs
@@ -48,6 +48,19 @@ pub enum Probe {
     Reclaim,
     /// Money per unit-hour.
     Cost,
+    /// Process launch on a fresh data directory, until the first turn is served.
+    ///
+    /// The redeploy definition: process artifact caches (compiled Wasm, bytecode, module
+    /// caches) may persist across samples; session data may not. One-time installation
+    /// (uploading an agentloop, creating a project) is excluded, matching `prepare`'s
+    /// never-timed contract.
+    ColdStart,
+    /// Kill -9 mid-conversation, relaunch on the same data, until the *same session*
+    /// serves the next turn with its history intact.
+    ///
+    /// Three honest outcomes: a time, a recorded "conversation lost", or an error. Most
+    /// subjects lose the conversation, and that is the result.
+    Recovery,
     /// Bytes written to durable storage per turn, against turn index.
     ///
     /// The probe that separates an append-only log from a snapshot-per-step: Agno rewrites
@@ -69,6 +82,8 @@ impl Probe {
             Self::Resident => "resident",
             Self::Reclaim => "reclaim",
             Self::Cost => "cost",
+            Self::ColdStart => "cold_start",
+            Self::Recovery => "recovery",
             Self::Persistence => "persistence",
         }
     }

--- a/tools/bench/subjects/agentscope-runtime/subject.json
+++ b/tools/bench/subjects/agentscope-runtime/subject.json
@@ -14,6 +14,12 @@
     "linux": false
   },
   "probes": {
+    "cold_start": {
+      "definition": "process launch on a fresh data directory until the first turn is served; one-time installation untimed"
+    },
+    "recovery": {
+      "definition": "kill -9 after 50 turns, relaunch on the same data, until the same session serves a turn whose model request carries its history"
+    },
     "ttfb": {
       "definition": "turn submitted to /process until the first content event on its SSE stream — the first model token, after the created and in_progress bookkeeping events that precede any model output. The stream is opened by submitting the turn, so the subscribe cost is inside this number by construction. The probe drains the stream to completion after taking the measurement: hanging up early cancels the handler mid-save and truncates the session's JSON file, poisoning every turn after it"
     },

--- a/tools/bench/subjects/awaken/subject.json
+++ b/tools/bench/subjects/awaken/subject.json
@@ -15,6 +15,12 @@
     "linux": false
   },
   "probes": {
+    "cold_start": {
+      "definition": "process launch on a fresh data directory until the first turn is served; one-time installation untimed"
+    },
+    "recovery": {
+      "definition": "kill -9 after 50 turns, relaunch on the same data, until the same session serves a turn whose model request carries its history"
+    },
     "create": {
       "definition": "POST /v1/threads until the response carries the thread id"
     },

--- a/tools/bench/subjects/brain/subject.json
+++ b/tools/bench/subjects/brain/subject.json
@@ -27,6 +27,12 @@
     "ready_timeout_secs": 60
   },
   "probes": {
+    "cold_start": {
+      "definition": "process launch on a fresh data directory until the first turn is served; one-time installation untimed"
+    },
+    "recovery": {
+      "definition": "kill -9 after 50 turns, relaunch on the same data, until the same session serves a turn whose model request carries its history"
+    },
     "create": {
       "definition": "POST /v1/sessions until the response carries a session_id, agentloop already admitted"
     },

--- a/tools/bench/subjects/langgraph-server/subject.json
+++ b/tools/bench/subjects/langgraph-server/subject.json
@@ -14,6 +14,12 @@
     "linux": true
   },
   "probes": {
+    "cold_start": {
+      "definition": "process launch on a fresh data directory until the first turn is served; one-time installation untimed"
+    },
+    "recovery": {
+      "definition": "kill -9 after 50 turns, relaunch on the same data, until the same session serves a turn whose model request carries its history"
+    },
     "create": {
       "definition": "thread create until it will accept input"
     },

--- a/tools/bench/subjects/letta/subject.json
+++ b/tools/bench/subjects/letta/subject.json
@@ -15,6 +15,12 @@
     "linux": true
   },
   "probes": {
+    "cold_start": {
+      "definition": "process launch on a fresh data directory until the first turn is served; one-time installation untimed"
+    },
+    "recovery": {
+      "definition": "kill -9 after 50 turns, relaunch on the same data, until the same session serves a turn whose model request carries its history"
+    },
     "create": {
       "definition": "POST /v1/agents/ until the response carries an agent id, at Letta's defaults including the base tool set it attaches; no memory blocks"
     },

--- a/tools/bench/subjects/openclaw/subject.json
+++ b/tools/bench/subjects/openclaw/subject.json
@@ -16,6 +16,12 @@
   ],
   "requires": { "linux": true },
   "probes": {
+    "cold_start": {
+      "definition": "process launch on a fresh data directory until the first turn is served; one-time installation untimed"
+    },
+    "recovery": {
+      "definition": "kill -9 after 50 turns, relaunch on the same data, until the same session serves a turn whose model request carries its history"
+    },
     "create": {
       "definition": "`sessions.create` on the Gateway control plane until it returns the session key — the same call the Control UI's new-session button makes. The control connection is opened in `prepare` and is not inside this number"
     },

--- a/tools/bench/subjects/openfang/subject.json
+++ b/tools/bench/subjects/openfang/subject.json
@@ -11,6 +11,12 @@
     "linux": true
   },
   "probes": {
+    "cold_start": {
+      "definition": "process launch on a fresh data directory until the first turn is served; one-time installation untimed"
+    },
+    "recovery": {
+      "definition": "kill -9 after 50 turns, relaunch on the same data, until the same session serves a turn whose model request carries its history"
+    },
     "create": {
       "definition": "session create call until the session will accept a message"
     },

--- a/tools/bench/subjects/zeroclaw/subject.json
+++ b/tools/bench/subjects/zeroclaw/subject.json
@@ -14,6 +14,12 @@
   ],
   "requires": { "linux": true },
   "probes": {
+    "cold_start": {
+      "definition": "process launch on a fresh data directory until the first turn is served; one-time installation untimed"
+    },
+    "recovery": {
+      "definition": "kill -9 after 50 turns, relaunch on the same data, until the same session serves a turn whose model request carries its history"
+    },
     "create": {
       "definition": "chat WebSocket upgrade until the gateway has answered the client's connect frame — zeroclaw's session create, after which the session accepts a message"
     },


### PR DESCRIPTION
Two probes no published agent-runtime benchmark has, per the measurement plan:

- **cold_start** — launch on a fresh data dir → first turn served (redeploy definition: artifact caches persist, session data doesn't; installation untimed). n clamped 3–10.
- **recovery** — 50-turn conversation, kill -9, relaunch on the same data dir, timed until the *same session* serves a turn whose model request carries ≥50 messages (verified at the scripted provider). A subject that restarts without the conversation records a skip with the reason — for most of the chart, "conversation lost" *is* the result. n clamped 2–5.
- **ttfb, made real** — with BENCH_FIRST_TOKEN_DELAY_MS set, the fixture's delay is subtracted from every sample, so Brain's first-token stops being a whole-turn upper bound.

Launch-lifecycle probes run only for runner-launched subjects (--base-url refuses with a reason). Declared for the eight charted agent runtimes. Sample counts deliberately small per the no-long-benchmarks rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)