### PR TITLE
test: cover public SDK journeys in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,14 @@ jobs:
           BRAIN_TEST_WORKER: ${{ github.workspace }}/target/debug/brain-loop-worker
           BRAIN_TEST_REFERENCE_AGENTLOOP: ${{ runner.temp }}/reference-agentloop.wasm
         run: node tests/release/runtime.mjs
+      - name: Run SDK user journeys in parallel
+        env:
+          BRAIN_TEST_SERVER: ${{ github.workspace }}/target/debug/brain
+          BRAIN_TEST_WORKER: ${{ github.workspace }}/target/debug/brain-loop-worker
+          BRAIN_TEST_AGENTLOOP_PACKAGE: ${{ runner.temp }}/diagnostic-agentloop.wasm
+          BRAIN_TEST_TOOL_COMPONENT: ${{ runner.temp }}/diagnostic-tool.wasm
+          BRAIN_TEST_REFERENCE_AGENTLOOP: ${{ runner.temp }}/reference-agentloop.wasm
+        run: npm run test:journeys
 
   image-smoke:
     runs-on: ubuntu-24.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ npm run package-smoke
 CI additionally runs real loop worker and HTTP lifecycle integration tests and an image smoke
 test. Performance probes are optional diagnostics during pre-launch iteration. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
+[SDK user journeys](tests/journeys/README.md) run against real Linux servers and workers with four
+isolated suites in parallel. They cover the public SDK lifecycle, tools, placement, events, and
+recovery on every pull request. Run them with `npm run test:journeys` after the documented builds.
+
 ## The Rust types are the source of the contracts
 
 The wire is defined once, as the types in [`crates/brain-protocol`](crates/brain-protocol) and the

--- a/docs/guides/write-a-loop.mdx
+++ b/docs/guides/write-a-loop.mdx
@@ -86,6 +86,7 @@ keep an observation cursor in your own slot when consuming additional pages. Col
 before producing new effects so a loop does not chase its own Events indefinitely. Suspension
 leaves external history reads available; it does not run guest callbacks.
 
-Admission is explicit when desired: call `await brain.admit(loop)` and `await brain.admit(tool)`
-on the same bound objects you will pass to creation. Their Component objects cache successful
-admission. Brain retains compiled and prelinked templates, never one session's credentials or heap.
+Admission is explicit when desired: call `await brain.admit(loopBinding)` and
+`await brain.admitTool(toolComponent)` before creation. Reuse those Component objects when binding
+extensions; they cache successful admission. Brain retains compiled and prelinked templates,
+never one session's credentials or heap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "gen": "cargo run -q -p brain-contracts && python tools/generate-providers.py && npm run gen -w packages/brain-sdk",
     "build": "npm run build --workspaces --if-present",
     "test": "npm test --workspaces --if-present",
+    "test:journeys": "node --test --test-concurrency=4 tests/journeys/*.test.mjs",
     "package-smoke": "node tools/package-smoke.mjs",
     "example:basic": "npm run basic -w examples",
     "example:events": "npm run events -w examples",

--- a/packages/brain-sdk/README.md
+++ b/packages/brain-sdk/README.md
@@ -67,7 +67,8 @@ canonical journal before its promise resolves.
 A Tool with `implementation` is placed and requires `{ env, ...options }`. Agentloops are always
 placed the same way. The SDK admits Component bytes by content identity, preserves explicit
 placement, and supplies deterministic idempotency keys for admission. A caller may supply an
-`idempotencyKey` for other mutating requests.
+`idempotencyKey` for other mutating requests. Repeating session creation with the same key keeps
+the existing resident handlers, including any active calls and their cancellation signals.
 
 Requests have no implicit client-side deadline because a turn may legitimately outlive a short
 HTTP timeout. Set `timeoutMs` on `Brain` when the caller owns a tighter bound; Brain still enforces
@@ -75,8 +76,9 @@ its configured model, Tool, and whole-turn limits.
 
 ## Preparation and suspended history
 
-Call `await brain.admit(loop)` and `await brain.admit(tool)` before creation to prepare the same
-Component objects you will bind. Successful admission is cached. `await session.transcript()`
+Prepare an Agentloop with `await brain.admit(loopBinding)` or
+`await brain.admitAgentloop(loopComponent)`, and a Tool with `await brain.admitTool(toolComponent)`.
+Use the same Component objects when binding them for creation. Successful admission is cached. `await session.transcript()`
 returns canonical messages and their journal sequence without starting execution; Events and live
 subscriptions also remain accessible while suspended.
 

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/packages/brain-sdk/src/client-pump.ts
+++ b/packages/brain-sdk/src/client-pump.ts
@@ -23,7 +23,8 @@ export class ResidentHostPump {
   }
 
   register(sessionId: string, registry: AppToolRegistry): void {
-    if (this.sessions.has(sessionId)) throw new Error(`resident session ${sessionId} is already registered`);
+    // Replayed creation must retain the registry that owns any in-flight calls.
+    if (this.sessions.has(sessionId)) return;
     this.sessions.set(sessionId, registry);
   }
 

