### PR TITLE
docs: keep the README extension section prose-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,155 +106,37 @@ the method and the subject versions.</sub>
 
 ## Extensions
 
-Brain owns the session. You write the rest as extensions with the same SDK. Export a
-definition, run `npx brain build`, and pass the generated factory to a session. There are
-three kinds of extension:
+Brain owns the session. Everything else is an extension. You write it with the `@aexhq/brain`
+SDK, run `npx brain build`, and pass the generated factory to a session. There are three
+kinds, and each one is a small typed declaration.
 
-- **Agent loops** decide what happens next. A loop is a set of synchronous hooks compiled to
-  a Wasm component, and Brain does the I/O it asks for.
-- **Tools** do the work. A tool is a program, a bundled function, a shell script, or an HTTP
-  request, that declares which resources it operates on.
-- **Environments** run programs. An environment can be a local process, a browser page, or a
-  sandbox service, and it declares the resources a program finds there.
+- **Agent loop** decides what happens next. It registers one synchronous handler per
+  observation, and each handler returns one action: call the model, run tools, reply, or stop.
+  You write it in TypeScript. `npx brain build` compiles it to a WebAssembly component, and
+  Brain runs that component in a [Wasmtime](https://wasmtime.dev/) sandbox with no filesystem,
+  network, clock, or secrets. Brain performs every effect the loop asks for, so each decision is
+  deterministic and can be replayed from the journal.
+  [Write an agent loop](https://aex.dev/brain/docs/guides/write-a-loop)
+- **Tool** does the work. It declares its input and output schemas and the resources it
+  operates on (`fs`, `process`, `net`, `dom`, `secrets`). Inside, it is plain code for the
+  platform it runs on. If the environment does not declare what the tool needs, Brain rejects
+  the session at create time. A tool that is one shell command or one HTTP request needs no
+  code at all. [Write a tool](https://aex.dev/brain/docs/guides/write-a-tool)
+- **Environment** runs programs. It opens an instance, declares the resources a program finds
+  there, and registers how to launch each program kind. Brain journals every call to it.
+  [Write an environment](https://aex.dev/brain/docs/guides/write-an-environment)
 
-### Agent loops
+### Official extensions
 
-An agent loop registers one handler per observation (`start`, `message`, `model`, `tools`,
-`event`, `cancel`). Each handler returns one action (`turn.model`, `turn.tools`, `turn.emit`,
-`turn.reply`, `turn.done`, `turn.fail`). Loop state is declared with a schema and can be
-replayed from the journal. The loop below runs a full turn. When the model asks for several
-tools at once, it hands the whole batch to Brain, which runs them in parallel and returns all
-the results in one observation. See the
-[guide](https://aex.dev/brain/docs/guides/write-a-loop) for details.
+The packages in [aexhq/extensions](https://github.com/aexhq/extensions) use the same SDK and
+the same build. Nothing built in gets a shortcut.
 
-```ts
-import { agentloop } from "@aexhq/brain";
-import { z } from "zod";
-
-const state = z.object({ messages: z.array(z.unknown()) });
-const text = (m) => m.content.filter((b) => b.type === "text").map((b) => b.text).join("");
-
-export const coder = agentloop({}, (author) => {
-  const memory = author.state(state, () => ({ messages: [] }));
-  const push = (role, content) => memory.messages.push({ role, content });
-
-  author.on.message(({ input }, turn) => {
-    push("user", [{ type: "text", text: input.message }]);
-    return turn.model({ messages: memory.messages });
-  });
-
-  author.on.model(({ response }, turn) => {
-    push("assistant", response.message.content);
-    const calls = response.message.content.filter((b) => b.type === "tool_use").map((b) => ({ callId: b.id, name: b.name, input: b.input }));
-    // One batch: Brain runs every call in parallel and reports back once.
-    return calls.length ? turn.tools(calls) : turn.reply(text(response.message));
-  });
-
-  author.on.tools(({ results }, turn) => {
-    push("user", results.map((r) => ({ type: "tool_result", tool_use_id: r.call_id, content: r.output, is_error: r.is_error })));
-    return turn.model({ messages: memory.messages });
-  });
-});
-```
-
-### Tools
-
-A tool declares its input and output schemas and the resources it operates on (`fs`,
-`process`, `net`, `dom`, `secrets`). Inside, it is plain code on the platform it runs on:
-`node:fs`, `child_process`, `fetch`. At run time it receives its binding values, a
-`deadline`, a `signal`, and a `progress` callback. If the environment does not declare what
-the tool needs, Brain rejects the session at create time. See the
-[guide](https://aex.dev/brain/docs/guides/write-a-tool) for the build output.
-
-```ts
-import { execFile } from "node:child_process";
-import { readFile } from "node:fs/promises";
-import { promisify } from "node:util";
-import { tool } from "@aexhq/brain";
-import { z } from "zod";
-
-export const test = tool(
-  {
-    description: "Run the test suite and return the report.",
-    input: z.object({ filter: z.string().optional() }),
-    output: z.object({ passed: z.boolean(), report: z.string() }),
-    needs: ["process", "fs"],
-  },
-  (author) => {
-    author.run(async ({ filter }, context) => {
-      context.progress({ stage: "running" });
-      const passed = await promisify(execFile)("npm", ["test", "--", filter ?? ""], { signal: context.signal }).then(() => true, () => false);
-      return { passed, report: await readFile("reports/junit.xml", "utf8") };
-    });
-  },
-);
-```
-
-A tool that is one command needs no code at all:
-
-```ts
-export const bash = tool.shell({
-  description: "Run a shell command in the workspace.",
-  input: z.object({ command: z.string() }),
-  needs: ["process"],
-  script: "$command",
-});
-```
-
-A tool with an `execute` function runs in your own process instead. There it can use the SDK
-directly, for example to create a child session for a subtask and read the child's events
-while it runs:
-
-```ts
-const delegate = tool({
-  name: "delegate",
-  description: "Hand a subtask to a fresh agent and return its answer.",
-  input: z.object({ task: z.string() }),
-  execute: async ({ task }) => {
-    const child = await brain.sessions.create({ model, agentloop: coder(), tools: [test({ env: box })] });
-    await child.send(task);
-    let answer;
-    for await (const e of child.events()) if (e.type === "output_emitted" && e.data.type === "assistant_message") { answer = e.data.message; break; }
-    await child.end();
-    return { answer };
-  },
-});
-```
-
-### Environments
-
-An environment opens an instance, declares the resources a program finds there, and
-registers an executor for each program kind it can launch. The methods it returns become
-typed calls on the application object, and Brain journals each call. The example below wraps
-a sandbox service. Replace the vendor SDK with your own. See the
-[guide](https://aex.dev/brain/docs/guides/write-an-environment) for the details.
-
-```ts
-import { environment } from "@aexhq/brain";
-import { Sandbox } from "@vendor/sandbox";
-import { z } from "zod";
-
-export const sandbox = environment(
-  {
-    options: z.object({ image: z.string() }),
-    resources: { fs: { root: "/workspace" }, process: {}, net: { allow: ["registry.npmjs.org"] } },
-  },
-  (author) => {
-    const box = author.open(({ options, id }) => Sandbox.create({ name: id, image: options.image }));
-    box.execute.esm({ artifacts: builtTools });
-    box.execute.shell(({ instance, signal }, script) => instance.run(script, { cwd: "/workspace", signal }));
-    box.close(({ instance }) => instance.kill());
-    return { snapshot: box.method((_input, { instance }) => instance.snapshot()) };
-  },
-);
-```
-
-Put all three into one session:
-
-```ts
-const box = sandbox({ image: "node:22" });
-const session = await brain.sessions.create({ model, agentloop: coder(), tools: [test({ env: box }), bash({ env: box }), delegate] });
-```
+| Package | Kind | What it is |
+| --- | --- | --- |
+| [`@aexhq/agentloop-pi`](https://www.npmjs.com/package/@aexhq/agentloop-pi) | Agent loop | Pi-style coding loop. Tool calls run in parallel. |
+| [`@aexhq/agentloop-codex`](https://www.npmjs.com/package/@aexhq/agentloop-codex) | Agent loop | Codex-style coding loop. Tool calls run one at a time. |
+| [`@aexhq/tools`](https://www.npmjs.com/package/@aexhq/tools) | Tools | `read`, `write`, `edit`, `ls`, `glob`, `grep`, `bash`, `todo` |
+| [`@aexhq/env-aws-microvm`](https://www.npmjs.com/package/@aexhq/env-aws-microvm) | Environment | One AWS microVM per session, with `fs`, `process`, and `net` |
 
 ## How it works
 
@@ -376,6 +258,9 @@ declares a hosting environment instead and the session API stays the same. See t
 - [ ] Sessions spread across machines sharing environments
 - [ ] `checkpoint` and `restore`
 - [ ] Custom images with scoped credentials and network metering
+- [ ] Local environment: run tools in a directory or container on your own machine
+- [ ] Browser environment and DOM tools: a page as the place tools run
+- [ ] An agent loop written in Rust against the same `agentloop.wit` contract
 
 ## Contact
 

--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -1,4 +1,11 @@
 {
   "title": "Guides",
-  "pages": ["write-a-loop", "write-a-tool", "app-tools", "write-an-environment", "embed"]
+  "pages": [
+    "write-a-loop",
+    "write-a-tool",
+    "app-tools",
+    "subagents",
+    "write-an-environment",
+    "embed"
+  ]
 }

--- a/docs/guides/subagents.mdx
+++ b/docs/guides/subagents.mdx
@@ -1,0 +1,64 @@
+---
+title: Spawn a subagent
+description: A tool in your own process creates a child session and returns its answer.
+---
+
+A tool with an `execute` function runs in the process that created the session, so it can
+use the SDK. That is enough for a subagent today: the tool creates a child session, sends it
+the task, reads the reply from the child's event feed, and returns it as the tool's output.
+The parent's loop sees an ordinary tool result. Native parent and child links between
+sessions are on the roadmap.
+
+```ts
+import { tool } from "@aexhq/brain";
+import { z } from "zod";
+import { coder } from "./loops.js";
+import { sandbox } from "./environments.js";
+import { test } from "./tools.js";
+
+const delegate = tool({
+  name: "delegate",
+  description: "Hand a subtask to a fresh agent and return its answer.",
+  input: z.object({ task: z.string() }),
+  execute: async ({ task }) => {
+    const child = await brain.sessions.create({
+      model,
+      agentloop: coder(),
+      tools: [test({ env: sandbox({ image: "node:22" }) })],
+    });
+    await child.send(task);
+    let answer;
+    for await (const event of child.events()) {
+      if (event.type === "output_emitted" && event.data.type === "assistant_message") {
+        answer = event.data.message;
+        break;
+      }
+    }
+    await child.end();
+    return { answer };
+  },
+});
+```
+
+The child gets its own agent loop, model, and tools, and its own environment. An Environment
+object attaches to exactly one session, so the child calls the environment factory again
+instead of reusing the parent's instance.
+
+## Put it in a session
+
+The parent runs the same loop with the sandbox tools plus `delegate`. Brain routes the
+`delegate` call back to this process over the session's event feed, the function above
+answers it, and the child's whole run is journalled under its own session id.
+
+```ts
+const box = sandbox({ image: "node:22" });
+const session = await brain.sessions.create({
+  model,
+  agentloop: coder(),
+  tools: [test({ env: box }), bash({ env: box }), delegate],
+});
+```
+
+Every event the child produces is readable on its own session, so a trace of the parent and
+a trace of the child are the same kind of record. See [Serve a tool from another
+process](/brain/docs/guides/app-tools) for the wire shape of an `execute` tool.

--- a/docs/guides/write-a-loop.mdx
+++ b/docs/guides/write-a-loop.mdx
@@ -41,6 +41,11 @@ Build every named extension export with one command:
 npx brain build
 ```
 
+For an agent loop the output is a WebAssembly component. `brain build` bundles the module and
+compiles it with [componentize-js](https://github.com/bytecodealliance/componentize-js) against
+Brain's `agentloop.wit` world, with stdio, random, clocks, and HTTP disabled. Brain runs the
+component in Wasmtime, so the loop has no I/O of its own and every decision is deterministic.
+
 Applications import the generated factory and pass it under `agentloop`:
 
 ```ts
@@ -58,3 +63,45 @@ The loop decides what the model is told on every call. Leave `system` out and th
 prompt the session was created with, `author.system`; the loop above replaces it with its own
 option. Leave `tools` out and every tool the session was created with is offered; name a subset of
 `author.tools` to offer fewer.
+
+## Run tools
+
+A loop that uses tools handles one more observation. When the model asks for tools, hand the
+whole batch to Brain with `turn.tools`. Brain runs the calls in parallel and reports back once,
+in `tools`, with every result. The loop below runs a full coding turn.
+
+```ts
+import { agentloop } from "@aexhq/brain";
+import { z } from "zod";
+
+const state = z.object({ messages: z.array(z.unknown()) });
+const text = (message) => message.content.filter((block) => block.type === "text").map((block) => block.text).join("");
+
+export const coder = agentloop((author) => {
+  const memory = author.state(state, () => ({ messages: [] }));
+  const push = (role, content) => memory.messages.push({ role, content });
+
+  author.on.message(({ input }, turn) => {
+    push("user", [{ type: "text", text: input.message }]);
+    return turn.model({ messages: memory.messages });
+  });
+
+  author.on.model(({ response }, turn) => {
+    push("assistant", response.message.content);
+    const calls = response.message.content
+      .filter((block) => block.type === "tool_use")
+      .map((block) => ({ callId: block.id, name: block.name, input: block.input }));
+    // One batch: Brain runs every call in parallel and reports back once.
+    return calls.length ? turn.tools(calls) : turn.reply(text(response.message));
+  });
+
+  author.on.tools(({ results }, turn) => {
+    push("user", results.map((r) => ({ type: "tool_result", tool_use_id: r.call_id, content: r.output, is_error: r.is_error })));
+    return turn.model({ messages: memory.messages });
+  });
+});
+```
+
+The model sees every tool the session was created with unless the loop names a subset in
+`turn.model`. The official `@aexhq/agentloop-pi` and `@aexhq/agentloop-codex` loops are this
+shape with the prompt, context management, and retry policy of Pi and Codex on top.

--- a/docs/guides/write-an-environment.mdx
+++ b/docs/guides/write-an-environment.mdx
@@ -59,6 +59,30 @@ Every program starts with the `fs` root as its working directory. That conventio
 environment's to keep: an in-process `esm` executor runs where the host process runs, so an
 environment whose workspace is elsewhere changes directory in `open`.
 
+## The smallest environment
+
+An environment needs an `open`, a `close`, one executor, and its resource declaration.
+This one runs shell tools in a directory on the machine that hosts it, and returns no
+methods of its own.
+
+```ts
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { environment } from "@aexhq/brain";
+
+export const workspace = environment(
+  { resources: { fs: { root: "/workspace" }, process: {} } },
+  (author) => {
+    const local = author.open(() => ({ cwd: "/workspace" }));
+    local.execute.shell(({ instance, signal }, script) =>
+      promisify(execFile)("sh", ["-c", script], { cwd: instance.cwd, signal }),
+    );
+    local.close(() => {});
+    return {};
+  },
+);
+```
+
 ## Launching provisioned programs
 
 An attach carries each tool's manifest and the content identity of its program. For `esm`


### PR DESCRIPTION
A Reddit reader asked why the Wasm claim when the README only showed
dense TypeScript. The Extensions section is now one definition per
kind, with the agent loop paragraph stating that brain build compiles
the TypeScript to a WebAssembly component, plus a table of the official
packages. The examples move to the guides: the tool-batching loop to
write-a-loop, the smallest environment to write-an-environment, and the
delegate subagent tool to a new subagents guide. That sample previously
reused the parent's Environment object, which the SDK rejects, so the
child now opens its own. The roadmap lists the planned local and
browser environments and a Rust agent loop.
