### PR TITLE
release: brain 0.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/tests/release/sdk-events.mjs
+++ b/tests/release/sdk-events.mjs
@@ -31,7 +31,7 @@ const suffix = [];
 for await (const event of session.events(cursor)) suffix.push(event);
 assert.deepEqual(
   suffix.map(({ type }) => type),
-  ["turn_started", "activation_started", "activation_ended", "turn_ended"],
+  ["turn_started", "activation_started", "note", "activation_ended", "turn_ended"],
 );
 assert.equal(suffix.at(-1)?.sequence, session.state.lastSequence);
 

--- a/tests/release/sdk-turns.mjs
+++ b/tests/release/sdk-turns.mjs
@@ -24,8 +24,8 @@ assert.equal(completed.status, "idle");
 const events = [];
 for await (const event of session.events()) events.push(event);
 assert.deepEqual(
-  events.slice(-4).map(({ type }) => type),
-  ["turn_started", "activation_started", "activation_ended", "turn_ended"],
+  events.slice(-5).map(({ type }) => type),
+  ["turn_started", "activation_started", "note", "activation_ended", "turn_ended"],
 );
 assert.deepEqual(events.at(-1)?.data.result, { turns: 1, message: "finish without external capabilities" });
 assert.ok(events.every(({ recordedAt }) => recordedAt instanceof Date && !Number.isNaN(recordedAt.valueOf())));


### PR DESCRIPTION
The 0.15.0 stage run (33855647619) failed in `e2e-sdk-events` (and would in `e2e-sdk-turns`): both scripts expected a turn of the diagnostic loop to produce `turn_started, activation_started, activation_ended, turn_ended`, but the loop has appended a `note` record each turn since #163. Those scripts run only in the release stage, never in CI. This fixes the expectations and bumps the SDK to 0.15.1 (contents unchanged) because a staged version's provenance binds its commit, so 0.15.0 cannot be re-staged from a new one; it stays under `next`, unpromoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XS1J4Fi2uNkjQZKj5HUyLB