--- a/tests/journeys/README.md
+++ b/tests/journeys/README.md
@@ -1,0 +1,47 @@
+# SDK user journeys
+
+These tests import the public `@aexhq/brain` package and exercise a real Brain server, Wasmtime
+worker, and local journal. The model speaks scripted OpenAI SSE; Environment providers run over
+HTTP. No model account, cloud deployment, SDK transport stub, or internal SDK import is needed.
+
+`npm run test:journeys` runs four files concurrently using Node's built-in test runner. Each file
+owns its server, worker process group, random ports, credentials, and temporary data directory.
+Tests within a file run in order. CI builds the binaries and Components once in the existing
+Linux worker job, then runs all journeys as a required part of `build-test`.
+
+| Public functionality | Journey coverage |
+| --- | --- |
+| `Brain` / `BrainClient`, `withToken`, custom `fetch`, `request`, `BrainError` | Authenticated and unauthenticated clients, isolated derived credentials, real request tracing, missing sessions, invalid options |
+| `component`, `agentloop`, `admit`, `admitAgentloop`, `admitTool`, inspection | File/bytes/HTTP artifacts, identity reuse, parallel preparation, rejected artifacts, prepared session creation, native Tool execution |
+| `sessions.create/get/list`, initial transcript, system, response format, idle policy | Full conversation lifecycle, seeded context, reopen through another client, idempotent creation with and without resident Tools, conflicting keys, parallel conversations |
+| `send`, `state`, `id`, `transcript` | String/structured input, multiple suspended turns, idempotent sends, invalid input, cold reads, committed input after interruption |
+| `cancel`, `end`, `delete` | Running and idle cancellation, model and resident Tool cancellation, repeated keyed operations, ended-session reads, invalid deletion, independent sessions |
+| `events`, `stream`, client `stream` | Durable cursors, a full page boundary, replay-to-live delivery, reconnect, abort, authentication, session isolation |
+| `tool` resident handlers, options, schemas, context | Progress ordering, input/output errors, handler errors, deadlines/signals, concurrent sessions, protected Event rejection |
+| `residentHost`, `residentHostCredentials`, reattachment | Save credentials, close the host connection, reject mismatched bindings, restore matching handlers, preserve active-call cancellation on creation replay |
+| `environment`, `brainWasm`, placed Tools and inspection | Independent authenticated providers, option/binding configuration, lazy allocation, expiry without retry, native workspace persistence/isolation, missing grants |
+| `timeoutMs` | Explicit client timeout leaves the server's execution observable and does not retry the model call |
+
+The pagination case emits fewer than the permitted Events per turn across enough turns to cross
+the real page boundary. It is a correctness check, not a throughput or memory benchmark. Cancellation
+tests synchronize with actual model/Tool entry rather than guessing execution progress with sleeps.
+
+## Run locally on Linux
+
+After `npm ci && npm run build`:
+
+```sh
+cargo build -p brain-server --bin brain -p brain-loophost --bin brain-loop-worker
+cargo build --manifest-path tests/fixtures/diagnostic-agentloop/Cargo.toml --target wasm32-wasip2 --release
+cargo build --manifest-path tests/fixtures/diagnostic-tool/Cargo.toml --target wasm32-wasip2 --release
+cargo build --manifest-path examples/reference-agentloop/Cargo.toml --target wasm32-wasip2 --release
+export BRAIN_TEST_SERVER="$PWD/target/debug/brain"
+export BRAIN_TEST_WORKER="$PWD/target/debug/brain-loop-worker"
+export BRAIN_TEST_AGENTLOOP_PACKAGE="$PWD/tests/fixtures/diagnostic-agentloop/target/wasm32-wasip2/release/diagnostic_agentloop.wasm"
+export BRAIN_TEST_TOOL_COMPONENT="$PWD/tests/fixtures/diagnostic-tool/target/wasm32-wasip2/release/diagnostic_tool.wasm"
+export BRAIN_TEST_REFERENCE_AGENTLOOP="$PWD/examples/reference-agentloop/target/wasm32-wasip2/release/reference_agentloop.wasm"
+npm run test:journeys
+```
+
+Missing binaries or Components fail the suite; no journeys are conditionally skipped. Use WSL for
+these Linux process/worker tests on Windows. Portable SDK unit tests still run with `npm test`.

--- a/tests/journeys/admission.test.mjs
+++ b/tests/journeys/admission.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { z } from "zod";
+import { agentloop, brainWasm, component, inspectAgentloop, inspectComponent, inspectEnvironment } from "@aexhq/brain";
+import { fixture, collect } from "./support.mjs";
+
+const f = fixture();
+
+test("file, bytes, and URL admission identify the same executable", { timeout: 30_000 }, async () => {
+  const bytes = component(new Uint8Array(await readFile(process.env.BRAIN_TEST_REFERENCE_AGENTLOOP)));
+  const remote = component(new URL("/artifact.wasm", f.upstreamUrl));
+  const identities = await Promise.all([f.brain.admitAgentloop(f.reference), f.brain.admitAgentloop(bytes), f.brain.admitAgentloop(remote)]);
+  assert.equal(new Set(identities).size, 1);
+  assert.match(identities[0], /^[a-f0-9]{64}$/u);
+  assert.ok(inspectComponent(bytes).artifact instanceof Uint8Array);
+});
+
+test("prepare a binding once and create multiple ready-to-use sessions", { timeout: 30_000 }, async (t) => {
+  const env = brainWasm();
+  const binding = agentloop({ implementation: f.reference })({ env });
+  const identity = await f.brain.admit(binding);
+  assert.equal(await f.brain.admitAgentloop(f.reference), identity);
+  assert.equal(inspectAgentloop(binding).environment, env);
+  assert.equal(inspectEnvironment(env).configuration.driver, "brain_wasm");
+  const sessions = await Promise.all([f.create(t, { agentloop: binding }), f.create(t, { agentloop: binding })]);
+  await Promise.all(sessions.map((session) => session.send("prepared")));
+  assert.ok(sessions.every(({ state }) => state.status === "idle"));
+});
+
+test("rejected bytes do not prevent a later valid admission", { timeout: 30_000 }, async () => {
+  const client = f.client();
+  await assert.rejects(client.admitAgentloop(component(new Uint8Array([1, 2, 3]))));
+  assert.match(await client.admitAgentloop(f.reference), /^[a-f0-9]{64}$/u);
+  await assert.rejects(client.admitTool(f.reference));
+  assert.match(await client.admitTool(f.toolComponent), /^[a-f0-9]{64}$/u);
+});
+
+test("simultaneous preparation coalesces one artifact upload", { timeout: 30_000 }, async () => {
+  let uploads = 0;
+  const client = f.client({ fetch: (url, init) => {
+    if (String(url).endsWith("/v1/agentloops") && init.method === "POST") uploads++;
+    return fetch(url, init);
+  } });
+  const ids = await Promise.all(Array.from({ length: 3 }, () => client.admitAgentloop(f.reference)));
+  assert.equal(new Set(ids).size, 1);
+  assert.equal(uploads, 1);
+});
+
+test("configured agentloops retain explicit slots across fresh activations", { timeout: 30_000 }, async (t) => {
+  const loop = agentloop({ implementation: f.diagnostic, options: z.object({ label: z.string().default("configured") }) });
+  const binding = loop({ env: brainWasm() });
+  assert.deepEqual(inspectAgentloop(binding).configuration, { label: "configured" });
+  const session = await f.create(t, { agentloop: binding });
+  await session.send("one");
+  await session.send("two");
+  assert.deepEqual((await collect(session.events())).filter(({ type }) => type === "turn_ended").map(({ data }) => data.result), [
+    { turns: 1, message: "one" }, { turns: 2, message: "two" },
+  ]);
+  assert.equal(f.modelRequests.length, 0);
+});

