### PR TITLE
runtime: keep the pre-launch data format at v1

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -36,7 +36,7 @@ These decisions supersede earlier lifecycle and residency choices below.
 - The entire official `tool-env` tool, mutable bindings, tools without bindings, automatic placement,
   configurable resource bounds, and suspension inside model/tool waits remain post-MVP. The
   roadmap includes inspection and explicit lifecycle operations for model-driven recovery.
-- This is a pre-launch clean break: the local data format is `brain-data/2`, and contracts and
+- This is a pre-launch clean break: the local data format is `brain-data/1`, and contracts and
   official consumers move together. No compatibility shims or old-data migration are provided.
 
 ## 2026-09-02: The agent loop owns what the model sees

--- a/crates/brain-server/src/data_layout.rs
+++ b/crates/brain-server/src/data_layout.rs
@@ -1,7 +1,7 @@
 //! Brain's v1 data directory.
 //!
 //! ```text
-//! {data_dir}/format             "brain-data/2"
+//! {data_dir}/format             "brain-data/1"
 //! {data_dir}/sessions/{id}/     one directory per session (see brain::LocalSessionStore)
 //! {data_dir}/agentloops         admitted Agentloop and Tool Components
 //! {data_dir}/native-workspaces  session workspaces for Brain Wasm Environments
@@ -11,7 +11,7 @@
 
 use std::path::{Path, PathBuf};
 
-pub const FORMAT: &str = "brain-data/2";
+pub const FORMAT: &str = "brain-data/1";
 
 /// Hold this handle for the server lifetime, before initializing any mutable stores.
 pub fn lock(data_dir: &Path) -> Result<std::fs::File, brain::Error> {

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -27,14 +27,14 @@ Each option is a flag and an environment variable. Flags win.
 
 ## The data directory
 
-Brain owns everything under `BRAIN_DATA_DIR`. Its only format is `brain-data/2`, replaced in place
+Brain owns everything under `BRAIN_DATA_DIR`. Its only format is `brain-data/1`, replaced in place
 during pre-launch development. Start with an empty directory; Brain writes its format marker on
 initialization. There are no legacy layouts or migrations.
 
 ```
 brain-data/
   .lock                               process-held single-writer lock
-  format                              layout marker (`brain-data/2`)
+  format                              layout marker (`brain-data/1`)
   sessions/{session_id}/journal/      one canonical journal per session
   sessions/{session_id}/checkpoint    disposable current-state/index projection
   environments/{environment_id}.json environment records


### PR DESCRIPTION
Keep the sole pre-launch data-directory marker at brain-data/1. The layout is replaced in place; no migration or compatibility path is introduced. Align the source layout documentation, configuration reference, and decision record.

Validation: brain-server tests and rustfmt passed locally. Normal repository CI remains the merge gate.
