### PR TITLE
docs: explain the runtime architecture and separate its roadmap

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -5,7 +5,7 @@
   ▀▀  ▀▀     |______/___|__|___|___|_______|__|____|
 </pre>
 
-<p align="center"><strong>极简、极速、可扩展的 agent 运行时。</strong></p>
+<p align="center"><strong>极简、分布式、可扩展的 agent 运行时。</strong></p>
 
 <p align="center">
   <a href="https://github.com/aexhq/brain/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/aexhq/brain/actions/workflows/ci.yml/badge.svg" /></a>
@@ -18,6 +18,7 @@
   <a href="https://aex.dev/brain/docs/reference/api">API 参考</a> ·
   <a href="https://aex.dev/brain">官网</a> ·
   <a href="https://github.com/aexhq/extensions">官方扩展</a> ·
+  <a href="ROADMAP.md">路线图</a> ·
   <a href="README.md">English</a>
 </p>
 
@@ -26,8 +27,8 @@
 
 ## 这是什么
 
-**Brain** 是一个持久化 agent 会话内核。Agentloop 决定一轮如何进行；Brain 管理唯一的会话日志、
-模型调用、工具分发、取消和结果。应用显式提供模型、Agentloop、工具与环境。
+**Brain** 是一个独立、极简、分布式、可扩展的 agent 运行时。应用通过小型公共接口组合 Agentloop、
+模型、工具和环境。同一会话可以调用多个环境中的工具；应用自行提供产品策略、调度和基础设施。
 
 - `component(urlOrBytes)` 包装已经编译好的 WebAssembly Component。Brain 接收原始 Wasm，
   不编译应用源码。
@@ -50,17 +51,39 @@ Brain 在发送外部副作用之前先把意图持久化提交，只发送一�
 常驻工具通过一条注册主机 SSE 连接接收命令。`ctx.emit(kind, data)` 把扩展事件提交到同一份日志，
 Promise 在提交完成后才返回。
 
-## 工作原理
+## 架构
 
-```text
-应用 <------ HTTP / SSE ------> Brain
-                              |
-                              +-- 每个会话一份规范日志
-                              +-- 模型提供商
-                              +-- Agentloop 环境
-                              +-- 工具环境
-                              `-- 常驻应用主机（SSE）
+Agentloop 控制上下文，决定何时调用模型或工具；Brain 协调执行并记录结果。
+同一会话可以使用原生工具、应用中的函数，以及多个远程环境中的工具。
+
+```mermaid
+flowchart TB
+  subgraph App["你的应用"]
+    Client["SDK / HTTP 客户端"]
+    Resident["常驻工具"]
+  end
+
+  subgraph Brain["Brain 运行时"]
+    Server["HTTP / SSE 服务器<br/>会话协调"]
+    Journal[("本地日志<br/>对话、slots 和事件")]
+    subgraph Worker["brainWasm 环境 · 独立 Wasmtime worker"]
+      Loop["Agentloop Component"]
+      Native["原生工具 Component"]
+    end
+    Server <-->|"提交 / 读取"| Journal
+    Server <-->|"激活 / host 调用"| Loop
+    Server <-->|"调用 / 结果"| Native
+  end
+
+  Client <-->|"HTTP / SSE"| Server
+  Server <-->|"host SSE / 结果"| Resident
+  Server <-->|"模型调用"| Models["模型提供商"]
+  Server <-->|"环境协议"| EnvA["环境 A<br/>工具与资源"]
+  Server <-->|"环境协议"| EnvB["环境 B<br/>工具与资源"]
 ```
