### PR TITLE
env: run the worker process natively on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,23 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.97.1"
+          targets: wasm32-wasip2
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-targets
+      - name: Build the diagnostic Components
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --manifest-path tests/fixtures/diagnostic-agentloop/Cargo.toml --target wasm32-wasip2 --release
+          cargo build --manifest-path tests/fixtures/diagnostic-tool/Cargo.toml --target wasm32-wasip2 --release
+          cargo build --manifest-path examples/reference-agentloop/Cargo.toml --target wasm32-wasip2 --release
+      - name: Admit and activate through the real worker process
+        shell: bash
+        env:
+          BRAIN_TEST_AGENTLOOP_PACKAGE: ${{ github.workspace }}/tests/fixtures/diagnostic-agentloop/target/wasm32-wasip2/release/diagnostic_agentloop.wasm
+          BRAIN_TEST_TOOL_COMPONENT: ${{ github.workspace }}/tests/fixtures/diagnostic-tool/target/wasm32-wasip2/release/diagnostic_tool.wasm
+          BRAIN_TEST_REFERENCE_AGENTLOOP: ${{ github.workspace }}/examples/reference-agentloop/target/wasm32-wasip2/release/reference_agentloop.wasm
+        run: cargo test -p brain-env --features integration-tests --test worker_process
 
   brain-env:
     needs: changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/brain-env/Cargo.toml
+++ b/crates/brain-env/Cargo.toml
@@ -46,6 +46,9 @@ wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
+
 [dev-dependencies]
 # Builds the smallest possible runaway guest for the fuel-exhaustion test. Already in the
 # lock file as a Wasmtime component dependency, so it costs no new crate.

--- a/crates/brain-env/src/client.rs
+++ b/crates/brain-env/src/client.rs
@@ -3,7 +3,6 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use brain_protocol::{AgentloopId, ToolId, TurnError, TurnInput, TurnOutput};
 
