### PR TITLE
perf: context stays resident in the worker for the turn

### DIFF
--- a/crates/brain-loophost/examples/activate-package.rs
+++ b/crates/brain-loophost/examples/activate-package.rs
@@ -20,11 +20,14 @@ fn main() -> Result<(), String> {
     )?;
     let admitted = engine.admit(&package)?;
     let warm = brain_loophost::WarmInstances::default();
-    let output = admitted.activate(
+    let resident = brain_loophost::ResidentContexts::default();
+    let (output, _context_attached) = admitted.activate(
         engine.engine(),
         engine.limits(),
         &warm,
+        &resident,
         "ses_example",
+        true,
         ActivationInput {
             context: ContextEnvelope {
                 protocol_version: "agentloop/v1".into(),

--- a/crates/brain-loophost/src/client.rs
+++ b/crates/brain-loophost/src/client.rs
@@ -45,14 +45,16 @@ impl WorkerClient {
         &self,
         session: String,
         digest: AgentloopIdentity,
+        context_attached: bool,
         input: ActivationInput,
         max_input_bytes: usize,
-    ) -> Result<ActivationOutput, String> {
+    ) -> Result<(ActivationOutput, bool), String> {
         match self
             .call_bounded(
                 WorkerRequest::Activate {
                     digest,
                     session,
+                    context_attached,
                     input: Box::new(input),
                 },
                 max_input_bytes,
@@ -65,7 +67,10 @@ impl WorkerClient {
                     error
                 }
             })? {
-            WorkerResponse::Activated { output } => Ok(output),
+            WorkerResponse::Activated {
+                output,
+                context_attached,
+            } => Ok((output, context_attached)),
             WorkerResponse::Error { code, message } => Err(format!("{code}: {message}")),
             response => Err(format!("unexpected worker response: {response:?}")),
         }

--- a/crates/brain-loophost/src/lib.rs
+++ b/crates/brain-loophost/src/lib.rs
@@ -10,7 +10,7 @@ mod wire;
 
 pub use limits::LoopLimits;
 pub use package::{AgentloopManifest, AgentloopPackage};
-pub use runtime::{AdmissionEngine, AdmittedAgentloop, WarmInstances};
+pub use runtime::{AdmissionEngine, AdmittedAgentloop, ResidentContexts, WarmInstances};
 pub use service::WorkerService;
 pub use supervisor::WorkerPool;
 pub use wire::{WorkerRequest, WorkerResponse};

--- a/crates/brain-loophost/src/runtime.rs
+++ b/crates/brain-loophost/src/runtime.rs
@@ -158,15 +158,68 @@ impl WarmInstances {
     }
 }
 
+/// The context of every turn currently mid-flight in this worker, keyed by session.
+///
+/// Residency is what lets a turn's later activations cross the wire without the
+/// conversation: the kernel attaches the context on the turn's opening observation, the
+/// worker holds it here between legs, and hands it back on the terminal decision. It is
+/// deliberately NOT part of [`WarmInstances`]: instance eviction is a memory policy, but
+/// dropping a mid-turn context fails a live turn — including turns legitimately parked
+/// for minutes on a client-hosted tool call.
+///
+/// Entries are freed at terminal decisions. A turn the kernel abandons without a
+/// terminal leg (cancel, failure, deadline) leaks its entry until the next turn's
+/// opening leg overwrites it, or the TTL sweep collects it.
+#[derive(Default)]
+pub struct ResidentContexts {
+    entries: std::sync::Mutex<std::collections::HashMap<String, ResidentContext>>,
+}
+
+struct ResidentContext {
+    context: ContextEnvelope,
+    held_since: std::time::Instant,
+}
+
+/// Sweep bound: a resident context older than this belongs to a turn nothing will
+/// finish — kernel deadlines are minutes, not hours. Checked amortized on insert.
+const RESIDENT_TTL: Duration = Duration::from_secs(3600);
+const RESIDENT_SWEEP_AT: usize = 256;
+
+impl ResidentContexts {
+    fn put(&self, session: &str, context: ContextEnvelope) {
+        let Ok(mut entries) = self.entries.lock() else {
+            return;
+        };
+        if entries.len() >= RESIDENT_SWEEP_AT {
+            entries.retain(|_, held| held.held_since.elapsed() < RESIDENT_TTL);
+        }
+        entries.insert(
+            session.to_owned(),
+            ResidentContext {
+                context,
+                held_since: std::time::Instant::now(),
+            },
+        );
+    }
+
+    fn take(&self, session: &str) -> Option<ContextEnvelope> {
+        let mut entries = self.entries.lock().ok()?;
+        entries.remove(session).map(|held| held.context)
+    }
+}
+
 impl AdmittedAgentloop {
+    #[allow(clippy::too_many_arguments)]
     pub fn activate(
         &self,
         engine: &Engine,
         limits: &LoopLimits,
         warm: &WarmInstances,
+        resident: &ResidentContexts,
         session: &str,
+        context_attached: bool,
         input: ActivationInput,
-    ) -> Result<ActivationOutput, String> {
+    ) -> Result<(ActivationOutput, bool), String> {
         let mut entry = match warm.take(session, &self.digest) {
             Some(entry) => entry,
             None => {
@@ -198,6 +251,21 @@ impl AdmittedAgentloop {
         entry
             .store
             .set_epoch_deadline(epoch_deadline_ticks(limits.wall_time));
+        // The turn's context: attached on its opening observation, resident here for the
+        // legs between, returned on the terminal decision. A mid-turn leg that finds
+        // nothing resident means this worker restarted with the turn in flight — the
+        // kernel's copy is the turn's opening state, so continuing from it would replay
+        // effects; the kernel fails the turn honestly instead.
+        let mut input = input;
+        if context_attached {
+            // The opening leg's context is authoritative: it overwrites whatever a
+            // cancelled or failed earlier turn left behind.
+            let _ = resident.take(session);
+        } else {
+            input.context = resident.take(session).ok_or_else(|| {
+                "context_required: the worker holds no resident context for this session".to_owned()
+            })?;
+        }
         let state_json = match (&entry.last_state, &input.context.state) {
             (Some(last), Some(state)) if &last.value == state => Some(last.raw.clone()),
             (_, Some(state)) => Some(serde_json::to_string(state).map_err(|e| e.to_string())?),
@@ -210,13 +278,26 @@ impl AdmittedAgentloop {
             .map_err(activation_error)?
             .map_err(|error| format!("{}: {}", error.code, error.message))?;
         let raw_state = output.context.state_json.clone();
-        let output = from_wit_output(output)?;
+        let mut output = from_wit_output(output)?;
         entry.last_state = match (raw_state, output.context.state.clone()) {
             (Some(raw), Some(value)) => Some(LastState { value, raw }),
             _ => None,
         };
         warm.keep(entry);
-        Ok(output)
+        let terminal = matches!(
+            output.decision,
+            Decision::Finish { .. } | Decision::Fail { .. }
+        );
+        if terminal {
+            Ok((output, true))
+        } else {
+            let context = std::mem::take(&mut output.context);
+            // The placeholder keeps the version so the kernel's per-leg contract check
+            // still holds; everything else stays resident here.
+            output.context.protocol_version = context.protocol_version.clone();
+            resident.put(session, context);
+            Ok((output, false))
+        }
     }
 }
 

--- a/crates/brain-loophost/src/service.rs
+++ b/crates/brain-loophost/src/service.rs
@@ -17,7 +17,8 @@ use std::{
 use tokio::sync::Semaphore;
 
 use crate::{
-    AdmissionEngine, AdmittedAgentloop, LoopLimits, WarmInstances, WorkerRequest, WorkerResponse,
+    AdmissionEngine, AdmittedAgentloop, LoopLimits, ResidentContexts, WarmInstances, WorkerRequest,
+    WorkerResponse,
 };
 
 pub struct WorkerService {
@@ -31,6 +32,8 @@ pub struct WorkerService {
     /// Warm instances, one per recently active session, so a turn's activations do not
     /// pay instantiation and state re-parsing for a conversation this worker just held.
     warm: Arc<WarmInstances>,
+    /// The context of every mid-flight turn, held between a turn's activation legs.
+    resident: Arc<ResidentContexts>,
 }
 
 impl WorkerService {
@@ -41,6 +44,7 @@ impl WorkerService {
             admitted: RwLock::new(HashMap::new()),
             running,
             warm: Arc::new(WarmInstances::default()),
+            resident: Arc::new(ResidentContexts::default()),
         })
     }
 
@@ -65,10 +69,16 @@ impl WorkerService {
             WorkerRequest::Activate {
                 digest,
                 session,
+                context_attached,
                 input,
             } => {
-                self.activate(digest.as_str().to_owned(), session, *input)
-                    .await
+                self.activate(
+                    digest.as_str().to_owned(),
+                    session,
+                    context_attached,
+                    *input,
+                )
+                .await
             }
         }
     }
@@ -98,6 +108,7 @@ impl WorkerService {
         &self,
         digest: String,
         session: String,
+        context_attached: bool,
         input: brain_protocol::ActivationInput,
     ) -> WorkerResponse {
         let component = self
@@ -118,14 +129,29 @@ impl WorkerService {
         };
         let engine = self.engine.clone();
         let warm = self.warm.clone();
+        let resident = self.resident.clone();
         // Wasmtime executes synchronously. Left on a runtime thread it blocks every other
         // connection this worker is serving for as long as the guest runs.
         let activated = tokio::task::spawn_blocking(move || {
-            component.activate(engine.engine(), engine.limits(), &warm, &session, input)
+            component.activate(
+                engine.engine(),
+                engine.limits(),
+                &warm,
+                &resident,
+                &session,
+                context_attached,
+                input,
+            )
         })
         .await;
         match activated {
-            Ok(Ok(output)) => WorkerResponse::Activated { output },
+            Ok(Ok((output, context_attached))) => WorkerResponse::Activated {
+                output,
+                context_attached,
+            },
+            Ok(Err(message)) if message.starts_with("context_required") => {
+                failed("context_required", message)
+            }
             Ok(Err(message)) => failed("activation_failed", message),
             Err(_) => failed("activation_failed", "the activation was lost".into()),
         }
@@ -184,6 +210,7 @@ mod tests {
                 service.clone().handle(WorkerRequest::Ping),
                 service.clone().handle(WorkerRequest::Activate {
                     session: "ses_test".into(),
+                    context_attached: true,
                     digest: brain_protocol::AgentloopIdentity::new("agl_missing"),
                     input: Box::new(input()),
                 }),

--- a/crates/brain-loophost/src/supervisor.rs
+++ b/crates/brain-loophost/src/supervisor.rs
@@ -90,8 +90,9 @@ impl WorkerPool {
         &self,
         session: String,
         digest: AgentloopIdentity,
+        context_attached: bool,
         input: ActivationInput,
-    ) -> Result<ActivationOutput, String> {
+    ) -> Result<(ActivationOutput, bool), String> {
         // The input bound is enforced where the input is encoded, in `write_frame`
         // below. Encoding it here as well to measure its length meant serialising the
         // whole context twice per decision and throwing one copy away.
@@ -118,7 +119,13 @@ impl WorkerPool {
             }
         }
         let client = WorkerClient::new(&self.socket);
-        let call = client.activate(session, digest, input, self.limits.activation_input_bytes);
+        let call = client.activate(
+            session,
+            digest,
+            context_attached,
+            input,
+            self.limits.activation_input_bytes,
+        );
         // The guest is stopped by its own epoch deadline at `wall_time`, which costs one
         // instance. This timeout is the backstop for what an epoch cannot interrupt — a
         // worker blocked in a host call, a crashed worker, a socket that never answers —
@@ -126,7 +133,7 @@ impl WorkerPool {
         // be strictly later than the bound the guest enforces on itself, or it fires
         // first and pays the expensive price for the cheap failure.
         match tokio::time::timeout(self.limits.wall_time + WORKER_BACKSTOP, call).await {
-            Ok(Ok(output)) => {
+            Ok(Ok((output, context_attached))) => {
                 let output_bytes =
                     serde_json::to_vec(&output).map_err(|error| error.to_string())?;
                 if output_bytes.len() > self.limits.activation_output_bytes {
@@ -136,7 +143,7 @@ impl WorkerPool {
                     // a far larger price than the violation.
                     return Err("Agentloop activation output exceeds the configured limit".into());
                 }
-                Ok(output)
+                Ok((output, context_attached))
             }
             Ok(Err(error)) => Err(error),
             Err(_) => {

--- a/crates/brain-loophost/src/wire.rs
+++ b/crates/brain-loophost/src/wire.rs
@@ -17,6 +17,10 @@ pub enum WorkerRequest {
         digest: AgentloopIdentity,
         /// Cache key for a warm instance; never handed to the guest.
         session: String,
+        /// Whether `input.context` carries the turn's context. On the turn's opening
+        /// observation it does; mid-turn legs send a placeholder and the worker uses
+        /// what it holds resident.
+        context_attached: bool,
         input: Box<ActivationInput>,
     },
 }
@@ -25,9 +29,20 @@ pub enum WorkerRequest {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WorkerResponse {
     Pong,
-    Admitted { digest: AgentloopIdentity },
-    Activated { output: ActivationOutput },
-    Error { code: String, message: String },
+    Admitted {
+        digest: AgentloopIdentity,
+    },
+    Activated {
+        output: ActivationOutput,
+        /// Whether `output.context` carries the turn's context. Terminal decisions
+        /// (finish, fail) return it; mid-turn legs keep it resident and send a
+        /// placeholder.
+        context_attached: bool,
+    },
+    Error {
+        code: String,
+        message: String,
+    },
 }
 
 pub(crate) async fn write_frame<W: AsyncWrite + Unpin, T: Serialize>(

--- a/crates/brain-loophost/tests/worker_process.rs
+++ b/crates/brain-loophost/tests/worker_process.rs
@@ -20,10 +20,11 @@ async fn real_worker_admits_and_activates_the_typescript_diagnostic_loop() {
         LoopLimits::default(),
     );
     let digest = pool.admit(package).await.unwrap();
-    let output = pool
+    let (output, _context_attached) = pool
         .activate(
             "ses_worker_test".into(),
             digest,
+            true,
             ActivationInput {
                 context: ContextEnvelope {
                     protocol_version: "agentloop/v1".into(),
@@ -82,8 +83,9 @@ async fn concurrent_activations_all_reach_the_agentloop() {
         let pool = pool.clone();
         let digest = digest.clone();
         activations.push(tokio::spawn(async move {
-            pool.activate(format!("ses_{index}"), digest, activation(index))
+            pool.activate(format!("ses_{index}"), digest, true, activation(index))
                 .await
+                .map(|(output, _)| output)
         }));
     }
 

--- a/crates/brain-server/src/service.rs
+++ b/crates/brain-server/src/service.rs
@@ -643,16 +643,53 @@ pub struct WorkerLoopExecutor(pub Arc<WorkerPool>);
 
 #[async_trait]
 impl LoopExecutor for WorkerLoopExecutor {
+    /// Context residency: the conversation crosses the wire twice per turn, not twice
+    /// per activation.
+    ///
+    /// The turn's opening observation (`user_message`, or `session_started` at create)
+    /// carries the context to the worker, which holds it resident between the turn's
+    /// legs; mid-turn legs send and receive a placeholder envelope, and the terminal
+    /// decision (finish, fail) brings the real context home for `finish_turn` to
+    /// journal. The kernel's own mid-turn copy is therefore a placeholder — its error
+    /// and cancel paths journal the turn-opening context they snapshot, which is the
+    /// same "effects may or may not have happened" honesty a worker restart already
+    /// has.
+    ///
+    /// A worker that restarts mid-turn holds nothing and answers `context_required`;
+    /// the turn fails honestly rather than replaying its effects from the opening
+    /// context.
     async fn activate(
         &self,
         session: &brain_protocol::SessionId,
         agentloop: &AgentloopIdentity,
         input: brain_protocol::ActivationInput,
     ) -> Result<brain_protocol::ActivationOutput, KernelError> {
-        self.0
-            .activate(session.as_str().to_owned(), agentloop.clone(), input)
+        let context_attached = matches!(
+            input.observation,
+            brain_protocol::Observation::UserMessage { .. }
+                | brain_protocol::Observation::SessionStarted { .. }
+        );
+        let (mut output, output_attached) = self
+            .0
+            .activate(
+                session.as_str().to_owned(),
+                agentloop.clone(),
+                context_attached,
+                input,
+            )
             .await
-            .map_err(KernelError::Executor)
+            .map_err(KernelError::Executor)?;
+        if !output_attached {
+            // Mid-turn: the context stays in the worker. The kernel only needs the
+            // envelope's version to accept the leg; the real context returns on the
+            // terminal decision.
+            output.context = brain_protocol::ContextEnvelope {
+                protocol_version: output.context.protocol_version,
+                items: Vec::new(),
+                state: None,
+            };
+        }
+        Ok(output)
     }
 }
 

--- a/crates/brain/src/session/actor.rs
+++ b/crates/brain/src/session/actor.rs
@@ -57,6 +57,11 @@ pub struct SessionActor {
     journalled_messages: usize,
     /// Where client-hosted tool calls wait for their POSTed outcome.
     pending_tools: Arc<PendingToolCalls>,
+    /// The context the running turn opened with. A turn that ends normally clears it
+    /// and journals the terminal context; every abnormal end restores it — under a
+    /// residency-holding executor the mid-turn copy is a placeholder, and the opening
+    /// state is the honest answer either way.
+    turn_opening_context: Option<ContextEnvelope>,
 }
 
 impl SessionActor {
@@ -111,6 +116,7 @@ impl SessionActor {
             // messages whole and every one after that is a delta again.
             journalled_messages: 0,
             pending_tools,
+            turn_opening_context: None,
         })
     }
 
@@ -160,6 +166,13 @@ impl SessionActor {
         let mut observation = Observation::UserMessage {
             input: request.input,
         };
+        // Hashed once per turn, not once per decision: the turn's decisions all derive
+        // from this opening context plus the observations between them, so hashing the
+        // whole envelope again on every activation re-read the conversation for a value
+        // that only its opening state and the per-decision observation distinguish.
+        let turn_context_identity =
+            Identity::of_bytes(&serde_json::to_vec(&self.context).map_err(json_error)?);
+        self.turn_opening_context = Some(self.context.clone());
         for decision_index in 0..self.max_decisions_per_turn {
             if self.cancel_requested.load(Ordering::Acquire) {
                 return self.finish_turn(vec![AppendRecord::new(
@@ -174,17 +187,23 @@ impl SessionActor {
             );
             // The sealed presentation is the same on every decision of the session, so
             // take the identity it was sealed with instead of reading its bytes again.
-            // What is left is hashed from Brain's own encoding: nothing outside Brain
-            // recomputes this one, so it does not have to be canonical.
+            // The identity of an activation is (presentation, turn-opening context,
+            // observation, position): nothing outside Brain recomputes this one, so it
+            // does not have to be canonical — it has to be deterministic and cheap.
             let activation_identity = Identity::over(&[
                 self.presentation.identity,
+                turn_context_identity,
                 Identity::of_bytes(
-                    &serde_json::to_vec(&(&self.context, &observation, &runtime))
-                        .map_err(json_error)?,
+                    &serde_json::to_vec(&(&observation, &runtime)).map_err(json_error)?,
                 ),
             ]);
+            // Moved, not cloned: nothing reads `self.context` while the activation is in
+            // flight, and every executor returns the turn's context in its output — the
+            // worker-backed one echoes what it holds resident, a scripted one passes the
+            // input through — so the envelope makes the round trip without a copy.
+            let context = std::mem::take(&mut self.context);
             let activation = ActivationInput {
-                context: self.context.clone(),
+                context,
                 observation,
                 configuration: self.sealed.brain_configuration.clone(),
                 presentation: self.presentation.clone(),
@@ -467,6 +486,7 @@ impl SessionActor {
                     }
                 }
                 Decision::Finish { result } => {
+                    self.turn_opening_context = None;
                     return self.finish_turn(vec![AppendRecord::new(
                         "turn_finished",
                         serde_json::json!({"result":result}),
@@ -477,6 +497,7 @@ impl SessionActor {
                     message,
                     retryable,
                 } => {
+                    self.turn_opening_context = None;
                     return self.finish_turn(vec![AppendRecord::new(
                         "turn_failed",
                         serde_json::json!({"code":code,"message":message,"retryable":retryable}),
@@ -529,6 +550,12 @@ impl SessionActor {
     /// turn with `turn_interrupted` rather than resuming it, and the row is read back only
     /// when an Idle session is rehydrated — which is to say, here.
     fn finish_turn(&mut self, records: Vec<AppendRecord>) -> Result<Session, KernelError> {
+        // An abnormal end rolls the context back to the turn's opening state; the
+        // decisions the turn did make stay journaled as events. Normal completion
+        // cleared this and keeps the terminal context.
+        if let Some(opening) = self.turn_opening_context.take() {
+            self.context = opening;
+        }
         let context = serde_json::to_value(&self.context).map_err(json_error)?;
         self.commit(
             records,


### PR DESCRIPTION
Closes the shuttle half of #134: the conversation context crossed the server↔worker wire on every activation leg (about twelve O(history) serde passes per turn), the intent identity re-hashed the whole envelope per decision, and the kernel cloned it per decision.

## Mechanism

- The turn's opening observation (`user_message`; `session_started` at create) attaches the context; the worker holds it in a session-keyed resident map between legs and returns it on the terminal decision (`finish`/`fail`) — the only point the kernel journals it. Mid-turn legs carry a version-only placeholder both ways.
- The resident map is deliberately separate from the warm-instance LRU: eviction is a memory policy, but dropping a mid-turn context would fail a live turn — including turns legitimately parked for minutes on a client-hosted tool call. Entries free at terminal decisions, with an hourly TTL sweep for turns abandoned without one; the next turn's opening leg always overwrites.
- The activation intent identity is now `over(presentation, turn-opening-context, (observation, position))`, hashed once per turn plus O(observation) per leg. Nothing outside Brain recomputes this identity; docstring updated. **No contract digest moves** (verified: `contracts/` untouched).
- The kernel moves the envelope instead of cloning, and snapshots the turn-opening context once: a turn that ends abnormally (cancel, executor failure, decision limit) journals its opening state — its decisions remain journaled as events. That matches the existing worker-restart honesty; previously an abnormal end journaled whatever mid-turn state the last activation left.

## Residency loss

A worker restart mid-turn holds nothing and answers `context_required`; the executor does not retry (continuing from the opening context would replay effects) and the turn fails with the reason. Same blast radius as today's worker-restart path.

## Scope confinement

`LoopExecutor` keeps its signature; scripted test executors see full context in and out as before (the envelope round-trips by move). Only `WorkerLoopExecutor` + the loophost wire/worker implement residency. `tools/bench/**`, README, and docs untouched.

Tests: workspace 131 passed / 0 failed, loophost lib 5/5, `--all-targets` clean including the unix-gated worker_process integration test.

Refs #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)