### PR TITLE
docs: read the assistant reply from the output_emitted event

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ const delegate = tool({
     const child = await brain.sessions.create({ model, agentloop: coder(), tools: [test({ env: box })] });
     await child.send(task);
     let answer;
-    for await (const e of child.events()) if (e.type === "assistant_message") { answer = e.data.message; break; }
+    for await (const e of child.events()) if (e.type === "output_emitted" && e.data.type === "assistant_message") { answer = e.data.message; break; }
     await child.end();
     return { answer };
   },


### PR DESCRIPTION
A reply reaches the feed as an `output_emitted` event whose data is typed `assistant_message`; the README subagent sample matched the inner type as the event type. Found while proving 0.13.0 end to end.