### PR TITLE
runtime: fix P1 durability and effect boundaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,12 @@
 .git
 .github
+.worktrees
+.claude
 brain-data
-node_modules
-packages/*/dist
-target
+**/node_modules
+**/dist
+tests/release/built
+**/target
 *.sqlite3
 *.sqlite3-shm
 *.sqlite3-wal

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -292,8 +292,8 @@ from the producer.
 
 ## 2026-09-04: The data directory is not migrated
 
-**Decided.** The data directory carries a format marker. A Brain that finds another format, or
-the previous layout, refuses to start and says so. There is no migration.
+**Decided.** The data directory carries the `brain-data/1` format marker. An unrecognized format
+or a nonempty directory without a marker is refused. There are no legacy layouts or migrations.
 
 **Why.** Brain is under early development and has said so: contracts are replaced in place
 until the first stable release. A migration path for a layout nobody should be depending on
@@ -413,3 +413,17 @@ failure appears.
 **Why.** A retry can duplicate an external side effect and only the Agentloop has enough policy to
 decide whether another attempt is appropriate. Effect-after-commit preserves evidence of what Brain
 tried without pretending exactly-once execution is possible.
+
+## 2026-09-05: Preserve effect identity and uncertainty across interruption
+
+HTTP request claims and resident host token hashes live in small durable server logs. Session
+journals remain the only source for lifecycle and effect outcomes, including Environment teardown.
+A request without a recorded answer is not executed again; an effect without a terminal record is
+unknown. Ending is fenced before detach, and failed teardown retains its resource row for an explicit
+retry. Session-owned model bindings avoid credential sharing across unrelated create operations.
+
+This closes restart and cancellation gaps without introducing a database, retry engine, or background
+effect scheduler. Metadata uses the same file synchronization and torn-tail repair rules at every
+acknowledgment boundary. These changes define the pre-launch `brain-data/1` layout in place.
+Wasm memory limits apply across all memories in a Store, and remote
+response bounds apply while reading, not after buffering.

--- a/contracts/environment/v1/schemas.json
+++ b/contracts/environment/v1/schemas.json
@@ -68,7 +68,7 @@
           "$ref": "#/$defs/EnvironmentRequest"
         },
         "sequence": {
-          "description": "The sequence of the journal record that started this operation. With\n`session_id` it names the operation: a redelivery carries the same pair, so a\nreceiver that already answered it can say so. An operation on the environment\nitself rather than on a session's behalf carries the environment's own id here.",
+          "description": "The sequence of the journal record that started this operation. With\n`session_id` it names the operation: a redelivery carries the same pair, so a\nreceiver that already answered it can say so. Setup and teardown belong to the\nowning session's journal too.",
           "format": "uint64",
           "minimum": 1,
           "type": "integer"

--- a/contracts/session/v1/codes.json
+++ b/contracts/session/v1/codes.json
@@ -14,6 +14,8 @@
     "session_creation_started",
     "session_creation_ended",
     "session_creation_failed",
+    "session_end_started",
+    "session_end_failed",
     "session_ended",
     "session_suspended",
     "session_resumed",

--- a/contracts/session/v1/openapi.yaml
+++ b/contracts/session/v1/openapi.yaml
@@ -559,6 +559,7 @@ components:
       - creating
       - idle
       - running
+      - ending
       - ended
       - failed
       type: string

--- a/contracts/session/v1/schemas.json
+++ b/contracts/session/v1/schemas.json
@@ -778,6 +778,7 @@
         "creating",
         "idle",
         "running",
+        "ending",
         "ended",
         "failed"
       ],