--- a/tests/journeys/client.test.mjs
+++ b/tests/journeys/client.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Brain, BrainClient, BrainError } from "@aexhq/brain";
+import { fixture, failure } from "./support.mjs";
+
+const f = fixture();
+
+test("authenticate a client and derive another without mutating the first", { timeout: 30_000 }, async () => {
+  assert.equal(Brain, BrainClient);
+  const anonymous = new Brain({ baseUrl: `${f.baseUrl}///` });
+  assert.equal(anonymous.baseUrl, f.baseUrl);
+  await assert.rejects(anonymous.sessions.list(), failure(401));
+  assert.ok(Array.isArray(await anonymous.withToken(f.token).sessions.list()));
+  await assert.rejects(anonymous.sessions.list(), failure(401));
+  await assert.rejects(f.brain.withToken("wrong-token").sessions.list(), failure(401));
+});
+
+test("custom transport observes real requests and structured errors remain actionable", { timeout: 30_000 }, async (t) => {
+  const paths = [];
+  const client = f.client({ fetch: (url, init) => { paths.push(new URL(url).pathname); return fetch(url, init); } });
+  const session = await f.create(t, {}, client);
+  assert.equal((await client.request("GET", `/v1/sessions/${session.id}`)).session_id, session.id);
+  await session.end();
+  await session.delete();
+  await assert.rejects(session.transcript(), (error) => {
+    assert.ok(error instanceof BrainError);
+    assert.equal(error.status, 404);
+    assert.equal(error.code, "not_found");
+    assert.equal(error.retryable, false);
+    assert.ok(error.message.length > 0);
+    return true;
+  });
+  assert.ok(paths.includes(`/v1/sessions/${session.id}/transcript`));
+});
+
+test("invalid configuration fails before any network work", async () => {
+  for (const options of [{ baseUrl: "" }, { baseUrl: "file:///tmp" }, { baseUrl: f.baseUrl, token: " " }, { baseUrl: f.baseUrl, timeoutMs: 0 }]) {
+    assert.throws(() => new Brain(options), TypeError);
+  }
+  let requests = 0;
+  const client = f.client({ fetch: (...args) => { requests++; return fetch(...args); } });
+  await assert.rejects(client.sessions.create(f.options({ model: { provider: "openai", name: "test", apiKey: "" } })), TypeError);
+  assert.equal(requests, 0);
+});

--- a/tests/journeys/events.test.mjs
+++ b/tests/journeys/events.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { z } from "zod";
+import { tool } from "@aexhq/brain";
+import { fixture, collect, callTools, reply, failure } from "./support.mjs";
+
+const f = fixture();
+
+test("read and resume durable events without rerunning the conversation", { timeout: 30_000 }, async (t) => {
+  const session = await f.create(t);
+  await session.send("first");
+  const first = await collect(session.events());
+  const cursor = first.at(-1).sequence;
+  await session.send("second");
+  const suffix = await collect(session.events(cursor));
+  assert.ok(suffix.every(({ sequence }) => sequence > cursor));
+  assert.equal(suffix.filter(({ type }) => type === "turn_ended").length, 1);
+  assert.deepEqual(await collect(session.events(cursor)), suffix);
+  assert.deepEqual(await collect(session.events(suffix.at(-1).sequence)), []);
+  assert.ok(first.every(({ id, recordedAt }) => typeof id === "string" && recordedAt instanceof Date && Number.isFinite(+recordedAt)));
+  assert.equal(f.modelRequests.length, 2);
+});
+
+test("stream historical events then observe a live turn and reconnect by sequence", { timeout: 30_000 }, async (t) => {
+  const session = await f.create(t);
+  await session.send("before subscription");
+  const cursor = session.state.lastSequence;
+  const replay = [];
+  for await (const event of f.brain.stream(session.id, 0, AbortSignal.timeout(10_000))) {
+    if (event.sequence !== undefined) replay.push(event);
+    if (event.sequence === cursor) break;
+  }
+  assert.deepEqual(replay.map(({ sequence }) => sequence), (await collect(session.events())).map(({ sequence }) => sequence));
+  const live = (async () => {
+    const events = [];
+    for await (const event of session.stream(cursor, AbortSignal.timeout(10_000))) {
+      if (event.sequence !== undefined) events.push(event);
+      if (event.type === "turn_ended") return events;
+    }
+    assert.fail("stream closed before completion");
+  })();
+  await session.send("after subscription");
+  const events = await live;
+  assert.ok(events.every(({ sequence }) => sequence > cursor));
+  assert.equal(new Set(events.map(({ sequence }) => sequence)).size, events.length);
+  assert.deepEqual(events.map(({ sequence }) => sequence), (await collect(session.events(cursor))).map(({ sequence }) => sequence));
+});
+
+test("aborting one subscription leaves other sessions and streams usable", { timeout: 30_000 }, async (t) => {
+  const first = await f.create(t);
+  const second = await f.create(t);
+  const controller = new AbortController();
+  const waiting = collect(first.stream(first.state.lastSequence, controller.signal)).catch((error) => error);
+  controller.abort();
+  assert.equal((await waiting).name, "AbortError");
+  await second.send("independent");
+  const sequence = second.state.lastSequence;
+  for await (const event of second.stream(0, AbortSignal.timeout(10_000))) {
+    if (event.sequence === sequence) break;
+  }
+  assert.equal((await collect(first.events())).filter(({ type }) => type === "turn_started").length, 0);
+  await assert.rejects(collect(f.brain.withToken("wrong").stream(second.id)), failure(401));
+});
+
+test("event iteration crosses a full page without omissions or duplicate progress", { timeout: 60_000 }, async (t) => {
+  let next = 0;
+  const progress = tool({ name: "progress", description: "Report progress", input: z.object({}), run: async (_input, context) => {
+    for (let i = 0; i < 120; i++) await context.emit("journey_progress", { i: next++ });
+    return "done";
+  } });
+  f.model = (request, response) => request.messages.at(-1).role === "tool"
+    ? reply(response) : callTools(response, [{ name: "progress", input: {} }]);
+  const session = await f.create(t, { tools: [progress()] });
+  for (let turn = 0; turn < 9; turn++) await session.send(`progress batch ${turn}`);
+  const events = await collect(session.events());
+  assert.deepEqual(events.filter(({ type }) => type === "journey_progress").map(({ data }) => data.i), Array.from({ length: 1080 }, (_, i) => i));
+  assert.equal(new Set(events.map(({ sequence }) => sequence)).size, events.length);
+  const cursor = events[999].sequence;
+  assert.deepEqual(await collect(session.events(cursor)), events.slice(1000));
+  assert.equal(f.modelRequests.length, 18);
+});

