### PR TITLE
release: brain 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/README.md
+++ b/packages/brain-sdk/README.md
@@ -5,7 +5,7 @@ The typed client and extension composition contract for any Brain server.
 ```ts
 import { Brain } from "@aexhq/brain";
 import { awsMicroVm } from "@aexhq/env-aws-microvm";
-import { pi } from "@aexhq/brain-pi";
+import { pi } from "@aexhq/agentloop-pi";
 import { bash, read } from "@aexhq/tools";
 
 const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
@aexhq/brain 0.14.0 -> 0.15.0. First release with the turn-shaped agent loop (#156-#165): a loop exports `turn` and drives the whole turn through Brain's model/dispatch/append/telemetry services; one `SessionConfig`; per-session event and journal logs with idle suspension; environments as resources; one code catalogue.

`agentloop/v1` was rewritten in place (contracts never version-bump before 1.0.0), so loops built with 0.14.0 or earlier are admitted by name but do not run: rebuild them with 0.15.0. The extensions loops are being ported in aexhq/extensions.

Also fixes the stale `@aexhq/brain-pi` import in the SDK README that ships in the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XS1J4Fi2uNkjQZKj5HUyLB