--- a/crates/brain-http/src/router.rs
+++ b/crates/brain-http/src/router.rs
@@ -571,11 +571,7 @@ async fn events<A: BrainApi>(
             let empty = page.events.is_empty();
             for event in page.events {
                 sent_through = event.sequence;
-                let terminal = is_last(&event);
                 yield sse(event);
-                if terminal {
-                    return;
-                }
             }
             if empty {
                 let terminal = match api.get_session(session_id.clone()).await {

--- a/crates/brain-loophost/src/client.rs
+++ b/crates/brain-loophost/src/client.rs
@@ -198,10 +198,18 @@ impl WorkerClient {
             };
             match response {
                 WorkerResponse::HostCall { id, call } => {
-                    let result = bridge.call(call).await;
                     if !cancelled && bridge.cancelled() {
                         cancelled = true;
                         write_frame(&mut writer, &WorkerRequest::Cancel, 1_024).await?;
+                    }
+                    if cancelled {
+                        continue;
+                    }
+                    let result = bridge.call(call).await;
+                    if bridge.cancelled() {
+                        cancelled = true;
+                        write_frame(&mut writer, &WorkerRequest::Cancel, 1_024).await?;
+                        continue;
                     }
                     write_frame(
                         &mut writer,

--- a/crates/brain-loophost/src/runtime.rs
+++ b/crates/brain-loophost/src/runtime.rs
@@ -4,7 +4,7 @@ use brain_protocol::{AgentloopIdentity, ToolIdentity, TurnError, TurnInput, Turn
 use http_body_util::BodyExt as _;
 use sha2::{Digest as _, Sha256};
 use wasmtime::component::{Component, HasSelf, Linker, ResourceTable};
-use wasmtime::{Cache, Config, Engine, Store, StoreLimits, StoreLimitsBuilder, Trap};
+use wasmtime::{Cache, Config, Engine, ResourceLimiter, Store, Trap};
 use wasmtime_wasi::{FsPerms, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::{
     Error as HttpError, RequestOptions, WasiBody, WasiHttpCtx, WasiHttpCtxView, WasiHttpHooks,
@@ -170,7 +170,7 @@ impl AdmissionEngine {
 
 /// The store's data: the memory limiter, bridge, and explicitly granted capabilities.
 pub struct HostState {
-    limits: StoreLimits,
+    limits: StoreBudget,
     bridge: Option<Arc<dyn GuestHost>>,
     table: ResourceTable,
     wasi: WasiCtx,
@@ -182,7 +182,7 @@ pub struct HostState {
 
 impl HostState {
     fn new(
-        limits: StoreLimits,
+        limits: StoreBudget,
         bridge: Arc<dyn GuestHost>,
         environment: NativeEnvironment,
     ) -> Result<Self, TurnError> {
@@ -387,6 +387,84 @@ fn wit_error(error: TurnError) -> wit::TurnError {
 /// for its imports.
 const MAX_CORE_INSTANCES: usize = 8;
 
+struct StoreBudget {
+    limit: usize,
+    memory: usize,
+    memory_growth: usize,
+    elements: usize,
+    table_growth: usize,
+}
+
+impl StoreBudget {
+    fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            memory: 0,
+            memory_growth: 0,
+            elements: 0,
+            table_growth: 0,
+        }
+    }
+}
+
+impl ResourceLimiter for StoreBudget {
+    fn memory_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        let growth = desired.saturating_sub(current);
+        if maximum.is_some_and(|max| desired > max)
+            || growth > self.limit.saturating_sub(self.memory)
+        {
+            return Ok(false);
+        }
+        self.memory += growth;
+        self.memory_growth = growth;
+        Ok(true)
+    }
+
+    fn memory_grow_failed(&mut self, _error: wasmtime::Error) -> wasmtime::Result<()> {
+        self.memory -= self.memory_growth;
+        self.memory_growth = 0;
+        Ok(())
+    }
+
+    fn table_growing(
+        &mut self,
+        current: usize,
+        desired: usize,
+        maximum: Option<usize>,
+    ) -> wasmtime::Result<bool> {
+        let growth = desired.saturating_sub(current);
+        if maximum.is_some_and(|max| desired > max)
+            || growth > 1_000_000_usize.saturating_sub(self.elements)
+        {
+            return Ok(false);
+        }
+        self.elements += growth;
+        self.table_growth = growth;
+        Ok(true)
+    }
+
+    fn table_grow_failed(&mut self, _error: wasmtime::Error) -> wasmtime::Result<()> {
+        self.elements -= self.table_growth;
+        self.table_growth = 0;
+        Ok(())
+    }
+
+    fn instances(&self) -> usize {
+        MAX_CORE_INSTANCES
+    }
+    fn memories(&self) -> usize {
+        MAX_CORE_INSTANCES
+    }
+    fn tables(&self) -> usize {
+        MAX_CORE_INSTANCES
+    }
+}
+
 impl AdmittedAgentloop {
     /// Runs one turn in a fresh Store and Component instance. Only compiled code is
     /// retained between invocations.
@@ -398,10 +476,7 @@ impl AdmittedAgentloop {
         input: TurnInput,
         bridge: Arc<dyn GuestHost>,
     ) -> Result<TurnOutput, TurnError> {
-        let store_limits = StoreLimitsBuilder::new()
-            .memory_size(limits.linear_memory_bytes)
-            .instances(MAX_CORE_INSTANCES)
-            .build();
+        let store_limits = StoreBudget::new(limits.linear_memory_bytes);
         let state = HostState::new(store_limits, bridge, environment)?;
         let mut store = Store::new(engine, state);
         store.limiter(|state| &mut state.limits);
@@ -448,10 +523,7 @@ impl AdmittedTool {
         input: NativeToolInput,
         bridge: Arc<dyn GuestHost>,
     ) -> Result<serde_json::Value, TurnError> {
-        let store_limits = StoreLimitsBuilder::new()
-            .memory_size(limits.linear_memory_bytes)
-            .instances(MAX_CORE_INSTANCES)
-            .build();
+        let store_limits = StoreBudget::new(limits.linear_memory_bytes);
         let state = HostState::new(store_limits, bridge, environment)?;
         let mut store = Store::new(engine, state);
         store.limiter(|state| &mut state.limits);
@@ -599,6 +671,24 @@ mod tests {
     const CEILING: Duration = Duration::from_secs(10);
     const HOST_WAIT: Duration = Duration::from_millis(250);
 
+    #[test]
+    fn memory_budget_is_aggregate_across_memories_and_failed_growth_releases_budget() {
+        let engine = wasmtime::Engine::default();
+        let mut store = Store::new(&engine, StoreBudget::new(2 * 65536));
+        store.limiter(|budget| budget);
+        let first = wasmtime::Memory::new(&mut store, wasmtime::MemoryType::new(1, None)).unwrap();
+        let _second =
+            wasmtime::Memory::new(&mut store, wasmtime::MemoryType::new(1, None)).unwrap();
+        assert!(first.grow(&mut store, 1).is_err());
+        assert!(wasmtime::Memory::new(&mut store, wasmtime::MemoryType::new(1, None)).is_err());
+        let mut budget = StoreBudget::new(65536);
+        assert!(budget.memory_growing(0, 65536, None).unwrap());
+        budget
+            .memory_grow_failed(wasmtime::Error::msg("allocation failed"))
+            .unwrap();
+        assert!(budget.memory_growing(0, 65536, None).unwrap());
+    }
+
     struct SlowHost;
 
     #[async_trait::async_trait]
@@ -706,7 +796,7 @@ mod tests {
         let admission = AdmissionEngine::new(LoopLimits::default(), Vec::new()).unwrap();
         let engine = admission.engine();
         let state = HostState::new(
-            StoreLimitsBuilder::new().build(),
+            StoreBudget::new(128 * 1024 * 1024),
             Arc::new(SlowHost),
             empty_environment(),
         )

--- a/crates/brain-loophost/src/supervisor.rs
+++ b/crates/brain-loophost/src/supervisor.rs
@@ -546,9 +546,25 @@ async fn persist_component(
     tokio::fs::write(&temporary, package)
         .await
         .map_err(|error| error.to_string())?;
+    tokio::fs::File::open(&temporary)
+        .await
+        .map_err(|error| error.to_string())?
+        .sync_all()
+        .await
+        .map_err(|error| error.to_string())?;
     tokio::fs::rename(&temporary, &target)
         .await
-        .map_err(|error| error.to_string())
+        .map_err(|error| error.to_string())?;
+    #[cfg(unix)]
+    for path in [Some(directory), directory.parent()].into_iter().flatten() {
+        tokio::fs::File::open(path)
+            .await
+            .map_err(|error| error.to_string())?
+            .sync_all()
+            .await
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(())
 }
 
 fn component_path(directory: &std::path::Path, kind: &str, digest: &str) -> PathBuf {

--- a/crates/brain-loophost/tests/worker_process.rs
+++ b/crates/brain-loophost/tests/worker_process.rs
@@ -288,3 +288,67 @@ async fn a_cancelled_turn_ends_at_its_next_host_call() {
         .to_string();
     assert!(error.contains("cancelled"), "{error}");
 }
+
+#[tokio::test]
+async fn host_calls_queued_before_cancel_are_not_answered_after_cancel() {
+    use brain_loophost::{NativeEnvironment, WorkerClient, WorkerRequest, WorkerResponse};
+
+    let directory = tempfile::tempdir().unwrap();
+    let socket = directory.path().join("worker.sock");
+    let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+    let worker = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        assert!(matches!(
+            brain_loophost::worker_read(&mut stream).await.unwrap(),
+            WorkerRequest::Turn { .. }
+        ));
+        assert!(matches!(
+            brain_loophost::worker_read(&mut stream).await.unwrap(),
+            WorkerRequest::Cancel
+        ));
+        brain_loophost::worker_write(
+            &mut stream,
+            &WorkerResponse::HostCall {
+                id: 1,
+                call: HostCall::Emit {
+                    kind: "note".into(),
+                    payload_json: "{}".into(),
+                },
+            },
+        )
+        .await
+        .unwrap();
+        brain_loophost::worker_write(
+            &mut stream,
+            &WorkerResponse::TurnFailed {
+                error: TurnError::new(brain_protocol::codes::failure::CANCELLED, "cancelled"),
+            },
+        )
+        .await
+        .unwrap();
+        assert!(brain_loophost::worker_read(&mut stream).await.is_err());
+    });
+    let bridge = RecordingBridge {
+        calls: Mutex::new(Vec::new()),
+        cancelled: AtomicBool::new(true),
+    };
+    let error = WorkerClient::new(socket)
+        .turn(
+            brain_protocol::AgentloopIdentity::new("diagnostic"),
+            NativeEnvironment {
+                scratch: false,
+                workspace: None,
+                network_allow: Vec::new(),
+                secrets: Default::default(),
+            },
+            input("hello"),
+            brain_loophost::MAX_TURN_INPUT_BYTES,
+            &bridge,
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("cancelled"), "{error}");
+    assert!(bridge.calls.lock().unwrap().is_empty());
+    worker.await.unwrap();
+}

--- a/crates/brain-protocol/src/codes.rs
+++ b/crates/brain-protocol/src/codes.rs
@@ -13,6 +13,8 @@ pub mod event {
     pub const SESSION_CREATION_STARTED: &str = "session_creation_started";
     pub const SESSION_CREATION_ENDED: &str = "session_creation_ended";
     pub const SESSION_CREATION_FAILED: &str = "session_creation_failed";
+    pub const SESSION_END_STARTED: &str = "session_end_started";
+    pub const SESSION_END_FAILED: &str = "session_end_failed";
     pub const SESSION_ENDED: &str = "session_ended";
     pub const SESSION_SUSPENDED: &str = "session_suspended";
     pub const SESSION_RESUMED: &str = "session_resumed";
@@ -68,6 +70,8 @@ pub mod event {
         SESSION_CREATION_STARTED,
         SESSION_CREATION_ENDED,
         SESSION_CREATION_FAILED,
+        SESSION_END_STARTED,
+        SESSION_END_FAILED,
         SESSION_ENDED,
         SESSION_SUSPENDED,
         SESSION_RESUMED,

--- a/crates/brain-protocol/src/environment.rs
+++ b/crates/brain-protocol/src/environment.rs
@@ -72,8 +72,8 @@ impl EnvironmentAttachment {
 pub struct EnvironmentOperation {
     /// The sequence of the journal record that started this operation. With
     /// `session_id` it names the operation: a redelivery carries the same pair, so a
-    /// receiver that already answered it can say so. An operation on the environment
-    /// itself rather than on a session's behalf carries the environment's own id here.
+    /// receiver that already answered it can say so. Setup and teardown belong to the
+    /// owning session's journal too.
     #[schemars(range(min = 1))]
     pub sequence: u64,
     pub environment_id: EnvironmentId,

--- a/crates/brain-protocol/src/session.rs
+++ b/crates/brain-protocol/src/session.rs
@@ -147,6 +147,7 @@ pub enum SessionStatus {
     Creating,
     Idle,
     Running,
+    Ending,
     Ended,
     Failed,
 }

--- a/crates/brain-server/src/data_layout.rs
+++ b/crates/brain-server/src/data_layout.rs
@@ -1,8 +1,7 @@
-//! What a Brain data directory holds, and the refusal to open one from before the
-//! per-session layout.
+//! Brain's v1 data directory.
 //!
 //! ```text
-//! {data_dir}/format             "brain-data/2"
+//! {data_dir}/format             "brain-data/1"
 //! {data_dir}/sessions/{id}/     one directory per session (see brain::LocalSessionStore)
 //! {data_dir}/agentloops         admitted Agentloop and Tool Components
 //! {data_dir}/native-workspaces  session workspaces for Brain Wasm Environments
@@ -12,12 +11,9 @@
 
 use std::path::{Path, PathBuf};
 
-pub const FORMAT: &str = "brain-data/2";
+pub const FORMAT: &str = "brain-data/1";
 
-/// Creates the layout if the directory is new, checks it if it is not, and returns the
-/// sessions directory. A directory written by an earlier Brain is refused with a message
-/// that names it: there is no migration from the shared journal, and starting over it
-/// would silently begin a second history beside the first.
+/// Initializes an empty directory or validates its format, then returns the sessions directory.
 pub fn prepare(data_dir: &Path) -> Result<PathBuf, brain::Error> {
     std::fs::create_dir_all(data_dir).map_err(io)?;
     let marker = data_dir.join("format");
@@ -25,19 +21,26 @@ pub fn prepare(data_dir: &Path) -> Result<PathBuf, brain::Error> {
         Ok(found) if found.trim() == FORMAT => {}
         Ok(found) => {
             return Err(brain::Error::InvalidState(format!(
-                "data directory {} is format {found:?}; this Brain reads {FORMAT} and does not migrate",
+                "data directory {} is format {found:?}; expected {FORMAT}",
                 data_dir.display()
             )));
         }
-        Err(_) if data_dir.join("journal").join("journal").exists() => {
-            return Err(brain::Error::InvalidState(format!(
-                "data directory {} holds a shared journal from an earlier Brain; this Brain keeps one directory per session and does not migrate. Start with an empty data directory",
-                data_dir.display()
-            )));
-        }
-        Err(_) => {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            if std::fs::read_dir(data_dir)
+                .map_err(io)?
+                .next()
+                .transpose()
+                .map_err(io)?
+                .is_some()
+            {
+                return Err(brain::Error::InvalidState(format!(
+                    "data directory {} is not empty and has no format marker",
+                    data_dir.display()
+                )));
+            }
             std::fs::write(&marker, format!("{FORMAT}\n")).map_err(io)?;
         }
+        Err(error) => return Err(io(error)),
     }
     let sessions = data_dir.join("sessions");
     std::fs::create_dir_all(&sessions).map_err(io)?;
@@ -76,11 +79,17 @@ mod tests {
     }
 
     #[test]
-    fn a_shared_journal_from_an_earlier_brain_is_refused() {
-        let data_dir = temporary("legacy");
-        std::fs::create_dir_all(data_dir.join("journal").join("journal")).unwrap();
+    fn an_unmarked_nonempty_directory_is_refused() {
+        let data_dir = temporary("unmarked");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::write(data_dir.join("existing"), "keep").unwrap();
         let error = prepare(&data_dir).unwrap_err().to_string();
-        assert!(error.contains("does not migrate"), "{error}");
+        assert!(error.contains("no format marker"), "{error}");
+        assert!(!data_dir.join("format").exists());
+        assert_eq!(
+            std::fs::read_to_string(data_dir.join("existing")).unwrap(),
+            "keep"
+        );
         let _ = std::fs::remove_dir_all(data_dir);
     }
 
@@ -88,14 +97,9 @@ mod tests {
     fn an_unknown_format_is_refused() {
         let data_dir = temporary("unknown");
         std::fs::create_dir_all(&data_dir).unwrap();
-        std::fs::write(
-            data_dir.join("format"),
-            "brain-data/9
-",
-        )
-        .unwrap();
+        std::fs::write(data_dir.join("format"), "unknown-format\n").unwrap();
         let error = prepare(&data_dir).unwrap_err().to_string();
-        assert!(error.contains("brain-data/9"), "{error}");
+        assert!(error.contains("unknown-format"), "{error}");
         let _ = std::fs::remove_dir_all(data_dir);
     }
 }

--- a/crates/brain-server/src/environment/adapter.rs
+++ b/crates/brain-server/src/environment/adapter.rs
@@ -50,7 +50,7 @@ impl EnvironmentAdapter for HttpEnvironmentAdapter {
         if let Some(token) = &self.bearer_token {
             request = request.bearer_auth(token);
         }
-        let response = request.send().await.map_err(|error| {
+        let mut response = request.send().await.map_err(|error| {
             brain::Error::Ambiguous(format!("Environment transport outcome is unknown: {error}"))
         })?;
         let status = response.status();
@@ -62,14 +62,18 @@ impl EnvironmentAdapter for HttpEnvironmentAdapter {
                 "Environment response exceeds 2 MiB".into(),
             ));
         }
-        let body = response
-            .bytes()
+        let mut body = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
             .await
-            .map_err(|error| brain::Error::Ambiguous(error.to_string()))?;
-        if body.len() > MAX_ENVIRONMENT_RESPONSE_BYTES {
-            return Err(brain::Error::Ambiguous(
-                "Environment response exceeds 2 MiB".into(),
-            ));
+            .map_err(|error| brain::Error::Ambiguous(error.to_string()))?
+        {
+            if chunk.len() > MAX_ENVIRONMENT_RESPONSE_BYTES - body.len() {
+                return Err(brain::Error::Ambiguous(
+                    "Environment response exceeds 2 MiB".into(),
+                ));
+            }
+            body.extend_from_slice(&chunk);
         }
         if !status.is_success() {
             return Err(brain::Error::Ambiguous(format!(
@@ -81,10 +85,61 @@ impl EnvironmentAdapter for HttpEnvironmentAdapter {
             brain::Error::Ambiguous(format!("Environment terminal receipt is invalid: {error}"))
         })?;
         if response.contract != ENVIRONMENT_CONTRACT || response.sequence != operation.sequence {
-            return Err(brain::Error::InvalidState(
+            return Err(brain::Error::Ambiguous(
                 "Environment response correlation does not match the operation".into(),
             ));
         }
         Ok(response.receipt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn oversized_chunked_response_is_rejected_before_waiting_for_eof() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0; 8192];
+            assert!(socket.read(&mut request).await.unwrap() > 0);
+            socket
+                .write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n")
+                .await
+                .unwrap();
+            let body = vec![b'x'; MAX_ENVIRONMENT_RESPONSE_BYTES + 1];
+            socket
+                .write_all(format!("{:x}\r\n", body.len()).as_bytes())
+                .await
+                .unwrap();
+            socket.write_all(&body).await.unwrap();
+            socket.write_all(b"\r\n").await.unwrap();
+            std::future::pending::<()>().await;
+        });
+        let environment_id = brain_protocol::EnvironmentId::new("env_large");
+        let binding = EnvironmentBinding {
+            environment_id: environment_id.clone(),
+            directory_generation: 1,
+        };
+        let operation = EnvironmentOperation {
+            sequence: 1,
+            environment_id,
+            session_id: brain_protocol::SessionId::new("ses_test"),
+            attachment_id: None,
+            request: brain_protocol::EnvironmentRequest::Teardown,
+        };
+        let adapter = HttpEnvironmentAdapter::new(reqwest::Client::new(), None);
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            adapter.send(&format!("http://{address}"), &binding, &operation),
+        )
+        .await;
+        server.abort();
+        assert!(
+            matches!(result.unwrap(), Err(brain::Error::Ambiguous(message)) if message.contains("exceeds 2 MiB"))
+        );
     }
 }

--- a/crates/brain-server/src/environment/registry.rs
+++ b/crates/brain-server/src/environment/registry.rs
@@ -11,7 +11,7 @@ use brain::{CreatingSession, Session, SessionStore};
 use brain_protocol::{
     AttachmentId, EnvironmentBinding, EnvironmentCallResult, EnvironmentId, EnvironmentOperation,
     EnvironmentReceipt, EnvironmentRequest, EnvironmentStatus, Provision, SessionConfig,
-    SessionEnvironment, SessionId, ToolManifest, codes,
+    SessionEnvironment, ToolManifest, codes,
 };
 use tokio::sync::broadcast;
 
@@ -88,13 +88,13 @@ impl EnvironmentRegistry {
         }
         let environment_id = specification.environment_id.clone();
         self.resources.create(EnvironmentRecord {
+            session_id: creation.session_id().clone(),
             environment_id: environment_id.clone(),
             configuration: specification.configuration.clone(),
             managed: specification.managed,
             idle_ttl_ms: specification.idle_ttl_ms,
             created_at_ms: resources::wall_clock_ms(),
             resources: Default::default(),
-            operations: 0,
         })?;
         let entry = self.entry(&environment_id);
         let receipt = self
@@ -111,7 +111,6 @@ impl EnvironmentRegistry {
         let receipt = match receipt {
             Ok(receipt) => receipt,
             Err(error) => {
-                let _ = self.resources.remove(&environment_id);
                 return Err(error);
             }
         };
@@ -153,18 +152,44 @@ impl EnvironmentRegistry {
 
     /// Tears the environment down and forgets it. Attached sessions hear
     /// `environment_closed`.
-    pub async fn close(&self, environment_id: &EnvironmentId) -> Result<(), brain::Error> {
-        if self.resources.get(environment_id)?.is_none() {
+    pub async fn close(
+        &self,
+        environment_id: &EnvironmentId,
+        store: &dyn SessionStore,
+        retry_failed: bool,
+    ) -> Result<(), brain::Error> {
+        let Some(record) = self.resources.get(environment_id)? else {
             return Ok(());
+        };
+        if &record.session_id != store.session_id() {
+            return Err(brain::Error::InvalidState(
+                "Environment belongs to another session".into(),
+            ));
         }
-        // Best effort: an environment that cannot be reached for its teardown is still
-        // forgotten here, and the notice says which.
-        if let Err(error) = self
-            .operation(environment_id, EnvironmentRequest::Teardown)
-            .await
+        let previous = operation_outcome(
+            store,
+            environment_id,
+            codes::event::call::ENVIRONMENT_TEARDOWN,
+        )?;
+        if previous
+            .as_ref()
+            .is_some_and(|attempt| attempt.outcome == Some(true))
         {
-            tracing::warn!(%environment_id, %error, "Environment teardown failed; forgetting it anyway");
+            return self.resources.remove(environment_id);
         }
+        if let Some(attempt) = &previous
+            && attempt.outcome.is_none()
+        {
+            store.append_sync(&[brain::AppendRecord::new(codes::event::ENVIRONMENT_TEARDOWN_FAILED,
+                serde_json::json!({"sequence":attempt.sequence,"code":"interrupted","ambiguous":true,"message":"teardown result was not recorded"}))], brain::SessionUpdate::default())?;
+        }
+        if previous.is_some() && !retry_failed {
+            return Err(brain::Error::Ambiguous(
+                "Environment teardown needs an explicit retry".into(),
+            ));
+        }
+        self.operation(environment_id, EnvironmentRequest::Teardown, store)
+            .await?;
         self.resources.remove(environment_id)?;
         let _ = self.notices.send(EnvironmentNotice {
             environment_id: environment_id.clone(),
@@ -384,9 +409,26 @@ impl EnvironmentRegistry {
         &self,
         session: &Session,
         config: &SessionConfig,
+        store: &dyn SessionStore,
     ) -> Result<(), brain::Error> {
         for attachment in config.environments.iter().rev() {
             if !attachment.attached() {
+                continue;
+            }
+            if let Some(attempt) = operation_outcome(
+                store,
+                &attachment.environment_id,
+                codes::event::call::ENVIRONMENT_DETACH,
+            )? {
+                if attempt.outcome.is_none() {
+                    session
+                        .record_call_failed(
+                            codes::event::call::ENVIRONMENT_DETACH,
+                            attempt.sequence,
+                            &brain::Error::Ambiguous("detach result was not recorded".into()),
+                        )
+                        .await?;
+                }
                 continue;
             }
             let entry = self.entry(&attachment.environment_id);
@@ -411,7 +453,7 @@ impl EnvironmentRegistry {
         request: EnvironmentRequest,
         kind: &str,
     ) -> Result<(), brain::Error> {
-        let sequence = session.record_call_started(kind, &request).await?;
+        let sequence = session.record(&format!("{kind}_started"), serde_json::json!({"environment_id":entry.binding.environment_id,"request":request})).await?;
         let operation = EnvironmentOperation {
             sequence,
             environment_id: entry.binding.environment_id.clone(),
@@ -424,31 +466,52 @@ impl EnvironmentRegistry {
             Ok(receipt) => session.record_call_ended(kind, sequence, &receipt).await,
             Err(error) => {
                 session.record_call_failed(kind, sequence, &error).await?;
-                Err(error)
+                Ok(())
             }
         }
     }
 
-    /// An operation on the environment's own behalf: setup at create, teardown at close.
-    /// Numbered by the environment's own counter and addressed to it, since no session
-    /// is involved.
     async fn operation(
         &self,
         environment_id: &EnvironmentId,
         request: EnvironmentRequest,
+        store: &dyn SessionStore,
     ) -> Result<EnvironmentReceipt, brain::Error> {
-        let sequence = self.resources.next_operation(environment_id)?;
+        let saved = store.append_sync(
+            &[brain::AppendRecord::new(
+                codes::event::ENVIRONMENT_TEARDOWN_STARTED,
+                serde_json::json!({"environment_id": environment_id, "request": request}),
+            )],
+            brain::SessionUpdate::default(),
+        )?;
+        let sequence = saved[0].sequence;
         let entry = self.entry(environment_id);
         let operation = EnvironmentOperation {
             sequence,
             environment_id: environment_id.clone(),
-            session_id: SessionId::new(environment_id.as_str()),
+            session_id: store.session_id().clone(),
             attachment_id: None,
             request,
         };
-        self.send(&entry, &operation)
+        let result = self
+            .send(&entry, &operation)
             .await
-            .and_then(|receipt| terminal(receipt, "lifecycle"))
+            .and_then(|receipt| terminal(receipt, "lifecycle"));
+        let (kind, payload) = match &result {
+            Ok(receipt) => (
+                codes::event::ENVIRONMENT_TEARDOWN_ENDED,
+                serde_json::json!({"sequence": sequence, "result": receipt}),
+            ),
+            Err(error) => (
+                codes::event::ENVIRONMENT_TEARDOWN_FAILED,
+                serde_json::json!({"sequence": sequence, "code": error.code(), "message": error.to_string(), "ambiguous": matches!(error, brain::Error::Ambiguous(_))}),
+            ),
+        };
+        store.append_sync(
+            &[brain::AppendRecord::new(kind, payload)],
+            brain::SessionUpdate::default(),
+        )?;
+        result
     }
 
     /// Sends one operation and keeps the environment's reachability current: a transport
@@ -504,6 +567,54 @@ impl EnvironmentRegistry {
                 directory_generation: 1,
             },
             endpoint: self.endpoint.clone(),
+        }
+    }
+}
+
+struct Attempt {
+    sequence: u64,
+    outcome: Option<bool>,
+}
+
+fn operation_outcome(
+    store: &dyn SessionStore,
+    environment_id: &EnvironmentId,
+    kind: &str,
+) -> Result<Option<Attempt>, brain::Error> {
+    let mut after = 0;
+    let mut attempt: Option<Attempt> = None;
+    loop {
+        let records = store.records_after(after, 1000)?;
+        if records.is_empty() {
+            return Ok(attempt);
+        }
+        for record in records {
+            after = record.sequence;
+            if record.kind == format!("{kind}_started")
+                && record
+                    .payload
+                    .get("environment_id")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(environment_id.as_str())
+            {
+                attempt = Some(Attempt {
+                    sequence: record.sequence,
+                    outcome: None,
+                });
+            } else if let Some(attempt) = &mut attempt
+                && record
+                    .payload
+                    .get("sequence")
+                    .and_then(serde_json::Value::as_u64)
+                    == Some(attempt.sequence)
+            {
+                if record.kind == format!("{kind}_ended") {
+                    attempt.outcome = Some(true);
+                }
+                if record.kind == format!("{kind}_failed") {
+                    attempt.outcome = Some(false);
+                }
+            }
         }
     }
 }
@@ -717,6 +828,91 @@ fn redacted(request: &EnvironmentRequest) -> Option<EnvironmentRequest> {
 #[cfg(test)]
 mod tests {
     use super::brain_wasm_resources;
+
+    #[tokio::test]
+    async fn teardown_is_journaled_and_failure_is_retained_without_automatic_retry() {
+        use super::*;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        struct Adapter {
+            store: Arc<brain::LocalSessionStore>,
+            calls: AtomicUsize,
+        }
+        #[async_trait::async_trait]
+        impl EnvironmentAdapter for Adapter {
+            async fn send(
+                &self,
+                _: &str,
+                _: &EnvironmentBinding,
+                operation: &EnvironmentOperation,
+            ) -> Result<EnvironmentReceipt, brain::Error> {
+                assert_eq!(&operation.session_id, self.store.session_id());
+                let records = self.store.records_after(0, 100).unwrap();
+                assert!(
+                    records
+                        .iter()
+                        .any(|record| record.sequence == operation.sequence
+                            && record.kind == codes::event::ENVIRONMENT_TEARDOWN_STARTED)
+                );
+                if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Err(brain::Error::Ambiguous("connection lost".into()))
+                } else {
+                    Ok(EnvironmentReceipt::Accepted {
+                        resources: Default::default(),
+                    })
+                }
+            }
+        }
+        let path = std::env::temp_dir().join(format!("brain-teardown-{}", rand::random::<u64>()));
+        let (telemetry, _) = brain_telemetry::telemetry_channel();
+        let store = brain::LocalSessionStore::create(
+            &path.join("session"),
+            brain_protocol::SessionId::new("ses_owner"),
+            &serde_json::json!({}),
+            brain::Writer::spawn(),
+            Arc::new(brain::Feed::new(telemetry)),
+        )
+        .unwrap();
+        let resources = Arc::new(EnvironmentResources::open(&path.join("environments")).unwrap());
+        let id = EnvironmentId::new("env_owned");
+        resources
+            .create(EnvironmentRecord {
+                session_id: store.session_id().clone(),
+                environment_id: id.clone(),
+                configuration: serde_json::json!({}),
+                managed: true,
+                idle_ttl_ms: None,
+                created_at_ms: 0,
+                resources: Default::default(),
+            })
+            .unwrap();
+        let adapter = Arc::new(Adapter {
+            store: store.clone(),
+            calls: AtomicUsize::new(0),
+        });
+        let registry = EnvironmentRegistry::new(
+            resources.clone(),
+            "http://environment",
+            adapter.clone(),
+            Duration::from_secs(60),
+        );
+        assert!(registry.close(&id, &*store, false).await.is_err());
+        assert!(resources.get(&id).unwrap().is_some());
+        assert!(registry.close(&id, &*store, false).await.is_err());
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 1);
+        assert!(
+            store
+                .records_after(0, 100)
+                .unwrap()
+                .iter()
+                .any(
+                    |record| record.kind == codes::event::ENVIRONMENT_TEARDOWN_FAILED
+                        && record.payload["ambiguous"] == true
+                )
+        );
+        registry.close(&id, &*store, true).await.unwrap();
+        assert_eq!(adapter.calls.load(Ordering::SeqCst), 2);
+        assert!(resources.get(&id).unwrap().is_none());
+    }
 
     #[test]
     fn brain_wasm_filesystem_roots_are_explicit() {

--- a/crates/brain-server/src/environment/resources.rs
+++ b/crates/brain-server/src/environment/resources.rs
@@ -14,11 +14,12 @@ use std::{
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
-use brain_protocol::{EnvironmentId, EnvironmentStatus, Resources};
+use brain_protocol::{EnvironmentId, EnvironmentStatus, Resources, SessionId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EnvironmentRecord {
+    pub session_id: SessionId,
     pub environment_id: EnvironmentId,
     pub configuration: serde_json::Value,
     pub managed: bool,
@@ -27,10 +28,6 @@ pub struct EnvironmentRecord {
     pub created_at_ms: u64,
     #[serde(default)]
     pub resources: Resources,
-    /// Operations issued on the environment's own behalf (setup, teardown): the
-    /// sequence its wire envelope carries, since no session's counter applies.
-    #[serde(default)]
-    pub operations: u64,
 }
 
 struct Row {
@@ -51,6 +48,9 @@ impl EnvironmentResources {
     /// with a warning: one damaged row must not stop a process starting.
     pub fn open(directory: &Path) -> Result<Self, brain::Error> {
         fs::create_dir_all(directory).map_err(io)?;
+        if let Some(parent) = directory.parent() {
+            crate::persistence::sync_directory(parent)?;
+        }
         let mut rows = HashMap::new();
         for entry in fs::read_dir(directory).map_err(io)?.flatten() {
             let path = entry.path();
@@ -138,16 +138,11 @@ impl EnvironmentResources {
         let row = rows.get_mut(environment_id).ok_or_else(|| {
             brain::Error::NotFound(format!("Environment `{environment_id}` does not exist"))
         })?;
-        change(&mut row.record);
-        self.write(&row.record)?;
+        let mut updated = row.record.clone();
+        change(&mut updated);
+        self.write(&updated)?;
+        row.record = updated;
         Ok(row.record.clone())
-    }
-
-    /// The next sequence for an operation on the environment's own behalf.
-    pub fn next_operation(&self, environment_id: &EnvironmentId) -> Result<u64, brain::Error> {
-        Ok(self
-            .update(environment_id, |record| record.operations += 1)?
-            .operations)
     }
 
     pub fn set_status(
@@ -180,22 +175,23 @@ impl EnvironmentResources {
 
     pub fn remove(&self, environment_id: &EnvironmentId) -> Result<(), brain::Error> {
         let mut rows = self.lock()?;
-        rows.remove(environment_id);
         match fs::remove_file(self.path(environment_id)) {
-            Ok(()) => Ok(()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Ok(()) => {
+                crate::persistence::sync_directory(&self.directory)?;
+                rows.remove(environment_id);
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                rows.remove(environment_id);
+                Ok(())
+            }
             Err(error) => Err(io(error)),
         }
     }
 
     fn write(&self, record: &EnvironmentRecord) -> Result<(), brain::Error> {
-        let bytes = serde_json::to_vec_pretty(record).map_err(json)?;
         let target = self.path(&record.environment_id);
-        let temporary = self
-            .directory
-            .join(format!(".{}.json.tmp", record.environment_id.as_str()));
-        fs::write(&temporary, bytes).map_err(io)?;
-        fs::rename(&temporary, &target).map_err(io)
+        crate::persistence::write_json(&target, record)
     }
 
     fn path(&self, environment_id: &EnvironmentId) -> PathBuf {
@@ -239,13 +235,13 @@ mod tests {
 
     fn record(id: &str) -> EnvironmentRecord {
         EnvironmentRecord {
+            session_id: SessionId::new("ses_owner"),
             environment_id: EnvironmentId::new(id),
             configuration: serde_json::json!({"image": "ubuntu"}),
             managed: true,
             idle_ttl_ms: Some(1_000),
             created_at_ms: 1,
             resources: Default::default(),
-            operations: 0,
         }
     }
 
@@ -263,17 +259,11 @@ mod tests {
                 record.configuration = serde_json::json!({"image": "debian"});
             })
             .unwrap();
-        assert_eq!(
-            resources
-                .next_operation(&EnvironmentId::new("env_a"))
-                .unwrap(),
-            1
-        );
         drop(resources);
         let reopened = EnvironmentResources::open(&directory).unwrap();
         let found = reopened.get(&EnvironmentId::new("env_a")).unwrap().unwrap();
         assert_eq!(found.configuration["image"], "debian");
-        assert_eq!(found.operations, 1);
+        assert_eq!(found.session_id.as_str(), "ses_owner");
         reopened.remove(&EnvironmentId::new("env_a")).unwrap();
         assert!(
             reopened

--- a/crates/brain-server/src/idempotency.rs
+++ b/crates/brain-server/src/idempotency.rs
@@ -1,21 +1,16 @@
-//! Answers already given to requests that carried an idempotency key.
-//!
-//! An HTTP concern, so it lives in the server: a retried create, message, or tool result
-//! is answered from here instead of being run again. Held in memory with a retention
-//! window. It does not survive a restart on purpose: what these answers are about is
-//! sessions, and a replayed `POST /v1/sessions` answer after a restart would hand the
-//! client a session id that refers to nothing.
+//! Durable HTTP operation claims and answers. An unresolved claim is never executed again.
 
 use std::{
     collections::HashMap,
+    fs::File,
+    path::Path,
     sync::Mutex,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use brain_protocol::Identity;
 
-/// How long a recorded answer is kept. Far longer than any retry a client makes and far
-/// shorter than forever, so memory is bounded by traffic within the window.
+/// Completed answers expire; unresolved claims remain to prevent duplicate effects.
 pub const DEFAULT_RETENTION: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Below this an eviction sweep costs more than the entries it would find.
@@ -27,32 +22,49 @@ pub struct IdempotencyStore {
 }
 
 struct State {
+    log: File,
     entries: HashMap<(String, String), Stored>,
     /// Sweep expired entries once the table has doubled since the last sweep, so the
     /// total cost of sweeping stays linear in the number of entries written.
     sweep_at: usize,
 }
 
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 struct Stored {
     /// The request the answer was given to, compared on every hit: the same key with a
     /// different request is a different request wearing that key's name, and an error.
     request: Identity,
-    response: serde_json::Value,
+    response: Option<serde_json::Value>,
     expires_at_ms: u64,
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Record {
+    scope: String,
+    key: String,
+    stored: Stored,
+}
+
 impl IdempotencyStore {
-    pub fn new(retention: Duration) -> Self {
-        Self {
+    pub fn open(path: &Path, retention: Duration) -> Result<Self, brain::Error> {
+        let (log, records) = crate::persistence::open_log::<Record>(path)?;
+        let now = wall_clock_ms()?;
+        let mut entries = HashMap::new();
+        for record in records {
+            entries.insert((record.scope, record.key), record.stored);
+        }
+        entries.retain(|_, stored| stored.response.is_none() || stored.expires_at_ms > now);
+        Ok(Self {
             state: Mutex::new(State {
-                entries: HashMap::new(),
+                log,
+                entries,
                 sweep_at: MIN_SWEEP,
             }),
             retention,
-        }
+        })
     }
 
-    /// The answer already recorded under `key`, if the request is the same one.
+    /// Replays a completed answer or durably claims a new request before the caller acts.
     pub fn get<T: serde::Serialize>(
         &self,
         scope: &str,
@@ -64,19 +76,44 @@ impl IdempotencyStore {
         let mut state = self.lock()?;
         let entry = (scope.to_string(), key.to_string());
         match state.entries.get(&entry) {
-            None => Ok(None),
+            None => self.claim(&mut state, entry, request),
             // Past its retention it is not a record any more. Dropped here rather than
             // returned, so the caller executes the request instead of replaying an
             // answer Brain has stopped promising to keep.
-            Some(stored) if stored.expires_at_ms <= now => {
+            Some(stored) if stored.response.is_some() && stored.expires_at_ms <= now => {
                 state.entries.remove(&entry);
-                Ok(None)
+                self.claim(&mut state, entry, request)
             }
             Some(stored) if stored.request != request => Err(brain::Error::Conflict(
                 "idempotency key reused with different request".into(),
             )),
-            Some(stored) => Ok(Some(stored.response.clone())),
+            Some(stored) => stored.response.clone().map(Some).ok_or_else(|| brain::Error::Ambiguous(
+                "this request was already accepted but its outcome is not recorded; it will not be executed again".into()
+            )),
         }
+    }
+
+    fn claim(
+        &self,
+        state: &mut State,
+        entry: (String, String),
+        request: Identity,
+    ) -> Result<Option<serde_json::Value>, brain::Error> {
+        let stored = Stored {
+            request,
+            response: None,
+            expires_at_ms: u64::MAX,
+        };
+        crate::persistence::append(
+            &mut state.log,
+            &Record {
+                scope: entry.0.clone(),
+                key: entry.1.clone(),
+                stored: stored.clone(),
+            },
+        )?;
+        state.entries.insert(entry, stored);
+        Ok(None)
     }
 
     pub fn put<T: serde::Serialize>(
@@ -92,27 +129,33 @@ impl IdempotencyStore {
             now.saturating_add(u64::try_from(self.retention.as_millis()).unwrap_or(u64::MAX));
         let mut state = self.lock()?;
         let entry = (scope.to_string(), key.to_string());
-        if state
-            .entries
-            .get(&entry)
-            .is_some_and(|stored| stored.expires_at_ms > now)
-        {
+        if state.entries.get(&entry).is_some_and(|stored| {
+            stored.request != request || (stored.response.is_some() && stored.expires_at_ms > now)
+        }) {
             return Err(brain::Error::Conflict(
                 "idempotency key already recorded".into(),
             ));
         }
         if state.entries.len() >= state.sweep_at {
-            state.entries.retain(|_, stored| stored.expires_at_ms > now);
+            state
+                .entries
+                .retain(|_, stored| stored.response.is_none() || stored.expires_at_ms > now);
             state.sweep_at = state.entries.len().saturating_mul(2).max(MIN_SWEEP);
         }
-        state.entries.insert(
-            entry,
-            Stored {
-                request,
-                response: response.clone(),
-                expires_at_ms,
+        let stored = Stored {
+            request,
+            response: Some(response.clone()),
+            expires_at_ms,
+        };
+        crate::persistence::append(
+            &mut state.log,
+            &Record {
+                scope: scope.into(),
+                key: key.into(),
+                stored: stored.clone(),
             },
-        );
+        )?;
+        state.entries.insert(entry, stored);
         Ok(())
     }
 
@@ -140,9 +183,19 @@ fn wall_clock_ms() -> Result<u64, brain::Error> {
 mod tests {
     use super::*;
 
+    fn store(retention: Duration) -> IdempotencyStore {
+        IdempotencyStore::open(
+            &std::env::temp_dir()
+                .join(format!("brain-idempotency-{}", rand::random::<u64>()))
+                .join("requests.log"),
+            retention,
+        )
+        .unwrap()
+    }
+
     #[test]
     fn a_recorded_answer_is_replayed_for_the_same_request_only() {
-        let store = IdempotencyStore::new(Duration::from_secs(60));
+        let store = store(Duration::from_secs(60));
         store
             .put(
                 "create",
@@ -160,8 +213,40 @@ mod tests {
     }
 
     #[test]
+    fn restart_replays_answers_and_never_reexecutes_unfinished_requests() {
+        let path = std::env::temp_dir()
+            .join(format!("brain-requests-{}", rand::random::<u64>()))
+            .join("requests.log");
+        let store = IdempotencyStore::open(&path, DEFAULT_RETENTION).unwrap();
+        assert_eq!(store.get("create", "done", &"body").unwrap(), None);
+        store
+            .put(
+                "create",
+                "done",
+                &"body",
+                &serde_json::json!({"id": "ses_1"}),
+            )
+            .unwrap();
+        assert_eq!(store.get("create", "pending", &"body").unwrap(), None);
+        drop(store);
+        let store = IdempotencyStore::open(&path, DEFAULT_RETENTION).unwrap();
+        assert_eq!(
+            store.get("create", "done", &"body").unwrap(),
+            Some(serde_json::json!({"id": "ses_1"}))
+        );
+        assert!(matches!(
+            store.get("create", "pending", &"body"),
+            Err(brain::Error::Ambiguous(_))
+        ));
+        assert!(matches!(
+            store.get("create", "pending", &"changed"),
+            Err(brain::Error::Conflict(_))
+        ));
+    }
+
+    #[test]
     fn an_expired_answer_is_not_replayed() {
-        let store = IdempotencyStore::new(Duration::ZERO);
+        let store = store(Duration::ZERO);
         store
             .put("create", "key", &"request", &serde_json::json!({}))
             .unwrap();
@@ -170,7 +255,7 @@ mod tests {
 
     #[test]
     fn expired_answers_are_swept_as_the_table_grows() {
-        let store = IdempotencyStore::new(Duration::ZERO);
+        let store = store(Duration::ZERO);
         for index in 0..(2 * MIN_SWEEP) {
             store
                 .put("scope", &index.to_string(), &index, &serde_json::json!({}))

--- a/crates/brain-server/src/lib.rs
+++ b/crates/brain-server/src/lib.rs
@@ -7,6 +7,7 @@ pub mod environment;
 pub mod idempotency;
 pub mod metadata;
 pub mod model_binding;
+mod persistence;
 pub mod resident;
 mod service;
 mod session_ownership;

--- a/crates/brain-server/src/main.rs
+++ b/crates/brain-server/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn compose(config: &ServerConfig) -> anyhow::Result<ServerApi> {
+    let sessions_dir = brain_server::data_layout::prepare(&config.data_dir)?;
     let (telemetry, worker) = telemetry_channel();
     tokio::spawn(worker.run(Arc::new(LogSink)));
     let loops = Arc::new(
@@ -59,8 +60,7 @@ async fn compose(config: &ServerConfig) -> anyhow::Result<ServerApi> {
         .ready()
         .await
         .map_err(|error| anyhow::anyhow!(error))?;
-    // The server's one-off record of each session: the credential it calls a model
-    // with. Appended, never fsynced.
+    // Credentials are durable before the session's creation record is committed.
     let metadata = Arc::new(brain_server::metadata::ServerMetadata::open(
         &brain_server::metadata::metadata_directory(&config.data_dir),
     )?);
@@ -107,10 +107,10 @@ async fn compose(config: &ServerConfig) -> anyhow::Result<ServerApi> {
     ));
     // Every session's directory, rebuilt from disk. A session that was mid-turn when the
     // last process stopped is failed with code `interrupted` before anything is served.
-    let sessions_dir = brain_server::data_layout::prepare(&config.data_dir)?;
     let writer = Writer::spawn();
     let feed = Arc::new(Feed::new(telemetry.clone()));
-    let resident_hosts = ResidentHosts::default();
+    let resident_hosts =
+        ResidentHosts::open(&config.data_dir.join("resident-hosts").join("hosts.log"))?;
     let session_runtime = Arc::new(SessionRuntime {
         max_model_calls_per_turn: config.max_model_calls_per_turn,
         max_turn_ms: config.max_turn_secs.saturating_mul(1_000),
@@ -131,7 +131,10 @@ async fn compose(config: &ServerConfig) -> anyhow::Result<ServerApi> {
         feed,
         session_runtime,
         session_idle_ttl: Duration::from_secs(config.session_idle_ttl_secs),
-        idempotency: IdempotencyStore::new(brain_server::idempotency::DEFAULT_RETENTION),
+        idempotency: IdempotencyStore::open(
+            &config.data_dir.join("requests").join("requests.log"),
+            brain_server::idempotency::DEFAULT_RETENTION,
+        )?,
         loops,
         environments,
         resident_hosts,

--- a/crates/brain-server/src/metadata.rs
+++ b/crates/brain-server/src/metadata.rs
@@ -5,18 +5,12 @@
 //! the record of what happened; this is the record of what the session calls its model
 //! with. Restoring a session after a restart needs both.
 //!
-//! Written on the same terms as the journal: appended, **never fsynced**, and best effort.
-//! A create returns as soon as the bytes are handed to the page cache, which is
-//! what took four milliseconds out of it — the previous version was a SQLite table opened
-//! `synchronous = FULL`, so every session create waited for a disk. A crash can lose the
-//! tail, and a session whose metadata went with it comes back readable but cannot take
-//! another turn. That is the trade this design accepts everywhere else, made here too.
-//!
+//! Credentials and their key are durable before session admission succeeds.
 
 use std::{
     collections::HashMap,
     fs::{self, File, OpenOptions},
-    io::{BufRead, BufReader, Write},
+    io::Write,
     path::{Path, PathBuf},
     sync::{Mutex, RwLock},
 };
@@ -57,9 +51,6 @@ enum Entry {
 
 pub struct ServerMetadata {
     credentials: RwLock<HashMap<String, ModelCredential>>,
-    /// Held only across a small buffered append. The old store held a process-global lock
-    /// across an fsync and an AES-GCM round trip, which serialised every session create in
-    /// the process behind a disk.
     log: Mutex<File>,
     key: Zeroizing<[u8; KEY_BYTES]>,
 }
@@ -69,12 +60,8 @@ impl ServerMetadata {
         fs::create_dir_all(directory).map_err(storage_error)?;
         let key = load_or_create_key(&directory.join("master.key"))?;
         let path = directory.join("metadata.log");
-        let credentials = replay(&path, &key)?;
-        let log = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .map_err(storage_error)?;
+        let (log, records) = crate::persistence::open_log(&path)?;
+        let credentials = replay(records, &key)?;
         Ok(Self {
             credentials: RwLock::new(credentials),
             log: Mutex::new(log),
@@ -90,25 +77,16 @@ impl ServerMetadata {
         binding_id: &str,
         selection: &ModelSelection,
     ) -> Result<(), brain::Error> {
-        {
-            let mut credentials = self.credentials.write().map_err(poisoned)?;
-            if let Some(existing) = credentials.get(binding_id) {
-                if existing.provider == selection.provider
-                    && existing.api_key.as_str() == selection.api_key
-                {
-                    return Ok(());
-                }
-                return Err(brain::Error::InvalidState(
-                    "model binding identity is already sealed to different credentials".into(),
-                ));
+        let mut credentials = self.credentials.write().map_err(poisoned)?;
+        if let Some(existing) = credentials.get(binding_id) {
+            if existing.provider == selection.provider
+                && existing.api_key.as_str() == selection.api_key
+            {
+                return Ok(());
             }
-            credentials.insert(
-                binding_id.to_owned(),
-                ModelCredential {
-                    provider: selection.provider.clone(),
-                    api_key: Zeroizing::new(selection.api_key.clone()),
-                },
-            );
+            return Err(brain::Error::InvalidState(
+                "model binding identity is already sealed to different credentials".into(),
+            ));
         }
         let (nonce, ciphertext) = self.seal(binding_id, selection)?;
         self.append(&Entry::Binding {
@@ -116,7 +94,15 @@ impl ServerMetadata {
             provider: selection.provider.clone(),
             nonce,
             ciphertext,
-        })
+        })?;
+        credentials.insert(
+            binding_id.to_owned(),
+            ModelCredential {
+                provider: selection.provider.clone(),
+                api_key: Zeroizing::new(selection.api_key.clone()),
+            },
+        );
+        Ok(())
     }
 
     pub fn binding(&self, binding_id: &str) -> Result<Option<ModelCredential>, brain::Error> {
@@ -129,26 +115,20 @@ impl ServerMetadata {
     }
 
     pub fn forget_binding(&self, binding_id: &str) -> Result<(), brain::Error> {
-        self.credentials
-            .write()
-            .map_err(poisoned)?
-            .remove(binding_id);
+        let mut credentials = self.credentials.write().map_err(poisoned)?;
         self.append(&Entry::BindingForgotten {
             binding_id: binding_id.to_owned(),
-        })
+        })?;
+        credentials.remove(binding_id);
+        Ok(())
     }
 
-    /// Appends one line. No fsync, on purpose: this is best effort, and waiting for a disk
-    /// here is the cost the whole design exists to avoid.
     fn append(&self, entry: &Entry) -> Result<(), brain::Error> {
-        let mut line = serde_json::to_vec(entry).map_err(|error| storage_json(&error))?;
-        line.push(b'\n');
         let mut log = self
             .log
             .lock()
             .map_err(|_| brain::Error::Executor("server metadata log is poisoned".into()))?;
-        log.write_all(&line).map_err(storage_error)?;
-        Ok(())
+        crate::persistence::append(&mut log, entry)
     }
 
     fn seal(
@@ -174,24 +154,12 @@ impl ServerMetadata {
     }
 }
 
-/// Reads back what reached the disk.
-///
-/// A line that will not parse ends the read. The last write of a crashed process is the one
-/// most likely to be half a line, and everything before it is whole — so the log is taken up
-/// to the tear and no further, rather than refusing to start over a partial record.
 fn replay(
-    path: &Path,
+    records: Vec<Entry>,
     key: &[u8; KEY_BYTES],
 ) -> Result<HashMap<String, ModelCredential>, brain::Error> {
     let mut credentials = HashMap::new();
-    let Ok(file) = File::open(path) else {
-        return Ok(credentials);
-    };
-    for line in BufReader::new(file).lines() {
-        let Ok(line) = line else { break };
-        let Ok(entry) = serde_json::from_str::<Entry>(&line) else {
-            break;
-        };
+    for entry in records {
         match entry {
             Entry::Binding {
                 binding_id,
@@ -199,18 +167,16 @@ fn replay(
                 nonce,
                 ciphertext,
             } => {
-                // A credential that will not decrypt is dropped rather than fatal: the key
-                // may have been replaced, and one unreadable binding must not stop a
-                // process starting.
-                if let Some(api_key) = unseal(key, &binding_id, &nonce, &ciphertext) {
-                    credentials.insert(
-                        binding_id,
-                        ModelCredential {
-                            provider,
-                            api_key: Zeroizing::new(api_key),
-                        },
-                    );
-                }
+                let api_key = unseal(key, &binding_id, &nonce, &ciphertext).ok_or_else(|| {
+                    brain::Error::Journal("model credential cannot be decrypted".into())
+                })?;
+                credentials.insert(
+                    binding_id,
+                    ModelCredential {
+                        provider,
+                        api_key: Zeroizing::new(api_key),
+                    },
+                );
             }
             Entry::BindingForgotten { binding_id } => {
                 credentials.remove(&binding_id);
@@ -274,6 +240,8 @@ fn load_or_create_key(path: &Path) -> Result<[u8; KEY_BYTES], brain::Error> {
     match options.open(path) {
         Ok(mut file) => {
             file.write_all(&key).map_err(storage_error)?;
+            file.sync_all().map_err(storage_error)?;
+            crate::persistence::sync_directory(path.parent().expect("master key has a directory"))?;
             Ok(key)
         }
         // Two processes opened the same directory at once. The one that lost reads what the
@@ -291,10 +259,6 @@ fn key_from_bytes(bytes: Vec<u8>) -> Result<[u8; KEY_BYTES], brain::Error> {
 }
 
 fn storage_error(error: std::io::Error) -> brain::Error {
-    brain::Error::Executor(format!("server metadata store: {error}"))
-}
-
-fn storage_json(error: &serde_json::Error) -> brain::Error {
     brain::Error::Executor(format!("server metadata store: {error}"))
 }
 

--- a/crates/brain-server/src/model_binding.rs
+++ b/crates/brain-server/src/model_binding.rs
@@ -40,8 +40,7 @@ pub trait ModelBindingStore: Send + Sync + 'static {
 
 /// The credential half of the server's session metadata.
 ///
-/// Reads come from memory; writes also append to the metadata log so a session can still
-/// call its model after a restart. Nothing fsyncs — see `crate::metadata`.
+/// Reads come from memory; writes commit the encrypted credential before admission.
 pub struct LocalModelBindingStore {
     metadata: Arc<crate::metadata::ServerMetadata>,
 }
@@ -312,17 +311,17 @@ mod tests {
         let directory = temporary();
         let store = store(&directory);
         store.put("model_a", &selection("secret")).unwrap();
+        store.put("model_b", &selection("secret")).unwrap();
         let credential = store.get("model_a").unwrap().expect("the binding is there");
         assert_eq!(credential.api_key.as_str(), "secret");
 
         store.delete("model_a").unwrap();
         assert!(store.get("model_a").unwrap().is_none());
+        assert!(store.get("model_b").unwrap().is_some());
         let _ = std::fs::remove_dir_all(directory);
     }
 
-    /// A session must still be able to call its model after a restart, so the credential
-    /// outlives the process — written asynchronously and never fsynced, so a crash may
-    /// lose the most recent ones.
+    /// A session's credential survives restart without appearing in plaintext on disk.
     #[test]
     fn a_credential_survives_a_restart_without_plaintext_on_disk() {
         let directory = temporary();

--- a/crates/brain-server/src/persistence.rs
+++ b/crates/brain-server/src/persistence.rs
@@ -1,0 +1,125 @@
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{BufRead, BufReader, Seek, SeekFrom, Write},
+    path::Path,
+};
+
+use serde::{Serialize, de::DeserializeOwned};
+
+pub(crate) fn sync_directory(path: &Path) -> Result<(), brain::Error> {
+    #[cfg(unix)]
+    File::open(path)
+        .and_then(|file| file.sync_all())
+        .map_err(io)?;
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+pub(crate) fn open_log<T: DeserializeOwned>(path: &Path) -> Result<(File, Vec<T>), brain::Error> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| brain::Error::Journal("log has no directory".into()))?;
+    fs::create_dir_all(parent).map_err(io)?;
+    if let Some(root) = parent.parent() {
+        sync_directory(root)?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(io)?;
+    let mut records = Vec::new();
+    let mut offset = 0;
+    {
+        let mut reader = BufReader::new(&mut file);
+        let mut line = Vec::new();
+        loop {
+            line.clear();
+            if reader.read_until(b'\n', &mut line).map_err(io)? == 0 {
+                break;
+            }
+            if !line.ends_with(b"\n") {
+                break;
+            }
+            records.push(
+                serde_json::from_slice(&line)
+                    .map_err(|error| brain::Error::Journal(error.to_string()))?,
+            );
+            offset += line.len() as u64;
+        }
+    }
+    file.set_len(offset).map_err(io)?;
+    file.seek(SeekFrom::End(0)).map_err(io)?;
+    file.sync_all().map_err(io)?;
+    sync_directory(parent)?;
+    Ok((file, records))
+}
+
+pub(crate) fn append<T: Serialize>(file: &mut File, record: &T) -> Result<(), brain::Error> {
+    let mut bytes =
+        serde_json::to_vec(record).map_err(|error| brain::Error::Journal(error.to_string()))?;
+    bytes.push(b'\n');
+    let before = file.metadata().map_err(io)?.len();
+    if let Err(error) = file.write_all(&bytes).and_then(|()| file.sync_data()) {
+        // Do not let a failed partial append hide later acknowledged records.
+        file.set_len(before)
+            .and_then(|()| file.sync_data())
+            .map_err(io)?;
+        file.seek(SeekFrom::End(0)).map_err(io)?;
+        return Err(io(error));
+    }
+    Ok(())
+}
+
+pub(crate) fn write_json(path: &Path, value: &impl Serialize) -> Result<(), brain::Error> {
+    let bytes =
+        serde_json::to_vec(value).map_err(|error| brain::Error::Journal(error.to_string()))?;
+    let temporary = path.with_extension("json.tmp");
+    let mut file = File::create(&temporary).map_err(io)?;
+    file.write_all(&bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(io)?;
+    drop(file);
+    fs::rename(&temporary, path).map_err(io)?;
+    sync_directory(path.parent().expect("resource file has a directory"))
+}
+
+fn io(error: std::io::Error) -> brain::Error {
+    brain::Error::Journal(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn torn_tail_is_removed_before_new_records_are_acknowledged() {
+        let path = std::env::temp_dir()
+            .join(format!("brain-log-{}", rand::random::<u64>()))
+            .join("records.log");
+        let (mut file, _) = open_log::<String>(&path).unwrap();
+        append(&mut file, &"first").unwrap();
+        file.write_all(b"{\"torn\"").unwrap();
+        drop(file);
+        let (mut file, records) = open_log::<String>(&path).unwrap();
+        assert_eq!(records, vec!["first"]);
+        append(&mut file, &"second").unwrap();
+        drop(file);
+        let (_, records) = open_log::<String>(&path).unwrap();
+        assert_eq!(records, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn complete_corrupt_record_fails_closed() {
+        let path = std::env::temp_dir()
+            .join(format!("brain-log-{}", rand::random::<u64>()))
+            .join("records.log");
+        let (mut file, _) = open_log::<String>(&path).unwrap();
+        file.write_all(b"corrupt\n").unwrap();
+        drop(file);
+        assert!(open_log::<String>(&path).is_err());
+    }
+}

--- a/crates/brain-server/src/resident.rs
+++ b/crates/brain-server/src/resident.rs
@@ -1,5 +1,7 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
+    fs::File,
+    path::Path,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
@@ -15,23 +17,42 @@ const COMMAND_CAPACITY: usize = 128;
 const MAX_HOSTS: usize = 4_096;
 const UNCONNECTED_TTL: Duration = Duration::from_secs(60);
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ResidentHosts {
     inner: Arc<Mutex<State>>,
 }
 
-#[derive(Default)]
 struct State {
+    log: File,
     hosts: HashMap<HostId, Host>,
 }
 
 struct Host {
+    sessions: HashSet<SessionId>,
     token: [u8; 32],
     disconnected_at: Instant,
     connection: u64,
     commands: Option<mpsc::Sender<HostCommand>>,
     disconnect: Option<oneshot::Sender<()>>,
     pending: HashMap<(SessionId, u64), PendingCall>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct RegistrationRecord {
+    host_id: HostId,
+    token: Option<[u8; 32]>,
+}
+
+fn registered(token: [u8; 32]) -> Host {
+    Host {
+        token,
+        sessions: HashSet::new(),
+        disconnected_at: Instant::now(),
+        connection: 0,
+        commands: None,
+        disconnect: None,
+        pending: HashMap::new(),
+    }
 }
 
 struct PendingCall {
@@ -46,27 +67,91 @@ struct PendingEvent {
 }
 
 impl ResidentHosts {
+    pub fn open(path: &Path) -> Result<Self, brain::Error> {
+        let (log, records) = crate::persistence::open_log::<RegistrationRecord>(path)?;
+        let mut hosts = HashMap::new();
+        for record in records {
+            if let Some(token) = record.token {
+                hosts.insert(record.host_id, registered(token));
+            } else {
+                hosts.remove(&record.host_id);
+            }
+        }
+        Ok(Self {
+            inner: Arc::new(Mutex::new(State { log, hosts })),
+        })
+    }
+
+    pub fn bind_session(
+        &self,
+        session_id: &SessionId,
+        host_ids: &[HostId],
+    ) -> Result<(), ApiError> {
+        let mut state = self.lock()?;
+        for id in host_ids {
+            if !state.hosts.contains_key(id) {
+                return Err(ApiError::invalid_request(
+                    "resident host registration is missing",
+                ));
+            }
+        }
+        for id in host_ids {
+            state
+                .hosts
+                .get_mut(id)
+                .expect("registration checked")
+                .sessions
+                .insert(session_id.clone());
+        }
+        Ok(())
+    }
+
+    pub fn release_session(&self, session_id: &SessionId) -> Result<(), ApiError> {
+        for host in self.lock()?.hosts.values_mut() {
+            host.sessions.remove(session_id);
+        }
+        Ok(())
+    }
+
     pub fn register(&self) -> Result<HostRegistration, ApiError> {
         let host_id = HostId::new(brain::random_id("host"));
         let token = brain::random_id("bht");
         let mut state = self.lock()?;
-        state.hosts.retain(|_, host| {
-            host.commands.is_some() || host.disconnected_at.elapsed() < UNCONNECTED_TTL
-        });
+        let expired = state
+            .hosts
+            .iter()
+            .filter(|(_, host)| {
+                host.sessions.is_empty()
+                    && host.commands.is_none()
+                    && host.disconnected_at.elapsed() >= UNCONNECTED_TTL
+            })
+            .map(|(id, _)| id.clone())
+            .collect::<Vec<_>>();
+        for id in expired {
+            crate::persistence::append(
+                &mut state.log,
+                &RegistrationRecord {
+                    host_id: id.clone(),
+                    token: None,
+                },
+            )
+            .map_err(|error| ApiError::internal(error.to_string()))?;
+            state.hosts.remove(&id);
+        }
         if state.hosts.len() >= MAX_HOSTS {
             return Err(ApiError::overloaded("resident host table is full"));
         }
-        state.hosts.insert(
-            host_id.clone(),
-            Host {
-                token: digest(&token),
-                disconnected_at: Instant::now(),
-                connection: 0,
-                commands: None,
-                disconnect: None,
-                pending: HashMap::new(),
+        crate::persistence::append(
+            &mut state.log,
+            &RegistrationRecord {
+                host_id: host_id.clone(),
+                token: Some(digest(&token)),
             },
-        );
+        )
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+        state
+            .hosts
+            .insert(host_id.clone(), registered(digest(&token)));
         Ok(HostRegistration { host_id, token })
     }
 
@@ -350,6 +435,63 @@ fn wall_clock_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_hosts() -> ResidentHosts {
+        ResidentHosts::open(
+            &std::env::temp_dir()
+                .join(format!("brain-hosts-{}", rand::random::<u64>()))
+                .join("hosts.log"),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn registration_survives_restart_and_session_references_prevent_expiry() {
+        let path = std::env::temp_dir()
+            .join(format!("brain-hosts-{}", rand::random::<u64>()))
+            .join("hosts.log");
+        let hosts = ResidentHosts::open(&path).unwrap();
+        let registration = hosts.register().unwrap();
+        drop(hosts);
+        let hosts = ResidentHosts::open(&path).unwrap();
+        assert!(
+            hosts
+                .connect(&registration.host_id, &registration.token)
+                .is_ok()
+        );
+        assert!(hosts.connect(&registration.host_id, "wrong token").is_err());
+        let session = SessionId::new("ses_pinned");
+        hosts
+            .bind_session(&session, std::slice::from_ref(&registration.host_id))
+            .unwrap();
+        hosts
+            .lock()
+            .unwrap()
+            .hosts
+            .get_mut(&registration.host_id)
+            .unwrap()
+            .disconnected_at = Instant::now() - UNCONNECTED_TTL;
+        hosts.register().unwrap();
+        assert!(
+            hosts
+                .connect(&registration.host_id, &registration.token)
+                .is_ok()
+        );
+        hosts.release_session(&session).unwrap();
+        hosts
+            .lock()
+            .unwrap()
+            .hosts
+            .get_mut(&registration.host_id)
+            .unwrap()
+            .disconnected_at = Instant::now() - UNCONNECTED_TTL;
+        hosts.register().unwrap();
+        assert!(
+            hosts
+                .connect(&registration.host_id, &registration.token)
+                .is_err()
+        );
+    }
     use brain_protocol::{ToolBinding, ToolHosting, ToolInvocation};
 
     struct NoEvents;
@@ -389,7 +531,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_resident_command_is_sent_once_and_resolved_by_session_sequence() {
-        let hosts = ResidentHosts::default();
+        let hosts = test_hosts();
         let registration = hosts.register().unwrap();
         let mut connection = hosts
             .connect(&registration.host_id, &registration.token)
@@ -425,7 +567,7 @@ mod tests {
 
     #[tokio::test]
     async fn dispatch_without_a_connected_host_fails_before_send() {
-        let hosts = ResidentHosts::default();
+        let hosts = test_hosts();
         let registration = hosts.register().unwrap();
         let error = hosts
             .execute(dispatch(registration.host_id), &NoEvents)
@@ -436,7 +578,7 @@ mod tests {
 
     #[test]
     fn closing_a_connection_keeps_its_registration_reconnectable() {
-        let hosts = ResidentHosts::default();
+        let hosts = test_hosts();
         let registration = hosts.register().unwrap();
         let connection = hosts
             .connect(&registration.host_id, &registration.token)
@@ -453,7 +595,7 @@ mod tests {
 
     #[tokio::test]
     async fn replacing_a_host_connection_makes_an_inflight_outcome_unknown() {
-        let hosts = ResidentHosts::default();
+        let hosts = test_hosts();
         let registration = hosts.register().unwrap();
         let mut first = hosts
             .connect(&registration.host_id, &registration.token)

--- a/crates/brain-server/src/service.rs
+++ b/crates/brain-server/src/service.rs
@@ -19,7 +19,6 @@ use brain_protocol::{
     SessionConfig, SessionId, SessionList, SessionStatus, SessionSummary, ToolAdmission,
     ToolAdmissionStatus, ToolBinding, ToolDefinition, ToolHosting, ToolIdentity,
 };
-use sha2::{Digest as _, Sha256};
 use tokio::sync::Mutex;
 
 use crate::{
@@ -239,6 +238,21 @@ impl ServerApi {
         session: Option<Session>,
     ) -> Result<(), ApiError> {
         let config = brain::session_config(&*store).ok();
+        if let Some(config) = &config
+            && !matches!(
+                store.session_summary().map_err(api_error)?.status,
+                SessionStatus::Failed
+            )
+        {
+            let hosts = config
+                .tool_bindings
+                .iter()
+                .filter_map(|tool| tool.host_id.clone())
+                .collect::<Vec<_>>();
+            self.resources
+                .resident_hosts
+                .bind_session(store.session_id(), &hosts)?;
+        }
         let idle_ttl = config
             .as_ref()
             .and_then(|config| config.idle_ttl_ms)
@@ -328,7 +342,29 @@ impl ServerApi {
             {
                 continue;
             }
-            if let Err(error) = self.resources.environments.close(&environment_id).await {
+            let Ok(Some(record)) = self.resources.environments.resources().get(&environment_id)
+            else {
+                continue;
+            };
+            let Ok(lock) = self.session_lock(&record.session_id) else {
+                continue;
+            };
+            let _guard = lock.lock().await;
+            let Ok(store) = self.store(&record.session_id) else {
+                continue;
+            };
+            if !matches!(
+                store.session_summary().map(|row| row.status),
+                Ok(SessionStatus::Ended | SessionStatus::Failed)
+            ) {
+                continue;
+            }
+            if let Err(error) = self
+                .resources
+                .environments
+                .close(&environment_id, &*store, false)
+                .await
+            {
                 tracing::warn!(%environment_id, %error, "idle Environment could not be closed");
             }
         }
@@ -469,9 +505,29 @@ impl ServerApi {
         serde_json::from_value(value).map_err(|error| internal(error.to_string()))
     }
 
-    async fn cleanup_environments(&self, environment_ids: &[EnvironmentId]) {
+    async fn cleanup_environments(
+        &self,
+        environment_ids: &[EnvironmentId],
+        store: &dyn SessionStore,
+    ) {
         for environment_id in environment_ids.iter().rev() {
-            if let Err(error) = self.resources.environments.close(environment_id).await {
+            if self
+                .resources
+                .environments
+                .resources()
+                .get(environment_id)
+                .ok()
+                .flatten()
+                .is_some_and(|record| &record.session_id != store.session_id())
+            {
+                continue;
+            }
+            if let Err(error) = self
+                .resources
+                .environments
+                .close(environment_id, store, false)
+                .await
+            {
                 tracing::warn!(%environment_id, %error, "failed to clean up Environment after session admission");
             }
         }
@@ -703,7 +759,8 @@ impl BrainApi for ServerApi {
             }
         }
         validate_model(&request, &self.resources.providers)?;
-        let binding_id = model_binding_id(&idempotency_key);
+        let session_id = SessionId::new(brain::random_id("ses"));
+        let binding_id = format!("model_{session_id}");
         self.resources
             .models
             .put(&binding_id, &request.model)
@@ -725,7 +782,6 @@ impl BrainApi for ServerApi {
             tool_bindings,
             idle_ttl_ms: request.idle_ttl_ms,
         };
-        let session_id = SessionId::new(brain::random_id("ses"));
         let store = LocalSessionStore::create(
             &self.resources.sessions_dir.join(session_id.as_str()),
             session_id.clone(),
@@ -763,6 +819,33 @@ impl BrainApi for ServerApi {
                 .map_err(api_error)?;
             return Err(api_error(error));
         }
+        let host_ids = request
+            .tools
+            .iter()
+            .filter_map(|tool| tool.host_id.clone())
+            .collect::<Vec<_>>();
+        if let Err(error) = self
+            .resources
+            .resident_hosts
+            .bind_session(&session_id, &host_ids)
+        {
+            creation
+                .fail(
+                    codes::failure::ENVIRONMENT_PREPARATION_FAILED,
+                    &error.message,
+                )
+                .map_err(api_error)?;
+            self.insert_slot(store, None)?;
+            self.ownership
+                .release(&session_id)
+                .await
+                .map_err(api_error)?;
+            self.resources
+                .models
+                .delete(&binding_id)
+                .map_err(api_error)?;
+            return Err(error);
+        }
         let mut created_environments = Vec::with_capacity(request.environments.len());
         for specification in &request.environments {
             match self
@@ -773,19 +856,21 @@ impl BrainApi for ServerApi {
             {
                 Ok(record) => created_environments.push(record.environment_id),
                 Err(error) => {
+                    created_environments.push(specification.environment_id.clone());
                     creation
                         .fail(
                             codes::failure::ENVIRONMENT_PREPARATION_FAILED,
                             &error.to_string(),
                         )
                         .map_err(api_error)?;
-                    self.insert_slot(store, None)?;
+                    self.insert_slot(store.clone(), None)?;
                     self.ownership
                         .release(&session_id)
                         .await
                         .map_err(api_error)?;
                     let _ = self.resources.models.delete(&binding_id);
-                    self.cleanup_environments(&created_environments).await;
+                    self.cleanup_environments(&created_environments, &*store)
+                        .await;
                     return Err(api_error(error));
                 }
             }
@@ -798,7 +883,7 @@ impl BrainApi for ServerApi {
         let (session, _) = match prepared {
             Ok(prepared) => prepared,
             Err(error) => {
-                self.insert_slot(store, None)?;
+                self.insert_slot(store.clone(), None)?;
                 self.ownership
                     .release(&session_id)
                     .await
@@ -807,7 +892,8 @@ impl BrainApi for ServerApi {
                     .models
                     .delete(&binding_id)
                     .map_err(api_error)?;
-                self.cleanup_environments(&created_environments).await;
+                self.cleanup_environments(&created_environments, &*store)
+                    .await;
                 return Err(api_error(error));
             }
         };
@@ -1009,14 +1095,26 @@ impl BrainApi for ServerApi {
         let store = self.store(&session_id)?;
         let summary = store.session_summary().map_err(api_error)?;
         if matches!(summary.status, brain_protocol::SessionStatus::Ended) {
-            // Already ended: nothing to release, and the answer is the same.
+            self.resources
+                .idempotency
+                .put(
+                    &scope,
+                    &idempotency_key,
+                    &request,
+                    &serde_json::to_value(&summary).map_err(|error| internal(error.to_string()))?,
+                )
+                .map_err(api_error)?;
             return Ok(summary);
         }
         let config = brain::session_config(&*store).map_err(api_error)?;
         let running = self.session(&session_id).await?;
+        running
+            .record(codes::event::SESSION_END_STARTED, serde_json::json!({}))
+            .await
+            .map_err(api_error)?;
         self.resources
             .environments
-            .release_session(&running, &config)
+            .release_session(&running, &config, &*store)
             .await
             .map_err(api_error)?;
         let session = running.end().await.map_err(api_error)?;
@@ -1060,9 +1158,19 @@ impl BrainApi for ServerApi {
         let config = brain::session_config(&*store).map_err(api_error)?;
         let binding_id = config.model.binding_id;
         for environment in config.environments.iter().rev() {
+            if self
+                .resources
+                .environments
+                .resources()
+                .get(&environment.environment_id)
+                .map_err(api_error)?
+                .is_some_and(|record| record.session_id != session_id)
+            {
+                continue;
+            }
             self.resources
                 .environments
-                .close(&environment.environment_id)
+                .close(&environment.environment_id, &*store, true)
                 .await
                 .map_err(api_error)?;
         }
@@ -1080,6 +1188,7 @@ impl BrainApi for ServerApi {
             .lock()
             .map_err(|_| internal("session table is poisoned"))?
             .remove(&session_id);
+        self.resources.resident_hosts.release_session(&session_id)?;
         self.resources
             .idempotency
             .put(&scope, &idempotency_key, &request, &serde_json::json!({}))
@@ -1335,13 +1444,6 @@ fn validate_model(
         ));
     }
     Ok(())
-}
-
-fn model_binding_id(idempotency_key: &str) -> String {
-    let mut digest = Sha256::new();
-    digest.update(b"brain.model-binding.v1\0");
-    digest.update(idempotency_key.as_bytes());
-    format!("model_{}", hex::encode(digest.finalize()))
 }
 
 fn loop_error(error: LoopError) -> ApiError {

--- a/crates/brain/src/journal/session_store.rs
+++ b/crates/brain/src/journal/session_store.rs
@@ -140,7 +140,7 @@ impl LocalSessionStore {
                 }
                 state.row.through_sequence = frame.sequence;
                 state.last_recorded_at_ms = frame.recorded_at_ms;
-                if journal_kind(frame.kind) {
+                if JournalEntry::is_kind(frame.kind) {
                     let entry = frame.decode::<JournalEntry>()?;
                     let visible = transcript_replaced(&mut state.transcript_len, &entry);
                     state.events.push(visible.then_some(location));
@@ -205,33 +205,86 @@ impl LocalSessionStore {
         Ok(stores)
     }
 
-    /// Closes a turn the previous process did not finish.
-    ///
-    /// A session still `Running` after its log has been read was mid-turn when that
-    /// process stopped. Whether the model call or the tool call actually happened is not
-    /// knowable from here, so Brain says exactly that and returns the session to Idle
-    /// rather than deciding on the client's behalf. Returns whether a turn was closed.
+    /// Records unknown outcomes for interrupted effects and closes unfinished creation,
+    /// turns, or ending without replaying their effects. Returns whether records were added.
     pub fn interrupt_unfinished_turn(&self) -> Result<bool, Error> {
-        {
-            let state = self.lock()?;
-            if !matches!(state.row.status, SessionStatus::Running) {
-                return Ok(false);
+        let status = self.lock()?.row.status.clone();
+        let mut pending = BTreeMap::new();
+        let mut after = 0;
+        loop {
+            let records = self.records_after(after, 1000)?;
+            if records.is_empty() {
+                break;
+            }
+            for record in records {
+                after = record.sequence;
+                if let Some(kind) = record.kind.strip_suffix("_started") {
+                    if matches!(
+                        kind,
+                        "model_call"
+                            | "tool_call"
+                            | "tool_cancel"
+                            | "environment_setup"
+                            | "environment_attach"
+                            | "environment_call"
+                            | "environment_detach"
+                            | "environment_teardown"
+                    ) {
+                        pending.insert(record.sequence, kind.to_owned());
+                    }
+                } else if (record.kind.ends_with("_ended") || record.kind.ends_with("_failed"))
+                    && let Some(sequence) = record
+                        .payload
+                        .get("sequence")
+                        .and_then(serde_json::Value::as_u64)
+                {
+                    pending.remove(&sequence);
+                }
             }
         }
+        let failure = serde_json::to_value(codes::Failure::new(codes::failure::INTERRUPTED,
+            "Brain restarted before the outcome was recorded; this operation will not be replayed").ambiguous(true)).map_err(json_error)?;
+        let mut records = pending
+            .into_iter()
+            .map(|(sequence, kind)| {
+                let mut payload = failure.clone();
+                payload["sequence"] = serde_json::json!(sequence);
+                AppendRecord::new(format!("{kind}_failed"), payload)
+            })
+            .collect::<Vec<_>>();
+        let next = match status {
+            SessionStatus::Creating => {
+                records.push(AppendRecord::new(
+                    codes::event::SESSION_CREATION_FAILED,
+                    failure,
+                ));
+                Some(SessionStatus::Failed)
+            }
+            SessionStatus::Running => {
+                records.push(AppendRecord::new(
+                    codes::event::ACTIVATION_FAILED,
+                    failure.clone(),
+                ));
+                records.push(AppendRecord::new(codes::event::TURN_FAILED, failure));
+                Some(SessionStatus::Idle)
+            }
+            SessionStatus::Ending => {
+                records.push(AppendRecord::new(codes::event::SESSION_END_FAILED, failure));
+                records.push(AppendRecord::new(
+                    codes::event::SESSION_ENDED,
+                    serde_json::json!({}),
+                ));
+                Some(SessionStatus::Ended)
+            }
+            _ => None,
+        };
+        if records.is_empty() {
+            return Ok(false);
+        }
         self.append_sync(
-            &[AppendRecord::new(
-                codes::event::TURN_FAILED,
-                serde_json::to_value(
-                    codes::Failure::new(
-                        codes::failure::INTERRUPTED,
-                        "Brain restarted while this turn was in flight; whether its effects reached the model or a tool is not recorded",
-                    )
-                    .ambiguous(true),
-                )
-                .map_err(json_error)?,
-            )],
+            &records,
             SessionUpdate {
-                status: Some(SessionStatus::Idle),
+                status: next,
                 configuration: None,
             },
         )?;
@@ -514,6 +567,9 @@ fn lifecycle_of(frame: &Frame<'_>) -> Result<Option<Lifecycle>, Error> {
         kind if kind == codes::event::SESSION_ENDED => {
             Some(Lifecycle::Status(SessionStatus::Ended))
         }
+        kind if kind == codes::event::SESSION_END_STARTED => {
+            Some(Lifecycle::Status(SessionStatus::Ending))
+        }
         _ => None,
     })
 }
@@ -533,10 +589,6 @@ fn apply_lifecycle(row: &mut SessionRow, lifecycle: Lifecycle) {
         }
         Lifecycle::Status(status) => row.status = status,
     }
-}
-
-fn journal_kind(kind: &str) -> bool {
-    matches!(kind, "transcript_delta" | "state_set")
 }
 
 impl SessionStore for LocalSessionStore {

--- a/crates/brain/src/journal/store.rs
+++ b/crates/brain/src/journal/store.rs
@@ -81,6 +81,12 @@ pub enum JournalEntry {
     },
 }
 
+impl JournalEntry {
+    pub(crate) fn is_kind(kind: &str) -> bool {
+        matches!(kind, "transcript_delta" | "state_set")
+    }
+}
+
 /// What folding a session's journal yields: its transcript, its slots, and the sequence
 /// the journal is current to.
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/crates/brain/src/model/http.rs
+++ b/crates/brain/src/model/http.rs
@@ -167,8 +167,8 @@ impl ModelExecutor for RemoteModelClient {
         on_event: &mut (dyn FnMut(ModelStreamEvent) + Send),
     ) -> Result<ModelResult, Error> {
         let body = self.body(binding, &request, tools)?;
-        let response = self.request(&body).send().await.map_err(|error| {
-            Error::Executor(format!("model request failed before response: {error}"))
+        let mut response = self.request(&body).send().await.map_err(|error| {
+            Error::Ambiguous(format!("model request outcome is unknown: {error}"))
         })?;
         if !response.status().is_success() {
             let status = response.status().as_u16();
@@ -178,14 +178,21 @@ impl ModelExecutor for RemoteModelClient {
                 .and_then(|value| value.to_str().ok())
                 .and_then(|value| value.trim().parse::<u64>().ok())
                 .and_then(|seconds| seconds.checked_mul(1_000));
-            let bytes = response
-                .bytes()
+            let mut bytes = Vec::new();
+            while let Some(chunk) = response
+                .chunk()
                 .await
-                .map_err(|error| Error::Executor(error.to_string()))?;
-            let bounded = &bytes[..bytes.len().min(MAX_ERROR_BYTES)];
+                .map_err(|error| Error::Ambiguous(error.to_string()))?
+            {
+                let count = chunk.len().min(MAX_ERROR_BYTES - bytes.len());
+                bytes.extend_from_slice(&chunk[..count]);
+                if bytes.len() == MAX_ERROR_BYTES {
+                    break;
+                }
+            }
             return Err(Error::ProviderStatus {
                 status,
-                body: String::from_utf8_lossy(bounded).into_owned(),
+                body: String::from_utf8_lossy(&bytes).into_owned(),
                 retry_after_ms,
             });
         }
@@ -445,7 +452,16 @@ mod tests {
 
         let denied = Router::new().route(
             "/chat/completions",
-            post(|| async { (StatusCode::BAD_REQUEST, "bad request") }),
+            post(|| async {
+                let chunks = futures_util::stream::once(async {
+                    Ok::<_, std::io::Error>(Bytes::from(vec![b'x'; MAX_ERROR_BYTES + 1]))
+                })
+                .chain(futures_util::stream::pending());
+                (
+                    StatusCode::BAD_REQUEST,
+                    axum::body::Body::from_stream(chunks),
+                )
+            }),
         );
         let address = serve(denied).await;
         let client = RemoteModelClient::new(RemoteModelConfig {
@@ -461,7 +477,7 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            matches!(error, Error::ProviderStatus { status: 400, .. }),
+            matches!(&error, Error::ProviderStatus { status: 400, body, .. } if body.len() == MAX_ERROR_BYTES),
             "a deterministic 4xx must surface as a typed status, got {error:?}"
         );
     }

--- a/crates/brain/src/session/actor.rs
+++ b/crates/brain/src/session/actor.rs
@@ -176,27 +176,34 @@ impl SessionActor {
             .find(|environment| environment.environment_id == self.config.agentloop_environment_id)
             .map(|environment| environment.configuration.clone())
             .ok_or_else(|| Error::InvalidState("Agentloop Environment is missing".into()))?;
-        let running = self.runtime.loop_executor.turn(
-            &self.row.session_id,
-            &self.config.agentloop_identity,
-            agentloop_environment,
-            input,
-            host.clone(),
-        );
-        let outcome = if self.runtime.max_turn_ms == 0 {
-            running.await
-        } else {
-            match tokio::time::timeout(Duration::from_millis(self.runtime.max_turn_ms), running)
+        let outcome = {
+            let running = self.runtime.loop_executor.turn(
+                &self.row.session_id,
+                &self.config.agentloop_identity,
+                agentloop_environment,
+                input,
+                host.clone(),
+            );
+            tokio::pin!(running);
+            if self.runtime.max_turn_ms == 0 {
+                running.await
+            } else {
+                match tokio::time::timeout(
+                    Duration::from_millis(self.runtime.max_turn_ms),
+                    &mut running,
+                )
                 .await
-            {
-                Ok(outcome) => outcome,
-                Err(_) => {
-                    // The loop is told through its next host call; whatever it was
-                    // doing in between is bounded by the executor's own guest budget.
-                    self.cancel_requested.store(true, Ordering::Release);
-                    Err(Error::Cancelled(
-                        "turn exceeded its wall-time budget".into(),
-                    ))
+                {
+                    Ok(outcome) => outcome,
+                    Err(_) => {
+                        self.cancel_requested.store(true, Ordering::Release);
+                        // Keep mediated calls alive through their terminal commit and bounded
+                        // cancellation. Dropping the executor here would abandon those records.
+                        let _ = running.await;
+                        Err(Error::Cancelled(
+                            "turn exceeded its wall-time budget".into(),
+                        ))
+                    }
                 }
             }
         };
@@ -339,10 +346,12 @@ impl SessionActor {
     /// A record for something the host did to the session between turns. Refused while
     /// a turn is running: the turn owns the sequence until it ends.
     async fn append_between_turns(&mut self, record: AppendRecord) -> Result<u64, Error> {
-        if !matches!(self.row.status, SessionStatus::Idle) {
+        if !matches!(self.row.status, SessionStatus::Idle | SessionStatus::Ending) {
             return Err(Error::InvalidState("session is not idle".into()));
         }
-        self.commit(vec![record], None).await?;
+        let status =
+            (record.kind == codes::event::SESSION_END_STARTED).then_some(SessionStatus::Ending);
+        self.commit(vec![record], status).await?;
         Ok(self.row.through_sequence)
     }
 
@@ -555,7 +564,7 @@ impl TurnServices for TurnHost {
         };
         let result = tokio::select! {
             result = call => result,
-            () = cancelled => Err(Error::Cancelled("turn cancelled during a model call".into())),
+            () = cancelled => Err(Error::Ambiguous("turn cancelled during a model call".into())),
         };
         let mut cursor = self.cursor.lock().await;
         match result {
@@ -672,43 +681,33 @@ impl TurnServices for TurnHost {
                             message: "Tool cancellation was requested after the call was sent".into(),
                         }, true)),
                     };
-                    (index, sequence, call_id, result)
+                    let dropped = matches!(&result, Ok((_, true)));
+                    let result = match result {
+                        Ok((outcome, _)) => ToolResult::from_outcome(call_id, outcome),
+                        Err(Error::Ambiguous(message)) => ToolResult::from_outcome(call_id, Outcome::Unknown { message }),
+                        Err(error) => ToolResult {
+                            call_id,
+                            output: serde_json::to_value(Failure::new(codes::failure::TOOL_ERROR, error.to_string())).map_err(json_error)?,
+                            is_error: true,
+                        },
+                    };
+                    let mut cursor = self.cursor.lock().await;
+                    self.append(&mut cursor, vec![AppendRecord::new(
+                        codes::event::TOOL_CALL_ENDED,
+                        serde_json::json!({"sequence": sequence, "result": result}),
+                    )]).await?;
+                    Ok::<_, Error>((index, result, dropped))
                 }
             });
         let completed = join_all(futures).await;
-        let mut terminal = Vec::with_capacity(completed.len());
         let mut results = Vec::with_capacity(completed.len());
         let mut abandoned = Vec::new();
-        for (index, sequence, call_id, result) in completed {
-            let result = match result {
-                Ok((outcome, dropped)) => {
-                    if dropped {
-                        abandoned.push(dispatches[index].clone());
-                    }
-                    ToolResult::from_outcome(call_id, outcome)
-                }
-                Err(Error::Ambiguous(message)) => {
-                    ToolResult::from_outcome(call_id, Outcome::Unknown { message })
-                }
-                Err(error) => ToolResult {
-                    call_id,
-                    output: serde_json::to_value(Failure::new(
-                        codes::failure::TOOL_ERROR,
-                        error.to_string(),
-                    ))
-                    .map_err(json_error)?,
-                    is_error: true,
-                },
-            };
-            terminal.push(AppendRecord::new(
-                codes::event::TOOL_CALL_ENDED,
-                serde_json::json!({"sequence": sequence, "result": result}),
-            ));
+        for completed in completed {
+            let (index, result, dropped) = completed?;
+            if dropped {
+                abandoned.push(dispatches[index].clone());
+            }
             results.push(result);
-        }
-        {
-            let mut cursor = self.cursor.lock().await;
-            self.append(&mut cursor, terminal).await?;
         }
         // A call abandoned locally is told to stop where it runs, best effort like every
         // cancellation.
@@ -724,6 +723,7 @@ impl TurnServices for TurnHost {
     async fn emit(&self, kind: String, payload: serde_json::Value) -> Result<u64, Error> {
         self.check_cancelled()?;
         if !valid_kind(&kind)
+            || JournalEntry::is_kind(&kind)
             || (codes::event::ALL.contains(&kind.as_str()) && kind != codes::event::OUTPUT_EMITTED)
         {
             return Err(Error::InvalidState(format!(
@@ -790,7 +790,7 @@ impl TurnHost {
     }
 
     async fn cancel_tools(&self, dispatches: &[ToolDispatch]) -> Result<(), Error> {
-        let (cancellations, sequences) = {
+        let cancellations = {
             let mut cursor = self.cursor.lock().await;
             let mut cancellations = Vec::with_capacity(dispatches.len());
             let mut started = Vec::with_capacity(dispatches.len());
@@ -814,53 +814,37 @@ impl TurnHost {
             for (cancellation, record) in cancellations.iter_mut().zip(saved) {
                 cancellation.sequence = record.sequence;
             }
-            let sequences: Vec<u64> = cancellations.iter().map(|c| c.sequence).collect();
-            (cancellations, sequences)
+            cancellations
         };
-        let futures = cancellations.into_iter().map(|cancellation| {
-            let executor = self.runtime.tool_executor.clone();
-            async move {
-                let sequence = cancellation.sequence;
-                let result = executor.cancel(cancellation).await;
-                (sequence, result)
-            }
+        let futures = cancellations.into_iter().map(|cancellation| async move {
+            let sequence = cancellation.sequence;
+            let result = tokio::time::timeout(
+                Duration::from_secs(5),
+                self.runtime.tool_executor.cancel(cancellation),
+            )
+            .await
+            .unwrap_or_else(|_| {
+                Err(Error::Ambiguous(
+                    "Environment cancellation deadline exceeded".into(),
+                ))
+            });
+            let record = match result {
+                Ok(()) => AppendRecord::new(
+                    codes::event::TOOL_CANCEL_ENDED,
+                    serde_json::json!({"sequence": sequence}),
+                ),
+                Err(error) => AppendRecord::new(
+                    codes::event::TOOL_CANCEL_FAILED,
+                    failure_payload(Some(sequence), &failure_of(&error))?,
+                ),
+            };
+            let mut cursor = self.cursor.lock().await;
+            self.append(&mut cursor, vec![record]).await?;
+            Ok::<_, Error>(())
         });
-        let results = tokio::time::timeout(Duration::from_secs(5), join_all(futures)).await;
-        let records = match results {
-            Ok(results) => results
-                .into_iter()
-                .map(|(sequence, result)| match result {
-                    Ok(()) => Ok(AppendRecord::new(
-                        codes::event::TOOL_CANCEL_ENDED,
-                        serde_json::json!({"sequence": sequence}),
-                    )),
-                    Err(error) => Ok(AppendRecord::new(
-                        codes::event::TOOL_CANCEL_FAILED,
-                        failure_payload(Some(sequence), &failure_of(&error).ambiguous(false))?,
-                    )),
-                })
-                .collect::<Result<Vec<_>, Error>>()?,
-            // Nothing answered in time: whether the environment stopped the work is not
-            // known, and the record says so.
-            Err(_) => sequences
-                .into_iter()
-                .map(|sequence| {
-                    Ok(AppendRecord::new(
-                        codes::event::TOOL_CANCEL_FAILED,
-                        failure_payload(
-                            Some(sequence),
-                            &Failure::new(
-                                codes::failure::TIMEOUT,
-                                "Environment cancellation deadline exceeded",
-                            )
-                            .ambiguous(true),
-                        )?,
-                    ))
-                })
-                .collect::<Result<Vec<_>, Error>>()?,
-        };
-        let mut cursor = self.cursor.lock().await;
-        self.append(&mut cursor, records).await?;
+        for result in join_all(futures).await {
+            result?;
+        }
         Ok(())
     }
 }

--- a/crates/brain/tests/recovery_boundaries.rs
+++ b/crates/brain/tests/recovery_boundaries.rs
@@ -1,0 +1,230 @@
+mod common;
+
+use brain::{LocalSessionStore, Session, SessionStore};
+use brain_protocol::{MessageRequest, ModelRequest, SessionId, SessionStatus, TurnOutput};
+use brain_telemetry::telemetry_channel;
+use common::{NoModels, NoTools, Runtime, SlowModel, config, scripted};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn interrupted_ending_is_terminal_and_pending_detach_is_unknown() {
+    let directory = common::temporary_directory("regression-ending");
+    let (telemetry, _) = telemetry_channel();
+    let runtime = Runtime::open(
+        &directory,
+        telemetry,
+        4,
+        1000,
+        common::echo_loop(),
+        Arc::new(NoModels),
+        Arc::new(NoTools),
+    );
+    let session = runtime.create(&config(), &[]).unwrap();
+    session
+        .record("session_end_started", serde_json::json!({}))
+        .await
+        .unwrap();
+    assert!(matches!(
+        runtime
+            .store(session.id())
+            .session_summary()
+            .unwrap()
+            .status,
+        SessionStatus::Ending
+    ));
+    session
+        .record_call_started("environment_detach", &serde_json::json!({}))
+        .await
+        .unwrap();
+    assert!(
+        session
+            .message(MessageRequest {
+                input: "too late".into()
+            })
+            .await
+            .is_err()
+    );
+    let recovered = LocalSessionStore::open_all(
+        &runtime.sessions_dir(),
+        runtime.writer.clone(),
+        runtime.feed.clone(),
+    )
+    .unwrap();
+    assert!(matches!(
+        recovered[0].session_summary().unwrap().status,
+        SessionStatus::Ended
+    ));
+    let records = recovered[0].records_after(0, 100).unwrap();
+    assert!(
+        records
+            .iter()
+            .any(|record| record.kind == "environment_detach_failed"
+                && record.payload["ambiguous"] == true)
+    );
+    assert!(!recovered[0].interrupt_unfinished_turn().unwrap());
+}
+
+#[tokio::test]
+async fn emitted_internal_kind_is_rejected_without_corrupting_recovery() {
+    let directory = common::temporary_directory("regression-internal-kind");
+    let (telemetry, _worker) = telemetry_channel();
+    let runtime = Runtime::open(
+        &directory,
+        telemetry,
+        4,
+        1000,
+        scripted(|input, services| async move {
+            services
+                .emit("state_set".into(), serde_json::json!({"ordinary":"event"}))
+                .await?;
+            Ok(TurnOutput {
+                transcript: input.transcript,
+                slots: Default::default(),
+                result: None,
+            })
+        }),
+        Arc::new(NoModels),
+        Arc::new(NoTools),
+    );
+    let session = runtime.create(&config(), &[]).unwrap();
+    session
+        .message(MessageRequest { input: "go".into() })
+        .await
+        .unwrap();
+    let store = runtime.store(session.id());
+    let reopened = LocalSessionStore::open(
+        store.directory(),
+        runtime.writer.clone(),
+        runtime.feed.clone(),
+    );
+    assert!(reopened.is_ok());
+    assert!(
+        !runtime
+            .kinds(session.id())
+            .iter()
+            .any(|kind| kind == "state_set")
+    );
+}
+
+#[tokio::test]
+async fn interrupted_creation_is_failed() {
+    let directory = common::temporary_directory("regression-creation");
+    let (telemetry, _worker) = telemetry_channel();
+    let runtime = Runtime::open(
+        &directory,
+        telemetry,
+        4,
+        1000,
+        common::echo_loop(),
+        Arc::new(NoModels),
+        Arc::new(NoTools),
+    );
+    let session_id = SessionId::new("ses_review");
+    let store = LocalSessionStore::create(
+        &runtime.sessions_dir().join(session_id.as_str()),
+        session_id,
+        &serde_json::to_value(config()).unwrap(),
+        runtime.writer.clone(),
+        runtime.feed.clone(),
+    )
+    .unwrap();
+    let creation = Session::begin(store.clone(), runtime.config.clone(), &config(), &[]).unwrap();
+    drop(creation);
+    let recovered = LocalSessionStore::open_all(
+        &runtime.sessions_dir(),
+        runtime.writer.clone(),
+        runtime.feed.clone(),
+    )
+    .unwrap();
+    assert!(matches!(
+        recovered[0].session_summary().unwrap().status,
+        SessionStatus::Failed
+    ));
+}
+
+#[tokio::test]
+async fn wall_deadline_records_unknown_model_outcome() {
+    let directory = common::temporary_directory("regression-deadline");
+    let (telemetry, _worker) = telemetry_channel();
+    let mut runtime = Runtime::open(
+        &directory,
+        telemetry,
+        4,
+        1000,
+        scripted(|_input, services| async move {
+            services
+                .model(ModelRequest {
+                    system: None,
+                    tools: None,
+                    messages: vec![brain_protocol::Message::user_text("go")],
+                    response_format: None,
+                    max_output_tokens: Some(16),
+                })
+                .await?;
+            unreachable!()
+        }),
+        Arc::new(SlowModel),
+        Arc::new(NoTools),
+    );
+    Arc::get_mut(&mut runtime.config).unwrap().max_turn_ms = 100;
+    let session = runtime.create(&config(), &[]).unwrap();
+    session
+        .message(MessageRequest { input: "go".into() })
+        .await
+        .unwrap();
+    let kinds = runtime.kinds(session.id());
+    assert!(kinds.iter().any(|k| k == "model_call_started"));
+    assert!(kinds.iter().any(|k| k == "turn_failed"));
+    assert!(kinds.iter().any(|k| k == "model_call_failed"));
+}
+
+#[tokio::test]
+async fn model_cancellation_records_ambiguous_failure() {
+    let directory = common::temporary_directory("regression-cancel");
+    let (telemetry, _worker) = telemetry_channel();
+    let runtime = Runtime::open(
+        &directory,
+        telemetry,
+        4,
+        1000,
+        scripted(|_input, services| async move {
+            services
+                .model(ModelRequest {
+                    system: None,
+                    tools: None,
+                    messages: vec![brain_protocol::Message::user_text("go")],
+                    response_format: None,
+                    max_output_tokens: Some(16),
+                })
+                .await?;
+            unreachable!()
+        }),
+        Arc::new(SlowModel),
+        Arc::new(NoTools),
+    );
+    let session = runtime.create(&config(), &[]).unwrap();
+    let handle = session.clone();
+    let running =
+        tokio::spawn(async move { handle.message(MessageRequest { input: "go".into() }).await });
+    loop {
+        if runtime
+            .kinds(session.id())
+            .iter()
+            .any(|k| k == "model_call_started")
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    session.cancel().await.unwrap();
+    running.await.unwrap().unwrap();
+    let records = runtime.store(session.id()).records_after(0, 100).unwrap();
+    let failed = records
+        .iter()
+        .find(|r| r.kind == "model_call_failed")
+        .unwrap();
+    assert_eq!(
+        failed.payload.get("ambiguous"),
+        Some(&serde_json::json!(true))
+    );
+}

--- a/crates/brain/tests/session.rs
+++ b/crates/brain/tests/session.rs
@@ -366,6 +366,82 @@ async fn cancel_forwards_inflight_tool_cancellation_to_the_environment_port() {
 }
 
 #[tokio::test]
+async fn wall_deadline_keeps_completed_tool_results_and_records_unknown_cancellation() {
+    struct Tools;
+    #[async_trait]
+    impl ToolExecutor for Tools {
+        async fn execute(
+            &self,
+            call: ToolDispatch,
+            _: &dyn brain::ToolServices,
+        ) -> Result<Outcome, Error> {
+            if call.invocation.call_id == "slow" {
+                std::future::pending::<()>().await;
+            }
+            Ok(Outcome::Ok {
+                value: serde_json::json!("known answer"),
+            })
+        }
+        async fn cancel(&self, _: ToolCancellation) -> Result<(), Error> {
+            Err(Error::Ambiguous("cancel response lost".into()))
+        }
+    }
+    let data_dir = temporary_directory("deadline-parallel-tools");
+    let executor = scripted(|input, services| async move {
+        services
+            .dispatch(vec![
+                invocation("lookup", "fast"),
+                invocation("lookup", "slow"),
+            ])
+            .await?;
+        done(input.transcript)
+    });
+    let mut runtime = runtime(&data_dir, executor, Arc::new(NoModels), Arc::new(Tools));
+    Arc::get_mut(&mut runtime.config).unwrap().max_turn_ms = 1500;
+    let session = runtime
+        .create(&tool_config("lookup", vec![], vec![]), &[])
+        .unwrap();
+    let turning = tokio::spawn({
+        let session = session.clone();
+        async move { session.message(MessageRequest { input: "go".into() }).await }
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let records = runtime.store(session.id()).records_after(0, 100).unwrap();
+            if records.iter().any(|record| {
+                record.kind == "tool_call_ended" && record.payload["result"]["call_id"] == "fast"
+            }) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("a known result must commit while its sibling is still waiting");
+    tokio::time::timeout(Duration::from_secs(3), turning)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let records = runtime.store(session.id()).records_after(0, 100).unwrap();
+    assert_eq!(
+        records
+            .iter()
+            .filter(|record| record.kind == "tool_call_ended")
+            .count(),
+        2
+    );
+    assert!(
+        records.iter().any(
+            |record| record.kind == "tool_cancel_failed" && record.payload["ambiguous"] == true
+        )
+    );
+    assert_eq!(records.last().unwrap().kind, "turn_failed");
+    drop(session);
+    settle(runtime, data_dir).await;
+}
+
+#[tokio::test]
 async fn a_subscriber_sees_model_output_while_the_turn_is_running() {
     let data_dir = temporary_directory("streaming");
     let loop_executor = scripted(|input, services| async move {
@@ -451,7 +527,13 @@ async fn a_session_can_be_created_with_a_transcript() {
 async fn a_loop_cannot_append_brains_own_kinds() {
     let data_dir = temporary_directory("reserved");
     let loop_executor = scripted(|input, services| async move {
-        for kind in ["turn_ended", "session_ended", "model_call_started"] {
+        for kind in [
+            "turn_ended",
+            "session_ended",
+            "model_call_started",
+            "state_set",
+            "transcript_delta",
+        ] {
             let refused = services.emit(kind.into(), serde_json::json!({})).await;
             assert!(refused.is_err(), "{kind} must be refused");
         }

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -30,6 +30,7 @@ unknown effect is not replayed onto another target.
 
 Extension Events use the same commit path. A turn may call `ctx.emit` at most 128 times and may
 emit at most 1 MiB across the serialized Event kinds and payloads.
+Public system codes and private journal record names are reserved; extensions cannot emit them.
 
 This makes `{session_id, sequence}` the stable name of an operation throughout the journal and its
 execution path.
@@ -54,6 +55,9 @@ Two server limits bound a turn:
 - `BRAIN_MAX_MODEL_CALLS`, default 128, limits model calls per turn.
 - `BRAIN_MAX_TURN_SECS`, default 1800, limits wall time; zero disables the limit.
 
+The wall deadline initiates cancellation. Brain records outstanding effect outcomes and waits for
+bounded executor cancellation before closing the turn; this cleanup can extend the response time.
+
 Cancellation requests stop local waiting and are forwarded to active executors. A remote effect
 that may have continued is reported as unknown, not as a successful cancellation.
 
@@ -66,6 +70,18 @@ Environments remain attached.
 Journal commits used as effect fences are durable before dispatch. If the process stops during a
 turn, restart records the interrupted turn as failed and does not rerun it. Any already committed
 effect record remains the source of truth.
+
+Restart also fails interrupted creation and closes interrupted ending. Every started effect with
+no terminal record becomes an ambiguous failure; Brain does not resend it. Ending is recorded before
+detach starts, so a partly detached session cannot accept another message. A failed detach does not
+prevent the session from ending. Teardown remains a separate journaled operation. If teardown fails,
+the Environment record remains and the idle sweeper does not retry it; an explicit session delete
+with a new idempotency key can request another attempt.
+
+HTTP idempotency claims survive restart. Completed answers are retained for 24 hours. If a claimed
+request has no recorded answer, reusing its key returns an ambiguous error and never executes the
+request again. Inspect the session before choosing a new operation key. The SDK derives Environment
+identities from the create key so repeating the same create sends the same body.
 
 You can also seed a new session with `transcript`; Brain records those messages as its opening
 conversation.

--- a/docs/guides/app-tools.mdx
+++ b/docs/guides/app-tools.mdx
@@ -73,3 +73,13 @@ wins after dispatch, the host returns an unknown outcome because the function ma
 The SDK cancels local in-flight work and reconnects the same registered host for future commands;
 it never replays the disconnected command. Cooperative functions should observe `ctx.signal` and
 stop promptly.
+
+## Reattaching after restart
+
+Save `await brain.residentHostCredentials()` in application credential storage. After restarting the
+application, pass those credentials as `residentHost` to `new Brain(...)`, then call
+`brain.sessions.get(sessionId, { tools: [lookup()] })` with the session's resident Tool handlers.
+The supplied names must match that host's sealed bindings. Without `tools`, `get` only opens a session
+handle. Brain persists the host identity and token hash; registrations referenced by sessions do not
+expire while disconnected. Restoring a host accepts future commands, never replays old ones, and
+does not restore the application state captured by its functions.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -27,19 +27,21 @@ Each option is a flag and an environment variable. Flags win.
 
 ## The data directory
 
-Brain owns everything under `BRAIN_DATA_DIR` and marks its layout with a format file. A
-directory written by an earlier layout is refused at start rather than migrated; point Brain at
-an empty directory instead.
+Brain owns everything under `BRAIN_DATA_DIR`. Its only format is `brain-data/1`, replaced in place
+during pre-launch development. Start with an empty directory; Brain writes its format marker on
+initialization. There are no legacy layouts or migrations.
 
 ```
 brain-data/
-  format                              layout marker (`brain-data/2`)
+  format                              layout marker (`brain-data/1`)
   sessions/{session_id}/journal/      one canonical journal per session
   environments/{environment_id}.json environment records
   agentloops/                         admitted Agentloop and Tool Components
   native-workspaces/                  workspaces for Brain Wasm Environments
   run/                                worker sockets
   server-metadata/                    model credential custody
+  requests/requests.log               durable HTTP request claims and answers
+  resident-hosts/hosts.log             resident host identities and token hashes
 ```
 
 Session configuration, status, public Events, transcript, and Agentloop slots are projections of

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/packages/brain-sdk/src/client.ts
+++ b/packages/brain-sdk/src/client.ts
@@ -24,7 +24,10 @@ export interface BrainOptions {
   token?: string;
   timeoutMs?: number;
   fetch?: typeof globalThis.fetch;
+  residentHost?: ResidentHostCredentials;
 }
+
+export interface ResidentHostCredentials { readonly hostId: string; readonly token: string }
 
 export class BrainClient {
   readonly baseUrl: string;
@@ -34,6 +37,7 @@ export class BrainClient {
   private readonly transport: typeof globalThis.fetch;
   private readonly agentloops = new WeakMap<object, Promise<string>>();
   private readonly tools = new WeakMap<object, Promise<string>>();
+  private registration?: HostRegistration;
   private resident?: Promise<{
     readonly hostId: string;
     readonly pump: ResidentHostPump;
@@ -54,6 +58,10 @@ export class BrainClient {
     this.token = options.token;
     this.timeoutMs = options.timeoutMs;
     this.transport = options.fetch ?? globalThis.fetch;
+    if (options.residentHost !== undefined) {
+      if (!options.residentHost.hostId || !options.residentHost.token) throw new TypeError("residentHost requires hostId and token");
+      this.registration = { host_id: options.residentHost.hostId, token: options.residentHost.token };
+    }
     this.sessions = new Sessions(this);
     Object.freeze(this.sessions);
   }
@@ -145,7 +153,8 @@ export class BrainClient {
   }> {
     if (this.resident !== undefined) return this.resident;
     const opening = (async () => {
-      const registration = await this.request<HostRegistration>("POST", "/v1/hosts");
+      const registration = this.registration ?? await this.request<HostRegistration>("POST", "/v1/hosts");
+      this.registration = registration;
       const hostClient = this.withToken(registration.token);
       const pump = new ResidentHostPump({
         stream: (signal, onOpen) => hostClient.streamPath(`/v1/hosts/${encodeURIComponent(registration.host_id)}/commands`, signal, onOpen),
@@ -169,6 +178,11 @@ export class BrainClient {
     this.resident = opening;
     opening.catch(() => { if (this.resident === opening) this.resident = undefined; });
     return opening;
+  }
+
+  async residentHostCredentials(): Promise<ResidentHostCredentials> {
+    await this.residentHost();
+    return Object.freeze({ hostId: this.registration!.host_id, token: this.registration!.token });
   }
 
   private async admitComponent(value: Component, cache: WeakMap<object, Promise<string>>, path: string, subject: string): Promise<string> {
@@ -198,9 +212,10 @@ export class Sessions {
 
   async create(options: CreateSessionOptions, operation: OperationOptions = {}): Promise<SessionHandle> {
     validateSessionOptions(options);
+    const key = keyOf(operation);
     const loop = inspectAgentloop(options.agentloop);
     const identity = await this.client.admitAgentloop(loop.component);
-    const environments = collectEnvironments(options);
+    const environments = collectEnvironments(options, await sha256(new TextEncoder().encode(key)));
     const residentTools = (options.tools ?? []).map(inspectResidentTool).filter((value) => value !== undefined);
     const resident = residentTools.length === 0 ? undefined : await this.client.residentHost();
     const implementations = new Map<ToolBinding, unknown>();
@@ -219,7 +234,7 @@ export class Sessions {
           });
     }
     const compiled = compileSession(options, identity, environments, implementations, resident?.hostId);
-    const session = await this.client.request<WireSession>("POST", "/v1/sessions", compiled.request, keyOf(operation));
+    const session = await this.client.request<WireSession>("POST", "/v1/sessions", compiled.request, key);
     if (resident !== undefined) {
       const registry = new AppToolRegistry();
       for (const tool of residentTools) registry.register(tool.contract, tool.handler);
@@ -232,9 +247,30 @@ export class Sessions {
     );
   }
 
-  async get(sessionId: string): Promise<SessionHandle> {
+  async get(sessionId: string, options: { tools?: readonly ToolBinding[] } = {}): Promise<SessionHandle> {
     const session = await this.client.request<WireSession>("GET", `/v1/sessions/${encodeURIComponent(sessionId)}`);
-    return new SessionHandle(this.client, toSessionState(session));
+    const handle = new SessionHandle(this.client, toSessionState(session));
+    if (options.tools === undefined) return handle;
+    const tools = options.tools.map((tool) => {
+      const resident = inspectResidentTool(tool);
+      if (resident === undefined) throw new TypeError("reattachment accepts only resident Tools");
+      return resident;
+    });
+    const host = await this.client.residentHost();
+    for await (const event of handle.events()) {
+      if (event.type !== "session_creation_ended") continue;
+      const configuration = (event.data as { configuration: { tool_bindings: { name: string; host_id?: string }[] } }).configuration;
+      const bound = configuration.tool_bindings.filter((binding) => binding.host_id === host.hostId).map((binding) => binding.name).sort();
+      const supplied = tools.map((tool) => tool.definition.name).sort();
+      if (bound.length === 0 || JSON.stringify(bound) !== JSON.stringify(supplied)) {
+        throw new TypeError("resident Tools must match this host's sealed session bindings");
+      }
+      const registry = new AppToolRegistry();
+      for (const tool of tools) registry.register(tool.contract, tool.handler);
+      host.pump.register(sessionId, registry);
+      return new SessionHandle(this.client, toSessionState(session), () => host.unregister(sessionId));
+    }
+    throw new TypeError("session has no completed creation record");
   }
 
   async list(): Promise<SessionState[]> {
@@ -292,11 +328,11 @@ export class SessionHandle {
   }
 }
 
-function collectEnvironments(options: CreateSessionOptions): ReadonlyMap<Environment, string> {
+function collectEnvironments(options: CreateSessionOptions, operationIdentity: string): ReadonlyMap<Environment, string> {
   const result = new Map<Environment, string>();
   const add = (environment: Environment) => {
     inspectEnvironment(environment);
-    if (!result.has(environment)) result.set(environment, `env_${crypto.randomUUID().replaceAll("-", "")}`);
+    if (!result.has(environment)) result.set(environment, `env_${operationIdentity}_${result.size}`);
   };
   add(inspectAgentloop(options.agentloop).environment);
   for (const selected of options.tools ?? []) {

--- a/packages/brain-sdk/src/generated/session.ts
+++ b/packages/brain-sdk/src/generated/session.ts
@@ -149,7 +149,7 @@ export type Identity = string;
  * This interface was referenced by `BrainSessionAPIV1`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
-export type SessionStatus = "creating" | "idle" | "running" | "ended" | "failed";
+export type SessionStatus = "creating" | "idle" | "running" | "ending" | "ended" | "failed";
 /**
  * This interface was referenced by `BrainSessionAPIV1`'s JSON-Schema
  * via the `definition` "ToolIdentity".

--- a/packages/brain-sdk/src/index.ts
+++ b/packages/brain-sdk/src/index.ts
@@ -1,5 +1,5 @@
 export { BrainClient as Brain, BrainClient, SessionHandle, Sessions } from "./client.js";
-export type { BrainOptions } from "./client.js";
+export type { BrainOptions, ResidentHostCredentials } from "./client.js";
 export {
   agentloop,
   brainWasm,

--- a/packages/brain-sdk/src/types.ts
+++ b/packages/brain-sdk/src/types.ts
@@ -108,7 +108,7 @@ export interface CreateSessionOptions {
 export interface OperationOptions { readonly idempotencyKey?: string }
 export interface SessionState {
   readonly id: string;
-  readonly status: "creating" | "idle" | "running" | "ended" | "failed";
+  readonly status: "creating" | "idle" | "running" | "ending" | "ended" | "failed";
   readonly lastSequence: number;
 }
 

--- a/packages/brain-sdk/test/client-tools.test.mjs
+++ b/packages/brain-sdk/test/client-tools.test.mjs
@@ -9,6 +9,32 @@ import { Brain, agentloop, brainWasm, component, tool } from "../dist/index.js";
 const sessionId = "ses_12345678901234567890";
 const sse = (data) => `event: command\ndata: ${JSON.stringify(data)}\n\n`;
 
+test("saved host credentials reattach handlers to an existing session", async () => {
+  const credentials = { hostId: "host_12345678901234567890", token: "saved-token" };
+  let controller;
+  let finish;
+  const result = new Promise((resolve) => { finish = resolve; });
+  const client = new Brain({ baseUrl: "https://brain.example", residentHost: credentials, fetch: async (input, init) => {
+    const request = new Request(input, init);
+    const path = new URL(request.url).pathname;
+    if (path.endsWith("/commands")) {
+      assert.equal(request.headers.get("authorization"), "Bearer saved-token");
+      return new Response(new ReadableStream({ start(value) { controller = value; } }), { headers: { "content-type": "text/event-stream" } });
+    }
+    if (path.endsWith("/results")) { finish(await request.json()); return new Response(null, { status: 204 }); }
+    if (path.endsWith("/events")) return Response.json({ events: [{ event_id: "evt_creation", sequence: 1, recorded_at_ms: 0, event_type: "session_creation_ended", data: { configuration: { tool_bindings: [{ name: "lookup", host_id: credentials.hostId }] } } }], next_cursor: 1 });
+    if (path.endsWith("/end")) return Response.json({ session_id: sessionId, status: "ended", last_sequence: 4 });
+    if (path === `/v1/sessions/${sessionId}`) return Response.json({ session_id: sessionId, status: "idle", last_sequence: 1 });
+    throw new Error(`unexpected request ${path}`);
+  } });
+  const lookup = tool({ name: "lookup", description: "Lookup.", input: z.object({}), run: async () => "restored" });
+  const session = await client.sessions.get(sessionId, { tools: [lookup()] });
+  assert.deepEqual(await client.residentHostCredentials(), credentials);
+  controller.enqueue(new TextEncoder().encode(sse({ session_id: sessionId, sequence: 2, deadline_at_ms: Date.now() + 5000, operation: { type: "invoke_tool", invocation: { call_id: "call_restored", name: "lookup", input: {} } } })));
+  assert.deepEqual((await result).outcome, { status: "ok", value: "restored" });
+  await session.end();
+});
+
 test("one resident host runs app Tools and commits ctx.emit before its result", async () => {
   const requests = [];
   let releaseStream;
@@ -143,7 +169,7 @@ test("a resident host reconnects without replaying old commands", async () => {
   await pump.closed;
 });
 
-test("a new resident session never reuses the stopped host of the previous session", async () => {
+test("a new resident session reconnects the durable host after its previous stream stopped", async () => {
   let hosts = 0;
   let sessions = 0;
   const bindings = [];
@@ -193,6 +219,6 @@ test("a new resident session never reuses the stopped host of the previous sessi
   const second = await client.sessions.create(options);
   await second.end();
 
-  assert.equal(hosts, 2);
-  assert.deepEqual(bindings, ["host_1", "host_2"]);
+  assert.equal(hosts, 1);
+  assert.deepEqual(bindings, ["host_1", "host_1"]);
 });

--- a/packages/brain-sdk/test/client.test.mjs
+++ b/packages/brain-sdk/test/client.test.mjs
@@ -66,6 +66,24 @@ test("failed admission is not cached and successful admission is", async () => {
   assert.equal(calls, 2);
 });
 
+test("retrying create with the same key sends the same Environment identities", async () => {
+  const bodies = [];
+  const client = new Brain({ baseUrl: "https://brain.example", fetch: async (input, init) => {
+    const request = new Request(input, init);
+    if (request.url.endsWith("/v1/agentloops")) return Response.json({ identity: "a".repeat(64), status: "admitted" });
+    bodies.push(await request.json());
+    if (bodies.length === 1) throw new TypeError("response lost after server accepted create");
+    return Response.json(sessionResponse);
+  } });
+  const pi = agentloop({ implementation: component(new Uint8Array([1])) });
+  const options = { model: { provider: "openai", name: "gpt-5", apiKey: "key" }, agentloop: pi({ env: brainWasm() }) };
+  await assert.rejects(client.sessions.create(options, { idempotencyKey: "create-once" }));
+  await client.sessions.create(options, { idempotencyKey: "create-once" });
+  assert.deepEqual(bodies[1], bodies[0]);
+  await client.sessions.create(options, { idempotencyKey: "create-another" });
+  assert.notEqual(bodies[2].environments[0].environment_id, bodies[0].environments[0].environment_id);
+});
+
 test("long operations have no implicit client timeout", async () => {
   let defaultSignal;
   const client = new Brain({


### PR DESCRIPTION
Fix the ten P1 architecture-review findings with focused regression tests: reserved journal events, aggregate Wasm memory limits, bounded remote responses, durable request claims and metadata, interrupted session lifecycle recovery, journaled Environment teardown, cancellation outcomes, stable SDK retries, and resident-host recovery. Keep the pre-launch data format at brain-data/1. Stage SDK 0.16.1. Local Windows/Linux suites, strict Clippy, SDK/package smoke, real Linux worker/component tests, throughput probes, and container restart checks passed. No new dependencies; P2 work is deferred.