+
+默认每轮结束后释放执行资源，对话与已记录事件仍可读取。环境提供方独立管理资源分配、TTL 和清理，
+会话挂起不会自动销毁或恢复环境资源。
 
 Brain 是基于 [Tokio](https://tokio.rs/) 的原生 Rust 二进制文件，用
 [Axum](https://github.com/tokio-rs/axum) 提供 HTTP 和 SSE API，本地部署无需外部存储。
@@ -125,20 +148,6 @@ const bound = custom({ env: brainWasm() });
 默认每轮结束后释放会话执行状态，重启时按需读取会话，不扫描所有对话日志。可重建的检查点加快恢复；
 已编译并预链接的 Wasm 模板跨调用复用，每次调用使用新的实例。原生工具拥有独立于 Agentloop 的并发容量。
 历史对比数据见 [BENCHMARKS.md](BENCHMARKS.md)，不能代表当前实现的性能承诺。
-
-## 路线图
-
-- [x] 最小、独立、可组合的运行时；Aex 与第三方使用相同接口
-- [x] 先提交后执行，不自动重试工具或环境操作
-- [x] 按需加载、每轮结束释放、可离线读取的会话记录和 transcript API
-- [x] Agentloop 事件分页读取、事件写入、每会话独立订阅
-- [x] 官方参考 Agentloop 将中断和环境故障交给模型；用户决定何时继续
-- [x] 显式绑定、预先准入、复用编译结果和预链接模板
-- [x] 环境按需分配并自行管理 TTL；重启不意味着恢复文件
-- [ ] MVP 后提供完整的 `tool-env` 工具、可变绑定和可选自动放置
-- [ ] 评估模型或工具等待期间释放计算资源的成本
-- [ ] 资源预算、公平调度，以及互不信任扩展的更强隔离
-- [ ] 可选外部提交服务和存储适配器；平台级持久工作流不属于 Brain
 
 ## 联系方式
 

--- a/README.cn.md
+++ b/README.cn.md
@@ -57,7 +57,7 @@ Agentloop 控制上下文，决定何时调用模型或工具；Brain 协调执�
 同一会话可以使用原生工具、应用中的函数，以及多个远程环境中的工具。
 
 ```mermaid
-flowchart TB
+flowchart LR
   subgraph App["你的应用"]
     Client["SDK / HTTP 客户端"]
     Resident["常驻工具"]
@@ -66,7 +66,7 @@ flowchart TB
   subgraph Brain["Brain 运行时"]
     Server["HTTP / SSE 服务器<br/>会话协调"]
     Journal[("本地日志<br/>对话、slots 和事件")]
-    subgraph Worker["brainWasm 环境 · 独立 Wasmtime worker"]
+    subgraph Worker["brainWasm · Wasmtime worker"]
       Loop["Agentloop Component"]
       Native["原生工具 Component"]
     end
@@ -76,7 +76,7 @@ flowchart TB
   end
 
   Client <-->|"HTTP / SSE"| Server
-  Server <-->|"host SSE / 结果"| Resident
+  Resident <-->|"host SSE / 结果"| Server
   Server <-->|"模型调用"| Models["模型提供商"]
   Server <-->|"环境协议"| EnvA["环境 A<br/>工具与资源"]
   Server <-->|"环境协议"| EnvB["环境 B<br/>工具与资源"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Environments. The Agentloop controls context and decides when to call the model 
 Brain coordinates execution and records the results.
 
 ```mermaid
-flowchart TB
+flowchart LR
   subgraph App["Your application"]
     Client["SDK / HTTP client"]
     Resident["Resident Tools"]
@@ -81,7 +81,7 @@ flowchart TB
   subgraph Brain["Brain runtime"]
     Server["HTTP / SSE server<br/>Session coordination"]
     Journal[("Local journal<br/>Transcript, slots and Events")]
-    subgraph Worker["brainWasm Environment · separate Wasmtime worker"]
+    subgraph Worker["brainWasm · Wasmtime worker"]
       Loop["Agentloop Component"]
       Native["Native Tool Components"]
     end
@@ -91,7 +91,7 @@ flowchart TB
   end
 
   Client <-->|"HTTP / SSE"| Server
-  Server <-->|"host SSE / results"| Resident
+  Resident <-->|"host SSE / results"| Server
   Server <-->|"model calls"| Models["Model providers"]
   Server <-->|"Environment protocol"| EnvA["Environment A<br/>Tools + resources"]
   Server <-->|"Environment protocol"| EnvB["Environment B<br/>Tools + resources"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   ▀▀  ▀▀     |______/___|__|___|___|_______|__|____|
 </pre>
 
-<p align="center"><strong>A minimal, blazing fast, extensible agent runtime.</strong></p>
+<p align="center"><strong>A minimal, distributed and extensible agent runtime</strong></p>
 
 <p align="center">
   <a href="https://github.com/aexhq/brain/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/aexhq/brain/actions/workflows/ci.yml/badge.svg" /></a>
@@ -18,6 +18,7 @@
   <a href="https://aex.dev/brain/docs/reference/api">API Reference</a> ·
   <a href="https://aex.dev/brain">Website</a> ·
   <a href="https://github.com/aexhq/extensions">Official extensions</a> ·
+  <a href="ROADMAP.md">Roadmap</a> ·
   <a href="README.cn.md">中文</a>
 </p>
 
@@ -27,8 +28,8 @@
 
 ## What is it
 
-**Brain** is a standalone, minimal, extensible agent runtime. Compose an Agentloop, Models, Tools,
-and Environments through small public interfaces. One session can invoke Tools in several execution
+**Brain** is a standalone, minimal, distributed and extensible agent runtime. Compose an Agentloop,
+Models, Tools, and Environments through small public interfaces. One session can invoke Tools in several execution
 Environments while keeping its transcript and canonical history locally accessible.
 
 It is for builders who need control over agent execution and want to assemble their own system:
@@ -64,35 +65,42 @@ Each native invocation is bounded by 10 billion Wasmtime fuel units for guest wo
 does not consume fuel, while the session's wall-time limit still bounds the complete turn.
 
 
-## How it works
+## Architecture
 
-This is one turn from start to finish. The Agentloop decides what to do next. Brain durably
-commits each external-effect intent before dispatch, sends it once, and streams live output while
-the turn is still running. Committed records and private state changes share one canonical journal;
-session status, transcript, Agentloop state, and the public event feed are projections of it.
+One session can use native Tools, functions in your application, and Tools in several remote
+Environments. The Agentloop controls context and decides when to call the model or dispatch Tools;
+Brain coordinates execution and records the results.
 
-```text
-                    +-------------------------------+
-   your app ------->| session state, in memory      |
-            <-------| live event feed               |
-                    +---------------+---------------+
-                                    | activate
-                                    v
-                    +-------------------------------+
-                    | agent loop, a Wasm component  |   
-                    +---------------+---------------+
-                                    | 
-                                    v
-                    +-------------------------------+        +-----------------+
-                    | Brain does the I/O            |<------>| canonical       |
-                    | for the loop                  | commit | journal         |
-                    +---------------+---------------+ result |                 |
-                                    |                        +-----------------+
-                                    +--> model provider, streaming
-                                    |
-                                    +--> placed tool, in its environment
-                                    `--> resident tool, over host SSE
+```mermaid
+flowchart TB
+  subgraph App["Your application"]
+    Client["SDK / HTTP client"]
+    Resident["Resident Tools"]
+  end
+
+  subgraph Brain["Brain runtime"]
+    Server["HTTP / SSE server<br/>Session coordination"]
+    Journal[("Local journal<br/>Transcript, slots and Events")]
+    subgraph Worker["brainWasm Environment · separate Wasmtime worker"]
+      Loop["Agentloop Component"]
+      Native["Native Tool Components"]
+    end
+    Server <-->|"commit / read"| Journal
+    Server <-->|"activate / host calls"| Loop
+    Server <-->|"invoke / result"| Native
+  end
+
+  Client <-->|"HTTP / SSE"| Server
+  Server <-->|"host SSE / results"| Resident
+  Server <-->|"model calls"| Models["Model providers"]
+  Server <-->|"Environment protocol"| EnvA["Environment A<br/>Tools + resources"]
+  Server <-->|"Environment protocol"| EnvB["Environment B<br/>Tools + resources"]
 ```
+
+Brain commits each external-effect intent before dispatch and sends it once. The local journal
+retains session state; execution is released after each turn by default. Transcripts and recorded
+Events remain readable while execution is suspended. Environment providers own resource allocation,
+TTL, and cleanup independently of session execution.
 
 Brain owns the session. You supply the agent loop, the model, the tools, and the environment.
 Three design choices make it fast:
@@ -172,65 +180,6 @@ independent of waiting Agentloops. These properties are covered by regression te
 The earlier comparison numbers describe an older execution/storage design. See [BENCHMARKS.md](BENCHMARKS.md)
 for their provenance and [the benchmark guide](docs/reference/benchmarks.mdx) for current measurements
 and limits. New-session latency, whole-process memory, and resume cost must be measured together.
-
-## Roadmap
-
-- [x] The four-part runtime: agent loop, model, tools, environment
-- [x] Raw WebAssembly Components supplied with `component(...)`
-- [x] Explicit Agentloop and Tool placement with `{ env, ...options }`
-- [x] One canonical per-session journal with disposable projections
-- [x] Effect-after-commit with no automatic retries
-- [x] Logical Environment setup/attachment; providers own lazy allocation and resource TTL
-- [x] Typed content identity
-- [x] HTTP/SSE session API and the `@aexhq/brain` SDK
-- [x] Remote Environment contract and `env-aws-microvm`
-- [x] `brainWasm` placement with deployment-granted HTTP, secrets, scratch, and workspace access
-- [x] Resident Tool host over SSE with durable `ctx.emit`
-- [x] Cross-session native workspace isolation test
-- [ ] Native subagent support, parent and child links between sessions
-- [ ] Post-MVP official `tool-env` Tool extension: inspect the session's Tool bindings and Environment
-  status, expose failures to the Agentloop for model-directed recovery, and request binding
-  changes and supported Environment lifecycle operations such as restart within explicitly
-  granted session authority; journal mutations and their outcomes
-- [ ] Post-MVP mutable Tool and Environment bindings: committed changes apply to subsequent calls,
-  including within a turn; already-dispatched calls retain their original target. MVP Tools require
-  explicit execution bindings, fixed at session creation
-- [ ] Post-MVP optional Brain-selected execution placement for Tools without an explicit
-  Environment binding, within caller-granted authority; MVP placement remains explicit
-- [x] Official Agentloop extensions expose Tool failures, Environment status, expiry, and
-  resource loss to the model; Agentloop policy decides recovery without runtime retries
-- [x] Record interrupted turns as session Events that Agentloops can read and include in their
-  transcripts; the user decides the next action, with explicit activation and no automatic retries
-- [x] Agentloop APIs to read session Events and append extension Events through the existing
-  emit interface, with history readable while execution is suspended; host imports run only during an activation
-- [x] Cheap suspension at turn boundaries with transcript and recorded Events readable from
-  disk without activating the Agentloop; load sessions on demand after a process restart
-- [ ] Evaluate releasing Agentloop memory while awaiting model or Tool results, keeping the
-  extension authoring interface simple and measuring continuation costs before adopting it
-- [x] Separate extension artifact admission and compilation from session creation; reuse
-  compatible compiled artifacts and invocation templates
-- [x] Environment extensions can prepare resources lazily on invocation and own TTL and cleanup
-  policy; attach need not provision compute, and expired resources need not be restored
-- [x] Per-session live subscriptions, independent of Agentloop activation
-- [ ] Post-MVP configurable resource admission, memory and compiled-code cache budgets, and
-  fair scheduling for deployments running mutually untrusted extensions
-- [ ] Optional worker isolation integrations such as gVisor or MicroVMs for deployments needing
-  an additional boundary around Wasm execution
-- [ ] Multimodal input, images and files on `send`
-- [ ] Freeze a v1 API with tagged releases
-- [ ] File access and workspace sync
-- [ ] crates.io publication
-- [ ] Sessions spread across machines sharing environments
-- [ ] Session export and import
-- [ ] Custom images with scoped credentials and network metering
-- [ ] Local environment: run tools in a directory or container on your own machine
-- [ ] Browser environment and DOM tools: a page as the place tools run
-- [ ] Post-MVP public storage/commit interfaces for optional external stores and commit services,
-  preserving acknowledged-record and commit-before-effect guarantees; the default remains local
-  and self-contained. Shared ownership, node-loss recovery, backup, and regional recovery belong
-  to extensions and consuming platforms
-- [ ] Post-MVP bounded client reorder buffer if parallel delivery can emit committed Events out of
-  journal sequence; replay repairs gaps
 
 ## Contact
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,62 @@
+# Roadmap
+
+Brain is a standalone runtime. Applications and extensions supply product policy and infrastructure.
+The MVP keeps Tool and Environment bindings explicit and fixed at session creation.
+
+- [x] The four-part runtime: agent loop, model, tools, environment
+- [x] Raw WebAssembly Components supplied with `component(...)`
+- [x] Explicit Agentloop and Tool placement with `{ env, ...options }`
+- [x] One canonical per-session journal with disposable projections
+- [x] Effect-after-commit with no automatic retries
+- [x] Logical Environment setup/attachment; providers own lazy allocation and resource TTL
+- [x] Typed content identity
+- [x] HTTP/SSE session API and the `@aexhq/brain` SDK
+- [x] Remote Environment contract and `env-aws-microvm`
+- [x] `brainWasm` placement with deployment-granted HTTP, secrets, scratch, and workspace access
+- [x] Resident Tool host over SSE with durable `ctx.emit`
+- [x] Cross-session native workspace isolation test
+- [x] Public SDK user journeys against real servers and workers, with isolated suites running in parallel
+- [ ] Native subagent support, parent and child links between sessions
+- [ ] Post-MVP official `tool-env` Tool extension: inspect the session's Tool bindings and Environment
+  status, expose failures to the Agentloop for model-directed recovery, and request binding
+  changes and supported Environment lifecycle operations such as restart within explicitly
+  granted session authority; journal mutations and their outcomes
+- [ ] Post-MVP mutable Tool and Environment bindings: committed changes apply to subsequent calls,
+  including within a turn; already-dispatched calls retain their original target. MVP Tools require
+  explicit execution bindings, fixed at session creation
+- [ ] Post-MVP optional Brain-selected execution placement for Tools without an explicit
+  Environment binding, within caller-granted authority; MVP placement remains explicit
+- [x] Official Agentloop extensions expose Tool failures, Environment status, expiry, and
+  resource loss to the model; Agentloop policy decides recovery without runtime retries
+- [x] Record interrupted turns as session Events that Agentloops can read and include in their
+  transcripts; the user decides the next action, with explicit activation and no automatic retries
+- [x] Agentloop APIs to read session Events and append extension Events through the existing
+  emit interface, with history readable while execution is suspended; host imports run only during an activation
+- [x] Cheap suspension at turn boundaries with transcript and recorded Events readable from
+  disk without activating the Agentloop; load sessions on demand after a process restart
+- [ ] Evaluate releasing Agentloop memory while awaiting model or Tool results, keeping the
+  extension authoring interface simple and measuring continuation costs before adopting it
+- [x] Separate extension artifact admission and compilation from session creation; reuse
+  compatible compiled artifacts and invocation templates
+- [x] Environment extensions can prepare resources lazily on invocation and own TTL and cleanup
+  policy; attach need not provision compute, and expired resources need not be restored
+- [x] Per-session live subscriptions, independent of Agentloop activation
+- [ ] Post-MVP configurable resource admission, memory and compiled-code cache budgets, and
+  fair scheduling for deployments running mutually untrusted extensions
+- [ ] Optional worker isolation integrations such as gVisor or MicroVMs for deployments needing
+  an additional boundary around Wasm execution
+- [ ] Multimodal input, images and files on `send`
+- [ ] Freeze a v1 API with tagged releases
+- [ ] File access and workspace sync
+- [ ] crates.io publication
+- [ ] Sessions spread across machines sharing environments
+- [ ] Session export and import
+- [ ] Custom images with scoped credentials and network metering
+- [ ] Local environment: run tools in a directory or container on your own machine
+- [ ] Browser environment and DOM tools: a page as the place tools run
+- [ ] Post-MVP public storage/commit interfaces for optional external stores and commit services,
+  preserving acknowledged-record and commit-before-effect guarantees; the default remains local
+  and self-contained. Shared ownership, node-loss recovery, backup, and regional recovery belong
+  to extensions and consuming platforms
+- [ ] Post-MVP bounded client reorder buffer if parallel delivery can emit committed Events out of
+  journal sequence; replay repairs gaps


### PR DESCRIPTION
Use the headline "A minimal, distributed and extensible agent runtime" and show the current architecture with a Mermaid diagram: application, Brain server, canonical journal, separate Wasmtime worker, model providers, and distributed Tool environments.

Move the complete roadmap to ROADMAP.md and link it from the English and Chinese READMEs. Keep the Chinese product description and architecture in sync. All existing roadmap items are preserved, with the shipped parallel SDK journeys added.

Validation: both Mermaid diagrams rendered and visually checked; relative links and preservation of every existing roadmap entry checked. Normal repository CI and CodeQL run for this change.