-#[cfg(unix)]
 use crate::wire::{max_request_bytes, read_frame, write_frame};
 use crate::{
     ComponentKind, EnvLimits, HostCall, LoopError, NativeEnvironment, NativeToolInput,
@@ -24,7 +23,6 @@ pub trait TurnBridge: Send + Sync {
 #[derive(Clone, Debug)]
 pub struct WorkerClient {
     socket: PathBuf,
-    #[cfg_attr(not(unix), allow(dead_code))]
     limits: EnvLimits,
 }
 
@@ -112,7 +110,6 @@ impl WorkerClient {
 
     /// Callback waits do not consume the worker liveness budget. Cancellation uses
     /// the same connection without dropping a partially read response frame.
-    #[cfg(unix)]
     async fn execute(
         &self,
         kind: ComponentKind,
@@ -122,7 +119,7 @@ impl WorkerClient {
         bridge: &dyn TurnBridge,
     ) -> Result<serde_json::Value, LoopError> {
         let liveness = self.limits.worker_liveness();
-        let mut stream = tokio::net::UnixStream::connect(&self.socket)
+        let mut stream = crate::socket::connect(&self.socket)
             .await
             .map_err(|error| error.to_string())?;
         write_frame(
@@ -144,7 +141,7 @@ impl WorkerClient {
                 error
             }
         })?;
-        let (mut reader, mut writer) = stream.split();
+        let (mut reader, mut writer) = tokio::io::split(stream);
         let mut cancelled = false;
         let mut poll = tokio::time::interval(std::time::Duration::from_millis(50));
         poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -207,23 +204,10 @@ impl WorkerClient {
         }
     }
 
-    #[cfg(not(unix))]
-    async fn execute(
-        &self,
-        _kind: ComponentKind,
-        _digest: String,
-        _environment: NativeEnvironment,
-        _input: serde_json::Value,
-        _bridge: &dyn TurnBridge,
-    ) -> Result<serde_json::Value, LoopError> {
-        Err("brain-env-worker IPC requires Unix domain sockets".into())
-    }
-
-    #[cfg(unix)]
     async fn call(&self, request: WorkerRequest) -> Result<WorkerResponse, String> {
         let max = max_request_bytes(&request, &self.limits);
         let response = async {
-            let mut stream = tokio::net::UnixStream::connect(&self.socket)
+            let mut stream = crate::socket::connect(&self.socket)
                 .await
                 .map_err(|error| error.to_string())?;
             write_frame(&mut stream, &request, max).await?;
@@ -232,10 +216,5 @@ impl WorkerClient {
         tokio::time::timeout(self.limits.worker_liveness(), response)
             .await
             .map_err(|_| "brain-env-worker stopped answering".to_owned())?
-    }
-
-    #[cfg(not(unix))]
-    async fn call(&self, _request: WorkerRequest) -> Result<WorkerResponse, String> {
-        Err("brain-env-worker IPC requires Unix domain sockets".into())
     }
 }

--- a/crates/brain-env/src/lib.rs
+++ b/crates/brain-env/src/lib.rs
@@ -6,6 +6,7 @@ pub use environment::{BrainEnvironment, NativePolicy};
 mod limits;
 mod runtime;
 mod service;
+mod socket;
 mod supervisor;
 mod wire;
 
@@ -13,6 +14,7 @@ pub use client::{TurnBridge, WorkerClient};
 pub use limits::{EnvLimits, WorkerArgs};
 pub use runtime::{AdmissionEngine, AdmittedAgentloop, AdmittedTool, GuestHost, NativeToolInput};
 pub use service::WorkerService;
+pub use socket::{Listener, listen};
 pub use supervisor::{LoopError, WorkerPool};
 pub use wire::{
     Access, ComponentKind, HostCall, NativeEnvironment, WorkerRequest, WorkerResponse, Workspace,

--- a/crates/brain-env/src/socket.rs
+++ b/crates/brain-env/src/socket.rs
@@ -1,0 +1,108 @@
+//! The local socket between the server and its worker processes.
+//!
+//! Both sides address the socket by a filesystem path. On Unix that is a Unix domain socket
+//! at the path; on Windows it is a named pipe whose name is derived from the path, since a
+//! pipe cannot live inside a directory. Either way the stream is a byte stream that
+//! [`crate::wire`] frames.
+
+use std::io;
+use std::path::Path;
+
+#[cfg(unix)]
+pub(crate) type Stream = tokio::net::UnixStream;
+#[cfg(windows)]
+pub(crate) type Stream = tokio::net::windows::named_pipe::NamedPipeClient;
+
+#[cfg(unix)]
+pub(crate) async fn connect(path: &Path) -> io::Result<Stream> {
+    tokio::net::UnixStream::connect(path).await
+}
+
+/// A pipe server instance answers one client; between one client's connection and the next
+/// instance's creation a connect attempt sees `ERROR_PIPE_BUSY`, and the caller retries as
+/// Windows documents.
+#[cfg(windows)]
+pub(crate) async fn connect(path: &Path) -> io::Result<Stream> {
+    use tokio::net::windows::named_pipe::ClientOptions;
+
+    const ERROR_PIPE_BUSY: i32 = 231;
+    let name = pipe_name(path);
+    loop {
+        match ClientOptions::new().open(&name) {
+            Err(error) if error.raw_os_error() == Some(ERROR_PIPE_BUSY) => {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            outcome => return outcome,
+        }
+    }
+}
+
+/// Serves the socket at the path, replacing whatever a previous worker left there.
+pub fn listen(path: &Path) -> io::Result<Listener> {
+    unlink(path)?;
+    Listener::bind(path)
+}
+
+/// Removes whatever a previous worker left at the path so a new one can bind it.
+pub(crate) fn unlink(path: &Path) -> io::Result<()> {
+    if cfg!(unix) && path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub struct Listener(tokio::net::UnixListener);
+
+#[cfg(unix)]
+impl Listener {
+    fn bind(path: &Path) -> io::Result<Self> {
+        tokio::net::UnixListener::bind(path).map(Self)
+    }
+
+    pub async fn accept(&mut self) -> io::Result<tokio::net::UnixStream> {
+        self.0.accept().await.map(|(stream, _)| stream)
+    }
+}
+
+/// Named pipes have one server instance per client, so accepting means handing out the
+/// instance a client connected to and creating the next one.
+#[cfg(windows)]
+pub struct Listener {
+    name: String,
+    next: tokio::net::windows::named_pipe::NamedPipeServer,
+}
+
+#[cfg(windows)]
+impl Listener {
+    fn bind(path: &Path) -> io::Result<Self> {
+        use tokio::net::windows::named_pipe::ServerOptions;
+
+        let name = pipe_name(path);
+        let next = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&name)?;
+        Ok(Self { name, next })
+    }
+
+    pub async fn accept(&mut self) -> io::Result<tokio::net::windows::named_pipe::NamedPipeServer> {
+        use tokio::net::windows::named_pipe::ServerOptions;
+
+        self.next.connect().await?;
+        let following = ServerOptions::new().create(&self.name)?;
+        Ok(std::mem::replace(&mut self.next, following))
+    }
+}
+
+/// A pipe name is one flat namespace with a length limit, so the path is hashed into it.
+#[cfg(windows)]
+fn pipe_name(path: &Path) -> String {
+    use sha2::{Digest as _, Sha256};
+
+    let digest = Sha256::digest(path.to_string_lossy().as_bytes());
+    let hex: String = digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    format!(r"\\.\pipe\brain-env-{hex}")
+}

--- a/crates/brain-env/src/supervisor.rs
+++ b/crates/brain-env/src/supervisor.rs
@@ -1,4 +1,3 @@
-#[cfg(unix)]
 use std::process::Stdio;
 use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
@@ -193,7 +192,6 @@ struct WorkerState {
     incarnation: u64,
     agentloops: HashSet<AgentloopId>,
     tools: HashSet<ToolId>,
-    #[cfg(unix)]
     child: Option<tokio::process::Child>,
 }
 
@@ -371,7 +369,6 @@ impl WorkerSlot {
         }
     }
 
-    #[cfg(unix)]
     async fn ensure_worker(&self, state: &mut WorkerState) -> Result<(), String> {
         let exited = match state.child.as_mut() {
             Some(child) => child
@@ -388,17 +385,26 @@ impl WorkerSlot {
                     .map_err(|error| error.to_string())?;
                 secure_worker_directory(parent).await?;
             }
-            let _ = tokio::fs::remove_file(&self.socket).await;
-            let child = tokio::process::Command::new(&self.worker_binary)
+            crate::socket::unlink(&self.socket).map_err(|error| error.to_string())?;
+            let mut command = tokio::process::Command::new(&self.worker_binary);
+            command
                 .arg(&self.socket)
                 .args(self.limits.args())
-                .env_clear()
+                .env_clear();
+            // Winsock refuses to initialise in a process without SystemRoot.
+            #[cfg(windows)]
+            if let Some(root) = std::env::var_os("SystemRoot") {
+                command.env("SystemRoot", root);
+            }
+            let child = command
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .kill_on_drop(true)
                 .spawn()
                 .map_err(|error| format!("failed to start brain-env-worker: {error}"))?;
+            #[cfg(windows)]
+            tie_to_this_process(&child)?;
             state.child = Some(child);
             state.incarnation = state.incarnation.wrapping_add(1);
             state.agentloops.clear();
@@ -428,13 +434,6 @@ impl WorkerSlot {
         Ok(())
     }
 
-    #[cfg(not(unix))]
-    async fn ensure_worker(&self, _state: &mut WorkerState) -> Result<(), String> {
-        let _ = &self.worker_binary;
-        Err("brain-env-worker requires a Unix server".into())
-    }
-
-    #[cfg(unix)]
     async fn stop_worker(&self, state: &mut WorkerState) {
         if let Some(mut child) = state.child.take() {
             let _ = child.kill().await;
@@ -442,13 +441,7 @@ impl WorkerSlot {
         }
         state.agentloops.clear();
         state.tools.clear();
-        let _ = tokio::fs::remove_file(&self.socket).await;
-    }
-
-    #[cfg(not(unix))]
-    async fn stop_worker(&self, state: &mut WorkerState) {
-        state.agentloops.clear();
-        state.tools.clear();
+        let _ = crate::socket::unlink(&self.socket);
     }
 }
 
@@ -459,6 +452,71 @@ async fn secure_worker_directory(path: &std::path::Path) -> Result<(), String> {
     tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
         .await
         .map_err(|error| format!("failed to restrict worker socket directory: {error}"))
+}
+
+/// A named pipe is not in the directory. Its default security descriptor already gives
+/// other users read access only, so they cannot send the worker a request.
+#[cfg(not(unix))]
+async fn secure_worker_directory(_path: &std::path::Path) -> Result<(), String> {
+    Ok(())
+}
+
+/// Windows has no process group to kill with. A job object that kills on close ties every
+/// worker to this process however it ends; the handle is closed by the process's death.
+#[cfg(windows)]
+fn tie_to_this_process(child: &tokio::process::Child) -> Result<(), String> {
+    use std::sync::OnceLock;
+
+    use windows_sys::Win32::{
+        Foundation::HANDLE,
+        System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+            SetInformationJobObject,
+        },
+    };
+
+    struct Job(HANDLE);
+    // SAFETY: a job handle is a kernel object reference usable from any thread.
+    unsafe impl Send for Job {}
+    unsafe impl Sync for Job {}
+    static JOB: OnceLock<Result<Job, String>> = OnceLock::new();
+
+    let job = JOB
+        .get_or_init(|| {
+            // SAFETY: plain Win32 calls with a zeroed, correctly sized information block.
+            unsafe {
+                let handle = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+                if handle.is_null() {
+                    return Err(std::io::Error::last_os_error().to_string());
+                }
+                let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+                limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                if SetInformationJobObject(
+                    handle,
+                    JobObjectExtendedLimitInformation,
+                    (&raw const limits).cast(),
+                    size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+                ) == 0
+                {
+                    return Err(std::io::Error::last_os_error().to_string());
+                }
+                Ok(Job(handle))
+            }
+        })
+        .as_ref()
+        .map_err(|error| format!("failed to create the worker job object: {error}"))?;
+    let process = child
+        .raw_handle()
+        .ok_or("brain-env-worker exited before it could join the job object")?;
+    // SAFETY: both handles are live; the child handle is owned by `child`.
+    if unsafe { AssignProcessToJobObject(job.0, process.cast()) } == 0 {
+        return Err(format!(
+            "failed to tie brain-env-worker to this process: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
 }
 
 async fn persist_component(
@@ -472,15 +530,15 @@ async fn persist_component(
         .map_err(|error| error.to_string())?;
     let target = component_path(directory, kind, digest);
     let temporary = directory.join(format!(".{kind}-{digest}.tmp"));
-    tokio::fs::write(&temporary, package)
+    // One writable handle writes and syncs: Windows refuses to flush a read-only one.
+    let mut file = tokio::fs::File::create(&temporary)
         .await
         .map_err(|error| error.to_string())?;
-    tokio::fs::File::open(&temporary)
-        .await
-        .map_err(|error| error.to_string())?
-        .sync_all()
+    tokio::io::AsyncWriteExt::write_all(&mut file, package)
         .await
         .map_err(|error| error.to_string())?;
+    file.sync_all().await.map_err(|error| error.to_string())?;
+    drop(file);
     tokio::fs::rename(&temporary, &target)
         .await
         .map_err(|error| error.to_string())?;

--- a/crates/brain-env/src/wire.rs
+++ b/crates/brain-env/src/wire.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-#[cfg(unix)]
 use crate::EnvLimits;
 
 /// What the guest asks Brain to do. Every payload is JSON in the shapes the
@@ -184,7 +183,6 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin, T: for<'de> Deserialize<'de
     serde_json::from_slice(&payload).map_err(|error| error.to_string())
 }
 
-#[cfg(unix)]
 pub(crate) fn max_request_bytes(request: &WorkerRequest, limits: &EnvLimits) -> usize {
     match request {
         WorkerRequest::Ping | WorkerRequest::Cancel => 1_024,

--- a/crates/brain-env/src/worker/main.rs
+++ b/crates/brain-env/src/worker/main.rs
@@ -1,23 +1,18 @@
-//! The Agentloop worker process: a Unix socket in front of [`WorkerService`].
+//! The Agentloop worker process: a local socket in front of [`WorkerService`].
 //!
 //! Every connection is served on its own task, so one long activation does not hold up
 //! the sessions behind it. What runs at once is bounded inside the service, where the
 //! Wasm instances actually live.
 
-#[cfg(unix)]
+use std::sync::Arc;
+
+use brain_env::{CAPABILITY_IMPORTS, RUNTIME_SHIM_IMPORTS, WorkerArgs, WorkerService};
+use clap::Parser as _;
+
 #[tokio::main]
 async fn main() -> Result<(), String> {
-    use std::sync::Arc;
-
-    use brain_env::{CAPABILITY_IMPORTS, RUNTIME_SHIM_IMPORTS, WorkerArgs, WorkerService};
-    use clap::Parser as _;
-    use tokio::net::UnixListener;
-
     let WorkerArgs { socket, limits } = WorkerArgs::parse();
-    if socket.exists() {
-        std::fs::remove_file(&socket).map_err(|error| error.to_string())?;
-    }
-    let listener = UnixListener::bind(&socket).map_err(|error| error.to_string())?;
+    let mut listener = brain_env::listen(&socket).map_err(|error| error.to_string())?;
     let service = Arc::new(WorkerService::new(
         limits,
         RUNTIME_SHIM_IMPORTS
@@ -28,14 +23,8 @@ async fn main() -> Result<(), String> {
     )?);
 
     loop {
-        let (mut stream, _) = listener.accept().await.map_err(|error| error.to_string())?;
+        let mut stream = listener.accept().await.map_err(|error| error.to_string())?;
         let service = service.clone();
         tokio::spawn(async move { service.serve(&mut stream).await });
     }
-}
-
-#[cfg(not(unix))]
-fn main() {
-    eprintln!("brain-env-worker supports Linux and other Unix servers only");
-    std::process::exit(2);
 }

--- a/crates/brain-env/tests/worker_process.rs
+++ b/crates/brain-env/tests/worker_process.rs
@@ -1,5 +1,3 @@
-#![cfg(unix)]
-
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},
@@ -618,9 +616,9 @@ async fn host_calls_queued_before_cancel_are_not_answered_after_cancel() {
 
     let directory = tempfile::tempdir().unwrap();
     let socket = directory.path().join("worker.sock");
-    let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+    let mut listener = brain_env::listen(&socket).unwrap();
     let worker = tokio::spawn(async move {
-        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut stream = listener.accept().await.unwrap();
         assert!(matches!(
             brain_env::worker_read(&mut stream, &EnvLimits::default())
                 .await

--- a/tests/journeys/README.md
+++ b/tests/journeys/README.md
@@ -45,5 +45,7 @@ export BRAIN_TEST_REFERENCE_AGENTLOOP="$PWD/examples/reference-agentloop/target/
 npm run test:journeys
 ```
 
-Missing binaries or Components fail the suite; no journeys are conditionally skipped. Use WSL for
-these Linux process/worker tests on Windows. Portable SDK unit tests still run with `npm test`.
+Missing binaries or Components fail the suite; no journeys are conditionally skipped. The server
+and worker run natively on Windows too (the worker listens on a named pipe there), but the journey
+harness stops servers by process group, so run the journeys themselves in WSL on Windows. Portable
+SDK unit tests still run with `npm test`.


### PR DESCRIPTION
## Summary

- The only Unix-only piece of Brain was the worker IPC: Windows builds compiled but every admission failed with "brain-env-worker requires a Unix server". A new `socket` module serves both platforms: a Unix domain socket at the path on Unix, a named pipe derived from the path on Windows. All `cfg(unix)` stubs in the client, supervisor, wire, and worker binary are removed, and `tests/worker_process.rs` builds on every target (the crash test that uses `kill -KILL` and `/proc` stays Linux-only).
- Two faults only a real Windows run exposed: persisting an admitted package reopened the file read-only to fsync it, which Windows rejects with "Access is denied"; it now syncs on the write handle. Terminating the server hard orphaned its workers, since `kill_on_drop` never runs; each worker now joins a kill-on-close Job Object, and the cleared child environment gets `SystemRoot` back so Winsock can initialise.
- The `rust-platforms` CI job (windows-2025, macos-15) now builds the wasm fixtures and runs `worker_process` with `--features integration-tests`.
- Journeys README states what runs natively on Windows and what still needs WSL (the journey harness stops servers by process group; the Python fixture build is bash).

## Test plan

| Gate | Windows | Linux (WSL, rustc 1.97.1) |
| --- | --- | --- |
| `cargo test --workspace --all-targets` | green | green |
| `worker_process` against the spawned worker | 7/7 | 8/8 |
| `cargo fmt --check` + clippy `-D warnings`, incl. `integration-tests` | clean | clean |
| `node tests/release/runtime.mjs` against `target/debug/brain.exe` | passed | n/a |
| `brain-env-worker.exe` left after the server is terminated | 0 | n/a |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
