### PR TITLE
ci: defer benchmark leakage gates during pre-launch iteration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,53 +145,9 @@ jobs:
           test "$(curl --silent --output /dev/null --write-out '%{http_code}' http://127.0.0.1:18080/v1/sessions)" = 401
           curl --fail --silent -H 'authorization: Bearer test-token' http://127.0.0.1:18080/v1/sessions | jq -e '.sessions == []'
 
-  benchmark-leakage:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: "1.97.1"
-      - uses: Swatinem/rust-cache@v2
-      - name: Exercise bounded resources in release mode
-        run: cargo test --release -p brain -p brain-telemetry -p brain-loophost -p brain-server --all-targets
-      - name: Exercise journal throughput probes
-        run: cargo test --release -p brain --test journal_throughput -- --ignored --nocapture
-      - name: Bound Brain HTTP memory after sustained requests
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo build --release -p brain-server --bin brain \
-            -p brain-loophost --bin brain-loop-worker
-          data_dir=$(mktemp -d)
-          BRAIN_LISTEN=127.0.0.1:18081 \
-          BRAIN_DATA_DIR="$data_dir" \
-          BRAIN_API_TOKEN=test-token \
-          BRAIN_LOOP_WORKER=target/release/brain-loop-worker \
-            target/release/brain >"$RUNNER_TEMP/brain-benchmark.log" 2>&1 &
-          brain_pid=$!
-          trap 'kill "$brain_pid" 2>/dev/null || true; wait "$brain_pid" 2>/dev/null || true; cat "$RUNNER_TEMP/brain-benchmark.log"' EXIT
-          for attempt in $(seq 1 60); do
-            if curl --fail --silent http://127.0.0.1:18081/health/ready >/dev/null; then break; fi
-            test "$attempt" -lt 60
-            sleep 1
-          done
-          rss_before=$(ps -o rss= -p "$brain_pid")
-          for _ in $(seq 1 10000); do
-            curl --fail --silent -H 'authorization: Bearer test-token' \
-              http://127.0.0.1:18081/v1/sessions >/dev/null
-          done
-          rss_after=$(ps -o rss= -p "$brain_pid")
-          rss_growth=$((rss_after - rss_before))
-          test "$rss_after" -le 262144
-          test "$rss_growth" -le 16384
-          printf 'Brain RSS: before=%s KiB after=%s KiB growth=%s KiB\n' \
-            "$rss_before" "$rss_after" "$rss_growth"
-
   build-test:
     if: always()
-    needs: [contracts, audit, lint, rust-core, rust-platforms, loophost, image-smoke, benchmark-leakage]
+    needs: [contracts, audit, lint, rust-core, rust-platforms, loophost, image-smoke]
     runs-on: ubuntu-24.04
     steps:
       - name: Every release gate passed
@@ -203,7 +159,6 @@ jobs:
           PLATFORMS: ${{ needs.rust-platforms.result }}
           LOOPHOST: ${{ needs.loophost.result }}
           IMAGE: ${{ needs.image-smoke.result }}
-          RESOURCE_BOUNDS: ${{ needs.benchmark-leakage.result }}
         run: |
           test "$CONTRACTS" = success
           test "$AUDIT" = success
@@ -212,4 +167,3 @@ jobs:
           test "$PLATFORMS" = success
           test "$LOOPHOST" = success
           test "$IMAGE" = success