--- a/tests/journeys/placement.test.mjs
+++ b/tests/journeys/placement.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { z } from "zod";
+import { brainWasm, environment, inspectEnvironment, inspectPlacedTool, tool } from "@aexhq/brain";
+import { lazyEnvironment } from "../../examples/lazy-environment.mjs";
+import { fixture, callTools, reply, collect } from "./support.mjs";
+
+let clock = 0;
+let allocations = 0;
+const east = lazyEnvironment({ now: () => clock, allocate: async () => { allocations++; return new Map(); } });
+const west = lazyEnvironment({ allocate: async () => { allocations++; return new Map(); } });
+const f = fixture({ providers: { east: east.handle, west: west.handle } });
+const dispatch = (calls) => (request, response) => request.messages.at(-1).role === "tool" ? reply(response) : callTools(response, calls);
+const echo = (name) => tool({ name, description: "Echo in a provider", input: z.object({ value: z.string() }), implementation: { type: "reference_echo" } });
+
+test("compose separately configured environments and allocate only on first invocation", { timeout: 30_000 }, async (t) => {
+  const eastFactory = environment({ driver: "east", options: z.object({ idleMs: z.number() }),
+    configure: ({ idleMs }) => ({ idle_ms: idleMs }), bindings: () => ({ label: "east" }) });
+  const eastEnv = eastFactory({ idleMs: 10_000 });
+  const westEnv = environment({ driver: "west" })();
+  assert.equal(inspectEnvironment(eastEnv).configuration.idle_ms, 10_000);
+  assert.deepEqual(inspectEnvironment(eastEnv).bindings, { label: "east" });
+  const first = echo("first")({ env: eastEnv });
+  assert.equal(inspectPlacedTool(first).environment, eastEnv);
+  const before = allocations;
+  const session = await f.create(t, { tools: [first, echo("second")({ env: westEnv })] });
+  assert.equal(allocations, before);
+  f.model = dispatch([{ name: "first", input: { value: "east" } }, { name: "second", input: { value: "west" } }]);
+  await session.send("use both");
+  assert.equal(allocations, before + 2);
+  assert.equal((await collect(session.events())).filter(({ type }) => type === "tool_call_ended").length, 2);
+  assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("east"));
+  assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("west"));
+});
+
+test("provider expiry is visible to the model without replacement allocation", { timeout: 30_000 }, async (t) => {
+  const env = environment({ driver: "east", options: z.object({ idle_ms: z.number() }) })({ idle_ms: 1 });
+  const session = await f.create(t, { tools: [echo("echo")({ env })] });
+  f.model = dispatch([{ name: "echo", input: { value: "value" } }]);
+  await session.send("allocate");
+  const before = allocations;
+  clock += 10;
+  await session.send("use expired environment");
+  assert.equal(allocations, before);
+  assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("expired"));
+});
+
+test("admit a native tool and use it from a model-driven conversation", { timeout: 30_000 }, async (t) => {
+  const identity = await f.brain.admitTool(f.toolComponent);
+  assert.match(identity, /^[a-f0-9]{64}$/u);
+  const native = tool({ name: "native", description: "Native echo", input: z.object({ value: z.string() }), implementation: f.toolComponent });
+  const session = await f.create(t, { tools: [native({ env: brainWasm() })] });
+  f.model = dispatch([{ name: "native", input: { value: "native value" } }]);
+  await session.send("execute native tool");
+  assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("native value"));
+  assert.equal((await collect(session.events())).filter(({ type }) => type === "tool_progress").length, 1);
+});
+
+test("native workspaces persist between turns but remain separate between sessions", { timeout: 30_000 }, async (t) => {
+  const workspace = tool({ name: "workspace", description: "Read and write a marker", input: z.object({ workspace: z.boolean(), write: z.string().optional() }),
+    implementation: f.toolComponent });
+  const binding = workspace({ env: brainWasm({ filesystem: { workspace: true } }) });
+  const first = await f.create(t, { tools: [binding] });
+  const second = await f.create(t, { tools: [binding] });
+  f.model = dispatch([{ name: "workspace", input: { workspace: true, write: "private marker" } }]);
+  await first.send("write");
+  f.model = dispatch([{ name: "workspace", input: { workspace: true } }]);
+  await first.send("read again");
+  assert.ok(JSON.stringify(f.modelRequests.at(-1).messages.at(-1)).includes("private marker"));
+  await second.send("read isolated workspace");
+  const output = JSON.stringify(f.modelRequests.at(-1).messages.at(-1));
+  assert.ok(!output.includes("private marker"));
+  assert.ok(output.includes("null"));
+});
+
+test("a native tool without a workspace grant cannot write a workspace", { timeout: 30_000 }, async (t) => {
+  const write = tool({ name: "write", description: "Write a marker", input: z.object({ workspace: z.boolean(), write: z.string() }), implementation: f.toolComponent });
+  const session = await f.create(t, { tools: [write({ env: brainWasm() })] });
+  f.model = dispatch([{ name: "write", input: { workspace: true, write: "denied" } }]);
+  await session.send("try writing");
+  const transcript = await session.transcript();
+  const result = transcript.messages.flatMap(({ content }) => content).find(({ type }) => type === "tool_result");
+  assert.equal(result.is_error, true);
+  assert.equal(f.modelRequests.length, 2);
+});

