### PR TITLE
release: brain 0.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,7 +2012,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "@bytecodealliance/componentize-js": "0.19.3",

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/tests/release/sdk-turns.mjs
+++ b/tests/release/sdk-turns.mjs
@@ -29,7 +29,8 @@ assert.deepEqual(
 );
 assert.deepEqual(events.at(-1)?.data.result, { turns: 1, message: "finish without external capabilities" });
 assert.ok(events.every(({ recordedAt }) => recordedAt instanceof Date && !Number.isNaN(recordedAt.valueOf())));
-assert.deepEqual(events.map(({ sequence }) => sequence), events.map((_, index) => index + 1));
+// One sequence counter numbers both logs, so the feed is strictly increasing, not contiguous.
+assert.ok(events.every(({ sequence }, index) => index === 0 || sequence > events[index - 1].sequence));
 
 await session.end();
 await session.delete();


### PR DESCRIPTION
The 0.15.1 stage (33859169150) failed in `e2e-sdk-turns` on the assertion that event sequences are contiguous `1..n`. Since #160 one sequence counter numbers both the events log and the journal (DECISIONS.md 2026-09-04, docs/concepts/sessions.mdx), so the feed is strictly increasing with gaps at journal-only records. The assertion now checks strict increase.

Verified locally against a Linux Brain built from main: `sdk.mjs`, `sdk-turns.mjs`, `sdk-events.mjs`, `http.mjs`, `http-contract.mjs` all pass. SDK contents unchanged; 0.15.0 and 0.15.1 stay under `next`, unpromoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XS1J4Fi2uNkjQZKj5HUyLB