### PR TITLE
release: brain 0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for the execution contract (#143). Release commit for the 0.13.0 npm package and image.