--- a/tests/journeys/resident.test.mjs
+++ b/tests/journeys/resident.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { z } from "zod";
+import { tool, inspectResidentTool } from "@aexhq/brain";
+import { fixture, collect, callTools, reply, deferred, failure } from "./support.mjs";
+
+const f = fixture();
+const dispatch = (name, input) => (request, response) => request.messages.at(-1).role === "tool"
+  ? reply(response) : callTools(response, [{ name, input }]);
+
+test("an application tool receives validated options and commits progress before its result", { timeout: 30_000 }, async (t) => {
+  const contexts = [];
+  const lookup = tool({ name: "lookup", description: "Look up a value", input: z.object({ id: z.string() }),
+    output: z.object({ value: z.string() }), options: z.object({ prefix: z.string() }),
+    run: async ({ id }, context) => {
+      contexts.push(context);
+      await context.emit("lookup_progress", { id });
+      return { value: context.options.prefix + id };
+    } });
+  const binding = lookup({ prefix: "item-" });
+  assert.equal(inspectResidentTool(binding).definition.name, "lookup");
+  f.model = dispatch("lookup", { id: "42" });
+  const session = await f.create(t, { tools: [binding] });
+  await session.send("find item");
+  assert.equal(contexts.length, 1);
+  assert.ok(contexts[0].deadline instanceof Date);
+  assert.ok(contexts[0].signal instanceof AbortSignal);
+  assert.ok(contexts[0].callId);
+  const events = await collect(session.events());
+  assert.ok(events.find(({ type }) => type === "lookup_progress").sequence < events.find(({ type }) => type === "tool_call_ended").sequence);
+  assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("item-42"));
+});
+
+for (const mode of ["input", "output", "throw"]) {
+  test(`a resident ${mode} failure reaches the model once without automatic retry`, { timeout: 30_000 }, async (t) => {
+    let calls = 0;
+    const lookup = tool({ name: "lookup", description: "Validate a result", input: z.object({ id: z.string() }),
+      output: z.object({ value: z.string() }), run: () => {
+        calls++;
+        if (mode === "throw") throw new Error("lookup unavailable");
+        return { value: 42 };
+      } });
+    f.model = dispatch("lookup", { id: mode === "input" ? 42 : "42" });
+    const session = await f.create(t, { tools: [lookup()] });
+    await session.send("lookup");
+    assert.equal(calls, mode === "input" ? 0 : 1);
+    const expected = mode === "throw" ? "tool_error" : `invalid_${mode}`;
+    assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes(expected));
+    assert.equal(f.modelRequests.length, 2);
+  });
+}
+
+test("saved host credentials reattach a tool after its connection is closed", { timeout: 30_000 }, async (t) => {
+  const firstClient = f.client();
+  const lookup = tool({ name: "lookup", description: "Lookup", input: z.object({}), run: () => "original" });
+  const original = await f.create(t, { tools: [lookup()] }, firstClient);
+  const credentials = await firstClient.residentHostCredentials();
+  const host = await firstClient.residentHost();
+  host.pump.stop();
+  await host.pump.closed;
+  const restored = f.client({ residentHost: credentials });
+  const rebound = tool({ name: "lookup", description: "Lookup", input: z.object({}), run: () => "restored" });
+  await assert.rejects(restored.sessions.get(original.id, { tools: [] }), /sealed session bindings/u);
+  const restoredHost = await restored.residentHost();
+  t.after(() => restoredHost.pump.stop());
+  const session = await restored.sessions.get(original.id, { tools: [rebound()] });
+  assert.deepEqual(await restored.residentHostCredentials(), credentials);
+  f.model = dispatch("lookup", {});
+  await session.send("after reconnect");
+  assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("restored"));
+  await session.end();
+});
+
+test("cancellation reaches the application's signal and does not execute the tool twice", { timeout: 30_000 }, async (t) => {
+  const entered = deferred();
+  const cancelled = deferred();
+  let calls = 0;
+  const wait = tool({ name: "wait", description: "Wait", input: z.object({}), run: async (_input, context) => {
+    calls++;
+    context.signal.addEventListener("abort", () => cancelled.resolve(), { once: true });
+    entered.resolve();
+    await cancelled.promise;
+    return "cancelled";
+  } });
+  f.model = dispatch("wait", {});
+  const session = await f.create(t, { tools: [wait()] });
+  const pending = session.send("wait").catch((error) => error);
+  await entered.promise;
+  await session.cancel();
+  await cancelled.promise;
+  await pending;
+  assert.equal(calls, 1);
+  assert.ok((await collect(session.events())).some(({ type }) => type === "turn_failed"));
+});
+
+test("one application serves tools for two sessions concurrently", { timeout: 30_000 }, async (t) => {
+  const bothEntered = deferred();
+  const entered = [];
+  const rendezvous = tool({ name: "rendezvous", description: "Meet another invocation", input: z.object({}), run: async (_input, context) => {
+    entered.push(context.callId);
+    if (entered.length === 2) bothEntered.resolve();
+    await bothEntered.promise;
+    return "met";
+  } });
+  const binding = rendezvous();
+  const first = await f.create(t, { tools: [binding] });
+  const second = await f.create(t, { tools: [binding] });
+  f.model = dispatch("rendezvous", {});
+  await Promise.all([first.send("first"), second.send("second")]);
+  assert.equal(new Set(entered).size, 2);
+  await first.end();
+  f.model = (_request, response) => reply(response);
+  await second.send("the other session remains connected");
+  assert.equal(second.state.status, "idle");
+});
+
+test("retrying resident session creation keeps one working registration", { timeout: 30_000 }, async (t) => {
+  let calls = 0;
+  const lookup = tool({ name: "lookup", description: "Lookup", input: z.object({}), run: () => { calls++; return "found"; } });
+  const options = { tools: [lookup()] };
+  const operation = { idempotencyKey: "resident-create-once" };
+  const first = await f.create(t, options, f.brain, operation);
+  const repeated = await f.brain.sessions.create(f.options(options), operation);
+  assert.equal(repeated.id, first.id);
+  f.model = dispatch("lookup", {});
+  await repeated.send("lookup once");
+  assert.equal(calls, 1);
+  assert.equal((await collect(first.events())).filter(({ type }) => type === "session_creation_ended").length, 1);
+});
+
+test("replaying creation during a tool call preserves its cancellation handler", { timeout: 30_000 }, async (t) => {
+  const entered = deferred();
+  const cancelled = deferred();
+  let calls = 0;
+  const wait = tool({ name: "wait", description: "Wait", input: z.object({}), run: async (_input, context) => {
+    calls++;
+    context.signal.addEventListener("abort", () => cancelled.resolve(), { once: true });
+    entered.resolve();
+    await cancelled.promise;
+    return "stopped";
+  } });
+  const options = { tools: [wait()] };
+  const operation = { idempotencyKey: "active-resident-create-once" };
+  const first = await f.create(t, options, f.brain, operation);
+  f.model = dispatch("wait", {});
+  const pending = first.send("wait").catch((error) => error);
+  await entered.promise;
+  const repeated = await f.brain.sessions.create(f.options(options), operation);
+  assert.equal(repeated.id, first.id);
+  await repeated.cancel();
+  await cancelled.promise;
+  await pending;
+  assert.equal(calls, 1);
+});
+
+test("a tool may emit observations but cannot forge protected runtime events", { timeout: 30_000 }, async (t) => {
+  let denied = false;
+  const observer = tool({ name: "observer", description: "Emit an observation", input: z.object({}), run: async (_input, context) => {
+    await assert.rejects(context.emit("turn_ended", {}), failure(400));
+    denied = true;
+    await context.emit("application_observation", { ready: true });
+    return "observed";
+  } });
+  const session = await f.create(t, { tools: [observer()] });
+  f.model = dispatch("observer", {});
+  await session.send("observe");
+  assert.equal(denied, true);
+  const events = await collect(session.events());
+  assert.equal(events.filter(({ type }) => type === "turn_ended").length, 1);
+  assert.deepEqual(events.find(({ type }) => type === "application_observation").data, { ready: true });
+});

