### PR TITLE
test: verify current HTTP and SDK release fixtures in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,12 @@ jobs:
           BRAIN_TEST_TOOL_COMPONENT: ${{ runner.temp }}/diagnostic-tool.wasm
           BRAIN_TEST_REFERENCE_AGENTLOOP: ${{ runner.temp }}/reference-agentloop.wasm
         run: npm run test:journeys
+      - name: Verify every package release fixture before publication
+        env:
+          BRAIN_TEST_SERVER: ${{ github.workspace }}/target/debug/brain
+          BRAIN_TEST_WORKER: ${{ github.workspace }}/target/debug/brain-env-worker
+          BRAIN_TEST_AGENTLOOP_PACKAGE: ${{ runner.temp }}/diagnostic-agentloop.wasm
+        run: bash tools/check-release-fixtures.sh
 
   image-smoke:
     runs-on: ubuntu-24.04

--- a/tests/release/http-contract.mjs
+++ b/tests/release/http-contract.mjs
@@ -70,7 +70,7 @@ const admission = await call("GET", `/v1/agentloops/${admitted.result.id}`);
 assert.deepEqual(admission.result, admitted.result);
 
 const createBody = {
-  agentloop: { id: admitted.result.id, configuration: {}, environment: "brain" },
+  agentloop: { implementation: { type: "brain_component", entrypoint: "turn", id: admitted.result.id }, configuration: {}, environment: "brain" },
   model: { provider: "vercel-ai-gateway", name: "openai/gpt-5-mini", api_key: "release-smoke-key" },
   tools: [],
   environments: [{ name: "brain", driver: "brain" }],

--- a/tests/release/http.mjs
+++ b/tests/release/http.mjs
@@ -38,7 +38,7 @@ const admission = await request(
 );
 assert.equal(admission.status, "admitted");
 const session = await request("POST", "/v1/sessions", {
-  agentloop: { id: admission.id, configuration: {}, environment: "brain" },
+  agentloop: { implementation: { type: "brain_component", entrypoint: "turn", id: admission.id }, configuration: {}, environment: "brain" },
   model: {
     provider: "vercel-ai-gateway",
     name: "openai/gpt-5-mini",

--- a/tools/check-release-fixtures.sh
+++ b/tools/check-release-fixtures.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(cd "$(dirname "$0")/.." && pwd)
+work=$(mktemp -d "$root/target/release-fixtures.XXXXXX")
+data=$(mktemp -d)
+server_pid=
+cleanup() {
+  if [[ -n "$server_pid" ]]; then kill "$server_pid" 2>/dev/null || true; wait "$server_pid" || true; fi
+  rm -rf "$work" "$data"
+}
+trap cleanup EXIT
+cp "$root"/tests/release/{sdk,http,sdk-turns,sdk-events,http-contract}.mjs "$work/"
+cp "${BRAIN_TEST_AGENTLOOP_PACKAGE:?}" "$work/diagnostic-agentloop.wasm"
+export BRAIN_API_TOKEN=release-fixture-token
+export BRAIN_BASE_URL=http://127.0.0.1:18089
+BRAIN_LISTEN=127.0.0.1:18089 BRAIN_DATA_DIR="$data" BRAIN_ENV_WORKER="${BRAIN_TEST_WORKER:?}" \
+  "${BRAIN_TEST_SERVER:?}" > "$work/server.log" 2>&1 &
+server_pid=$!
+for attempt in $(seq 1 120); do
+  if curl --fail --silent "$BRAIN_BASE_URL/health/ready" >/dev/null; then break; fi
+  if [[ "$attempt" == 120 ]]; then cat "$work/server.log"; exit 1; fi
+  sleep 0.1
+done
+for fixture in sdk http sdk-turns sdk-events http-contract; do
+  timeout 120 node "$work/$fixture.mjs"
+done


### PR DESCRIPTION
Update both raw-HTTP release clients to declare the native Agentloop implementation descriptor. Run all five SDK/HTTP publication fixtures in normal CI, using the already-built server and diagnostic Component, so release-only contract drift is caught before publishing.

Validation: all five release fixtures pass against the built Linux server. Runtime behavior and package version are unchanged; this replaces the pending release source before npm publication.