-          test "$RESOURCE_BOUNDS" = success

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ npm test
 npm run package-smoke
 ```
 
-CI additionally runs the loop worker integration tests, an image smoke test, and a resident-memory
-bound against a live server. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+CI additionally runs real loop worker and HTTP lifecycle integration tests and an image smoke
+test. Performance probes are optional diagnostics during pre-launch iteration. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
 ## The Rust types are the source of the contracts
 

--- a/docs/reference/benchmarks.mdx
+++ b/docs/reference/benchmarks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Benchmarks
-description: Current figures, how they are measured, and what CI enforces.
+description: Performance diagnostics and CI correctness coverage.
 ---
 
 The current regression suite proves lazy history access, turn-end passivation, isolated subscription
@@ -31,16 +31,12 @@ is recorded as a refusal rather than a number.
 
 ## What CI enforces
 
-The Linux HTTP integration also retains 32 sessions with eight model/tool turns each, reads their
-transcripts after passivation, and bounds the combined server and worker private-memory growth
-to 64 MiB. It checks two independently authenticated lazy providers, expiration without retry, and
-restart history access without model execution. This is a regression workload, not a session-density
-claim for production.
+The Linux HTTP integration checks two independently authenticated lazy providers, expiration
+without retry, restart history access without model execution, and repeated turns across suspended
+sessions. CI does not impose throughput or resident-memory thresholds during pre-launch iteration.
+Benchmark and leakage gates are deferred until representative workloads and baselines stabilize.
 
-Every push bounds resident memory against a live server: after 10,000 requests it must stay under
-256 MiB and must not have grown by more than 16 MiB.
-
-The same push bounds journal growth on both axes. A transcript grows with every model call and
+Correctness tests still bound journal growth on both axes. A transcript grows with every model call and
 across every turn, so anything written per call or per turn would cost the sum of every intermediate
 size rather than the final one; `crates/brain/tests/journal_growth.rs` holds the canonical journal
 — and one public Event projection page — to a small constant multiple of the final context, and holds a

--- a/tests/release/runtime.mjs
+++ b/tests/release/runtime.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -49,15 +49,6 @@ async function start(baseUrl) {
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error("server did not become ready");
-}
-async function memory() {
-  const children = (await readFile(`/proc/${server.pid}/task/${server.pid}/children`, "utf8")).trim().split(/\s+/u).filter(Boolean);
-  let privateKiB = 0;
-  for (const pid of [server.pid, ...children]) {
-    const rollup = await readFile(`/proc/${pid}/smaps_rollup`, "utf8");
-    for (const match of rollup.matchAll(/^Private_(?:Clean|Dirty):\s+(\d+)/gmu)) privateKiB += Number(match[1]);
-  }
-  return privateKiB;
 }
 let modelUrl;
 let runtimeBaseUrl;
@@ -115,18 +106,14 @@ try {
   await start(baseUrl);
   assert.deepEqual(await session.transcript(), before);
   assert.equal(modelCalls, calls, "restart and history reads must not activate a loop");
-  await session.send("warm the restarted worker before measuring retained-session growth");
-  const baseline = await memory();
   const histories = [];
-  for (let i = 0; i < 32; i++) {
+  for (let i = 0; i < 2; i++) {
     const retained = await brain.sessions.create(options);
-    for (let turn = 0; turn < 8; turn++) await retained.send(`turn ${turn}: ${"context ".repeat(128)}`);
+    for (let turn = 0; turn < 2; turn++) await retained.send(`turn ${turn}`);
     histories.push(retained);
   }
-  for (const retained of histories) assert.equal((await retained.transcript()).messages.length, 32);
-  const after = await memory();
-  assert.ok(after - baseline < 64 * 1024, `retained histories grew private memory by ${after - baseline} KiB`);
-  console.log(JSON.stringify({ sessions: histories.length, turnsPerSession: 8, serverAndWorkerPrivateKiB: { baseline, after } }));
+  for (const retained of histories) assert.equal((await retained.transcript()).messages.length, 8);
+  console.log("lazy providers, expiry, restart, and suspended transcripts passed");
 } finally {
   await stop();
   await Promise.all(listeners.map((listener) => new Promise((resolve) => listener.close(resolve))));


### PR DESCRIPTION
Remove the benchmark-leakage job and live memory thresholds during rapid pre-launch iteration, as requested after the architecture change landed. Keep the HTTP lifecycle workload focused on provider authentication, lazy allocation, expiry without retry, restart reads, and suspended transcripts across sessions.

All correctness, security, image, contract, and cross-platform gates remain. Journal growth regressions remain correctness coverage; manual journal throughput probes remain available as diagnostics. Update contributor and public benchmark documentation to match.

Validation: the simplified HTTP workload passes through the real Linux Brain worker; normal CI remains the merge gate. Remove only the obsolete benchmark-leakage branch-protection context, preserving strict build-test protection.