--- a/tests/journeys/sessions.test.mjs
+++ b/tests/journeys/sessions.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fixture, collect, failure, text } from "./support.mjs";
+
+const f = fixture();
+
+test("create, list, reopen, end, and delete a conversation", { timeout: 30_000 }, async (t) => {
+  const session = await f.create(t);
+  assert.equal(session.state.status, "idle");
+  assert.ok((await f.brain.sessions.list()).some(({ id }) => id === session.id));
+  const reopened = await f.client().sessions.get(session.id);
+  assert.deepEqual(reopened.state, session.state);
+  await assert.rejects(session.delete(), failure(400));
+  await reopened.send("hello");
+  assert.equal((await reopened.end()).status, "ended");
+  assert.equal((await session.transcript()).messages.length, 2);
+  await assert.rejects(reopened.send("too late"), failure(400));
+  await reopened.delete();
+  assert.ok(!(await f.brain.sessions.list()).some(({ id }) => id === session.id));
+  await assert.rejects(f.brain.sessions.get(session.id), failure(404));
+});
+
+test("cancel an idle session and repeat deletion using the same operation key", { timeout: 30_000 }, async (t) => {
+  const session = await f.create(t);
+  await session.cancel();
+  assert.equal((await f.brain.sessions.get(session.id)).state.status, "idle");
+  await session.send("still usable");
+  await session.end();
+  const operation = { idempotencyKey: "delete-once" };
+  await session.delete(operation);
+  await session.delete(operation);
+  await assert.rejects(session.transcript(), failure(404));
+});
+
+test("initial transcript, system prompt, and response format reach the model", { timeout: 30_000 }, async (t) => {
+  const transcript = [{ role: "user", content: [{ type: "text", text: "earlier context" }] }];
+  const responseFormat = { type: "json_object" };
+  const session = await f.create(t, { transcript, system: "Answer briefly", responseFormat, idleTtlMs: 0 });
+  assert.deepEqual((await session.transcript()).messages, transcript);
+  await session.send({ message: "next question" });
+  const request = f.modelRequests.at(-1);
+  assert.ok(JSON.stringify(request.messages).includes("Answer briefly"));
+  assert.ok(JSON.stringify(request.messages).includes("earlier context"));
+  assert.deepEqual(request.response_format, responseFormat);
+  assert.equal(text((await session.transcript()).messages.at(-2)), "next question");
+});
+
+test("retrying creation with the same key returns one session", { timeout: 30_000 }, async (t) => {
+  const operation = { idempotencyKey: "create-once" };
+  const first = await f.create(t, {}, f.brain, operation);
+  const second = await f.brain.sessions.create(f.options(), operation);
+  assert.equal(second.id, first.id);
+  assert.equal((await f.brain.sessions.list()).filter(({ id }) => id === first.id).length, 1);
+  await assert.rejects(f.brain.sessions.create(f.options({ system: "different" }), operation), failure(409));
+});
+
+test("end is repeatable with a key and preserves the recorded conversation", { timeout: 30_000 }, async (t) => {
+  const session = await f.create(t);
+  await session.send("keep this");
+  const before = await session.transcript();
+  const operation = { idempotencyKey: "end-once" };
+  assert.deepEqual(await session.end(operation), await session.end(operation));
+  assert.deepEqual((await session.transcript()).messages, before.messages);
+  assert.ok((await session.transcript()).through_sequence >= before.through_sequence);
+  const ended = (await collect(session.events())).filter(({ type }) => type === "session_ended");
+  assert.equal(ended.length, 1);
+});
+
+test("parallel conversations preserve separate transcripts and independent deletion", { timeout: 30_000 }, async (t) => {
+  const sessions = await Promise.all([f.create(t), f.create(t)]);
+  await Promise.all(sessions.map((session, i) => session.send(`conversation ${i}`)));
+  for (const [i, session] of sessions.entries()) assert.equal(text((await session.transcript()).messages[0]), `conversation ${i}`);
+  await sessions[0].end();
+  await sessions[0].delete();
+  await sessions[1].send("still available");
+  assert.equal((await sessions[1].transcript()).messages.length, 4);
+});

--- a/tests/journeys/support.mjs
+++ b/tests/journeys/support.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { before, beforeEach, after } from "node:test";
+import { pathToFileURL } from "node:url";
+import { Brain, BrainError, agentloop, brainWasm, component, inspectResidentTool } from "@aexhq/brain";
+
+export const collect = async (events) => { const result = []; for await (const event of events) result.push(event); return result; };
+export const deferred = () => Promise.withResolvers();
+export const failure = (status) => (error) => error instanceof BrainError && error.status === status;
+export const text = (message) => message.content.filter((block) => block.type === "text").map((block) => block.text).join("");
+
+export function reply(response, content = "answered") {
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  response.end(`data: ${JSON.stringify({ choices: [{ index: 0, delta: { content }, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`);
+}
+
+export function callTools(response, calls) {
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  response.end(`data: ${JSON.stringify({ choices: [{ index: 0, delta: { tool_calls: calls.map(({ name, input }, index) => ({
+    index, id: randomUUID(), type: "function", function: { name, arguments: JSON.stringify(input) },
+  })) }, finish_reason: "tool_calls" }] })}\n\ndata: [DONE]\n\n`);
+}
+
+export function fixture({ providers = {} } = {}) {
+  const f = { modelRequests: [], model: (_request, response) => reply(response) };
+  let child;
+  let upstream;
+  let directory;
+  let logs = "";
+  const pumps = new Set();
+  beforeEach(() => {
+    f.modelRequests.length = 0;
+    f.model = (_request, response) => reply(response);
+  });
+  before(async () => {
+    for (const name of ["BRAIN_TEST_SERVER", "BRAIN_TEST_WORKER", "BRAIN_TEST_REFERENCE_AGENTLOOP", "BRAIN_TEST_AGENTLOOP_PACKAGE", "BRAIN_TEST_TOOL_COMPONENT"]) {
+      assert.ok(process.env[name], `${name} is required; see tests/journeys/README.md`);
+    }
+    directory = await mkdtemp(join(tmpdir(), "brain-sdk-journey-"));
+    f.token = randomUUID();
+    f.reference = component(pathToFileURL(process.env.BRAIN_TEST_REFERENCE_AGENTLOOP));
+    f.diagnostic = component(pathToFileURL(process.env.BRAIN_TEST_AGENTLOOP_PACKAGE));
+    f.toolComponent = component(pathToFileURL(process.env.BRAIN_TEST_TOOL_COMPONENT));
+    upstream = createServer(async (request, response) => {
+      try {
+        if (request.url === "/artifact.wasm") {
+          response.end(await readFile(process.env.BRAIN_TEST_REFERENCE_AGENTLOOP));
+          return;
+        }
+        const chunks = [];
+        for await (const chunk of request) chunks.push(chunk);
+        const body = JSON.parse(Buffer.concat(chunks).toString() || "{}");
+        const driver = request.url.split("/")[1];
+        if (providers[driver]) {
+          assert.equal(request.headers.authorization, `Bearer ${driver}-token`);
+          response.setHeader("content-type", "application/json");
+          response.end(JSON.stringify(await providers[driver](body)));
+        } else {
+          assert.equal(request.headers.authorization, "Bearer journey-model-token");
+          f.modelRequests.push(body);
+          await f.model(body, response);
+        }
+      } catch (error) {
+        response.writeHead(500).end(String(error));
+      }
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    f.upstreamUrl = `http://127.0.0.1:${upstream.address().port}`;
+    const routes = Object.fromEntries(Object.keys(providers).map((driver) => [driver, {
+      endpoint: `${f.upstreamUrl}/${driver}`, api_key: `${driver}-token`,
+    }]));
+    await writeFile(join(directory, "routes.json"), JSON.stringify(routes));
+    const reservation = createServer();
+    reservation.listen(0, "127.0.0.1");
+    await once(reservation, "listening");
+    f.baseUrl = `http://127.0.0.1:${reservation.address().port}`;
+    await new Promise((resolve) => reservation.close(resolve));
+    await f.start();
+    f.brain = f.client();
+    f.options = (extra = {}) => ({
+      model: { provider: "vercel-ai-gateway", name: "test/journey", apiKey: "journey-model-token" },
+      agentloop: agentloop({ implementation: f.reference })({ env: brainWasm() }),
+      ...extra,
+    });
+  }, { timeout: 60_000 });
+  f.client = (options = {}) => new Brain({ baseUrl: f.baseUrl, token: f.token, ...options });
+  f.start = async () => {
+    child = spawn(process.env.BRAIN_TEST_SERVER, [], { env: {
+      ...process.env,
+      BRAIN_LISTEN: new URL(f.baseUrl).host, BRAIN_DATA_DIR: join(directory, "data"),
+      BRAIN_API_TOKEN: f.token, BRAIN_LOOP_WORKER: process.env.BRAIN_TEST_WORKER,
+      BRAIN_MODEL_BASE_URL: `${f.upstreamUrl}/v1`, BRAIN_ENVIRONMENT_ROUTES_FILE: join(directory, "routes.json"),
+      BRAIN_WASM_FILESYSTEM_ALLOW: "scratch,workspace",
+    }, detached: true, stdio: ["ignore", "pipe", "pipe"] });
+    child.stdout.on("data", (chunk) => { logs += chunk; });
+    child.stderr.on("data", (chunk) => { logs += chunk; });
+    for (let attempt = 0; attempt < 1200; attempt++) {
+      if (child.exitCode !== null) throw new Error(`Brain exited: ${logs}`);
+      try { if ((await fetch(`${f.baseUrl}/health/ready`)).ok) return; } catch {}
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`Brain readiness timed out: ${logs}`);
+  };
+  f.stop = async (signal = "SIGTERM") => {
+    if (child && child.exitCode === null) {
+      const exited = once(child, "exit");
+      process.kill(-child.pid, signal);
+      await exited;
+    }
+  };
+  f.create = async (t, extra = {}, client = f.brain, operation) => {
+    const session = await client.sessions.create(f.options(extra), operation);
+    if (extra.tools?.some(inspectResidentTool)) pumps.add((await client.residentHost()).pump);
+    t.after(async () => {
+      try { await session.end(); await session.delete(); } catch (error) { if (!failure(404)(error)) throw error; }
+    }, { timeout: 10_000 });
+    return session;
+  };
+  after(async () => {
+    for (const pump of pumps) pump.stop();
+    await Promise.all([...pumps].map((pump) => pump.closed));
+    await f.stop();
+    if (upstream) {
+      upstream.closeAllConnections();
+      await new Promise((resolve) => upstream.close(resolve));
+    }
+    if (directory) await rm(directory, { recursive: true, force: true });
+  });
+  return f;
+}

--- a/tests/journeys/turns.test.mjs
+++ b/tests/journeys/turns.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fixture, collect, deferred, reply, failure, text } from "./support.mjs";
+
+const f = fixture();
+
+test("string and structured input accumulate across suspended turns", { timeout: 30_000 }, async (t) => {
+  const session = await f.create(t);
+  await session.send("first");
+  await session.send({ message: "second" });
+  assert.deepEqual((await session.transcript()).messages.map(text), ["first", "answered", "second", "answered"]);
+  assert.equal((await collect(session.events())).filter(({ type }) => type === "session_resumed").length, 2);
+  await assert.rejects(session.send(""), TypeError);
+  await assert.rejects(session.send({ message: 1 }), TypeError);
+  assert.equal(f.modelRequests.length, 2);
+});
+
+test("resending an acknowledged message with its key never repeats the model effect", { timeout: 30_000 }, async (t) => {
+  const session = await f.create(t);
+  const operation = { idempotencyKey: "message-once" };
+  const first = await session.send("one answer", operation);
+  assert.deepEqual(await session.send({ message: "one answer" }, operation), first);
+  assert.equal(f.modelRequests.length, 1);
+  await assert.rejects(session.send("another answer", operation), failure(409));
+  assert.equal((await session.transcript()).messages.length, 2);
+});
+
+test("cancel a running turn, inspect its outcome, and explicitly send again", { timeout: 30_000 }, async (t) => {
+  const entered = deferred();
+  f.model = () => { entered.resolve(); };
+  const session = await f.create(t);
+  const pending = session.send("wait for cancellation").then((value) => ({ value }), (error) => ({ error }));
+  await entered.promise;
+  assert.equal((await f.brain.sessions.get(session.id)).state.status, "running");
+  await session.cancel({ idempotencyKey: "cancel-once" });
+  await session.cancel({ idempotencyKey: "cancel-once" });
+  await pending;
+  const events = await collect(session.events());
+  assert.ok(events.some(({ type }) => type === "turn_failed"));
+  assert.equal(f.modelRequests.length, 1);
+  f.model = (_request, response) => reply(response, "recovered");
+  await session.send("try a new turn");
+  assert.equal(text((await session.transcript()).messages.at(-1)), "recovered");
+});
+
+test("a client timeout does not silently retry or cancel server execution", { timeout: 30_000 }, async (t) => {
+  const entered = deferred();
+  const release = deferred();
+  f.model = async (_request, response) => { entered.resolve(); await release.promise; reply(response); };
+  const session = await f.create(t);
+  const impatient = await f.client({ timeoutMs: 500 }).sessions.get(session.id);
+  const pending = impatient.send("finish later").then(() => undefined, (error) => error);
+  await entered.promise;
+  const error = await pending;
+  assert.equal(error?.name, "TimeoutError");
+  assert.equal((await f.brain.sessions.get(session.id)).state.status, "running");
+  const completion = (async () => {
+    for await (const event of session.stream(0, AbortSignal.timeout(10_000))) if (event.type === "turn_ended") return;
+    assert.fail("stream ended without turn completion");
+  })();
+  release.resolve();
+  await completion;
+  assert.equal(f.modelRequests.length, 1);
+  assert.equal((await session.transcript()).messages.length, 2);
+});
+
+test("restart keeps history cold, and lost execution becomes an observation", { timeout: 30_000 }, async (t) => {
+  const session = await f.create(t);
+  await session.send("remember");
+  const saved = await session.transcript();
+  await f.stop();
+  await f.start();
+  const reopened = await f.client().sessions.get(session.id);
+  assert.deepEqual(await reopened.transcript(), saved);
+  assert.equal(f.modelRequests.length, 1);
+  const entered = deferred();
+  f.model = () => { entered.resolve(); };
+  const pending = reopened.send("unfinished").catch((error) => error);
+  await entered.promise;
+  await f.stop("SIGKILL");
+  await pending;
+  await f.start();
+  const events = await collect(reopened.events());
+  assert.ok(events.some(({ type, data }) => type === "turn_failed" && JSON.stringify(data).includes("interrupted")));
+  const recovered = await reopened.transcript();
+  assert.deepEqual(recovered.messages.slice(0, saved.messages.length), saved.messages);
+  assert.equal(text(recovered.messages.at(-1)), "unfinished");
+  assert.ok(recovered.through_sequence > saved.through_sequence);
+  assert.equal(f.modelRequests.length, 2);
+  f.model = (_request, response) => reply(response);
+  await reopened.send("continue explicitly");
+  assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("interrupted"));
+});


### PR DESCRIPTION
Add 38 public-SDK user journeys covering admission, session lifecycle, initial context and model configuration, idempotency, suspended history, events and live streams, resident and placed tools, cancellation, recovery, authentication, and transport errors. Run seven isolated suites with four files concurrently inside the existing Linux worker CI job, reusing its compiled artifacts. A coverage map and local command document the supported journeys.

The journeys found a real SDK defect: replaying session creation with resident tools threw after the server correctly returned the existing session. Preserve the existing handler registry, including cancellation of active calls. Advance the SDK patch to 0.17.1 and correct the documented Tool admission method. The local format remains brain-data/1.

Validation: all 38 journeys passed through real Brain/Wasmtime processes with no skipped tests or model credentials: roughly 19 seconds locally and 43 seconds in [CI](https://github.com/aexhq/brain/actions/runs/33970299602). SDK unit/example tests, clean-consumer package smoke, and all functional CI gates passed. CodeQL remains required before merge.
