### PR TITLE
env: split the Wasmtime host into brain-env-worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
           BRAIN_TEST_AGENTLOOP_PACKAGE: ${{ github.workspace }}/tests/fixtures/diagnostic-agentloop/target/wasm32-wasip2/release/diagnostic_agentloop.wasm
           BRAIN_TEST_TOOL_COMPONENT: ${{ github.workspace }}/tests/fixtures/diagnostic-tool/target/wasm32-wasip2/release/diagnostic_tool.wasm
           BRAIN_TEST_REFERENCE_AGENTLOOP: ${{ github.workspace }}/examples/reference-agentloop/target/wasm32-wasip2/release/reference_agentloop.wasm
-        run: cargo test -p brain-env --features integration-tests --test worker_process
+        run: cargo test -p brain-env-worker --features integration-tests --test worker_process
 
   brain-env:
     needs: changes
@@ -188,14 +188,14 @@ jobs:
           BRAIN_TEST_AGENTLOOP_PACKAGE: ${{ runner.temp }}/diagnostic-agentloop.wasm
           BRAIN_TEST_TOOL_COMPONENT: ${{ runner.temp }}/diagnostic-tool.wasm
           BRAIN_TEST_REFERENCE_AGENTLOOP: ${{ runner.temp }}/reference-agentloop.wasm
-        run: cargo test -p brain-env --features integration-tests --test worker_process --test in_process
+        run: cargo test -p brain-env-worker --features integration-tests --test worker_process --test in_process
 
       - uses: actions/setup-node@v7
         with:
           node-version: "22.23.2"
           cache: npm
       - run: npm ci && npm run build
-      - run: cargo build -p brain-server --bin brain -p brain-env --bin brain-env-worker
+      - run: cargo build -p brain-server --bin brain -p brain-env-worker --bin brain-env-worker
       - name: Exercise lazy providers, cold history, and retained sessions through HTTP
         env:
           BRAIN_TEST_SERVER: ${{ github.workspace }}/target/debug/brain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,8 +357,6 @@ dependencies = [
  "brain-protocol",
  "brain-telemetry",
  "clap",
- "http",
- "http-body-util",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -366,11 +364,31 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "url",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "brain-env-worker"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.23.1",
+ "brain-env",
+ "brain-protocol",
+ "clap",
+ "http",
+ "http-body-util",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+ "tokio",
+ "url",
  "wasm-encoder",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/brain-protocol",
   "crates/brain-telemetry",
   "crates/brain-env",
+  "crates/brain-env-worker",
   "crates/brain",
   "crates/brain-http",
   "crates/brain-server",
@@ -24,6 +25,7 @@ brain-http = { path = "crates/brain-http" }
 brain-sessions = { path = "crates/brain-sessions" }
 brain-server = { path = "crates/brain-server" }
 brain-env = { path = "crates/brain-env" }
+brain-env-worker = { path = "crates/brain-env-worker" }
 
 anyhow = "1"
 async-trait = "0.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 # change to process readiness. It is set here rather than in `[profile.release]` so
 # CI, benchmarks and local release builds keep symbolicated panic backtraces.
 ENV RUSTFLAGS="-C strip=symbols"
-RUN cargo build --locked --release -p brain-server --bin brain -p brain-env --bin brain-env-worker
+RUN cargo build --locked --release -p brain-server --bin brain -p brain-env-worker --bin brain-env-worker
 
 FROM debian:bookworm-slim
 RUN apt-get update \

--- a/crates/brain-env-worker/Cargo.toml
+++ b/crates/brain-env-worker/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "brain-env-worker"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Bounded Wasmtime Component host for Brain Agentloops"
+publish = false
+autobins = false
+
+[features]
+integration-tests = []
+
+[[bin]]
+name = "brain-env-worker"
+path = "src/main.rs"
+
+[[test]]
+name = "worker_process"
+path = "tests/worker_process.rs"
+required-features = ["integration-tests"]
+
+[[test]]
+name = "in_process"
+path = "tests/in_process.rs"
+required-features = ["integration-tests"]
+
+[dependencies]
+brain-env = { workspace = true }
+brain-protocol = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+http = { workspace = true }
+http-body-util = { workspace = true }
+tokio = { workspace = true, features = ["fs", "process", "net", "io-util", "sync", "macros", "rt-multi-thread"] }
+url = { workspace = true }
+wasmtime = { workspace = true }
+wasmtime-wasi = { workspace = true }
+wasmtime-wasi-http = { workspace = true }
+tempfile = { workspace = true }
+
+[dev-dependencies]
+# Builds the smallest possible runaway guest for the fuel-exhaustion test. Already in the
+# lock file as a Wasmtime component dependency, so it costs no new crate.
+wasm-encoder = "0.254"

--- a/crates/brain-env-worker/src/lib.rs
+++ b/crates/brain-env-worker/src/lib.rs
@@ -1,0 +1,63 @@
+//! The Wasmtime host: Component admission, guest execution, and the worker service that
+//! answers Brain over the socket in `brain-env`.
+//!
+//! This crate is the only place a Wasm engine is linked. `brain-env` supervises the process
+//! it produces and never compiles or instantiates a guest itself.
+
+use brain_env::{EnvLimits, WorkerRequest, WorkerResponse};
+
+mod runtime;
+mod service;
+
+pub use runtime::{AdmissionEngine, AdmittedAgentloop, AdmittedTool, GuestHost};
+pub use service::WorkerService;
+
+/// The interfaces a guest may import: the contract's own types and the host services.
+pub const RUNTIME_SHIM_IMPORTS: &[&str] =
+    &["brain:agentloop/types@0.1.0", "brain:agentloop/host@0.1.0"];
+pub const CAPABILITY_IMPORTS: &[&str] = &[
+    "wasi:cli/environment@0.2.9",
+    "wasi:cli/exit@0.2.9",
+    "wasi:cli/stderr@0.2.9",
+    "wasi:cli/stdin@0.2.9",
+    "wasi:cli/stdout@0.2.9",
+    "wasi:cli/terminal-input@0.2.9",
+    "wasi:cli/terminal-output@0.2.9",
+    "wasi:cli/terminal-stderr@0.2.9",
+    "wasi:cli/terminal-stdin@0.2.9",
+    "wasi:cli/terminal-stdout@0.2.9",
+    "wasi:clocks/monotonic-clock@0.2.9",
+    "wasi:clocks/wall-clock@0.2.9",
+    "wasi:filesystem/types@0.2.9",
+    "wasi:filesystem/preopens@0.2.9",
+    "wasi:http/types@0.2.9",
+    "wasi:http/outgoing-handler@0.2.9",
+    "wasi:io/error@0.2.9",
+    "wasi:io/poll@0.2.9",
+    "wasi:io/streams@0.2.9",
+    "wasi:filesystem/types@0.2.12",
+    "wasi:filesystem/preopens@0.2.12",
+    "wasi:io/error@0.2.12",
+    "wasi:io/poll@0.2.12",
+    "wasi:io/streams@0.2.12",
+    "wasi:http/types@0.2.12",
+    "wasi:http/outgoing-handler@0.2.12",
+];
+pub const TOOL_IMPORTS: &[&str] = &["brain:tool/types@0.1.0", "brain:tool/host@0.1.0"];
+
+/// Read one request frame from Brain, bounded by the request ceiling.
+pub async fn worker_read<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut R,
+    limits: &EnvLimits,
+) -> Result<WorkerRequest, String> {
+    brain_env::read_frame(reader, limits.max_request_frame_bytes()).await
+}
+
+/// Write one response frame to Brain, bounded by the response ceiling.
+pub async fn worker_write<W: tokio::io::AsyncWrite + Unpin>(
+    writer: &mut W,
+    response: &WorkerResponse,
+    limits: &EnvLimits,
+) -> Result<(), String> {
+    brain_env::write_frame(writer, response, limits.max_response_frame_bytes()).await
+}

--- a/crates/brain-env-worker/src/main.rs
+++ b/crates/brain-env-worker/src/main.rs
@@ -6,7 +6,8 @@
 
 use std::sync::Arc;
 
-use brain_env::{CAPABILITY_IMPORTS, RUNTIME_SHIM_IMPORTS, WorkerArgs, WorkerService};
+use brain_env::WorkerArgs;
+use brain_env_worker::{CAPABILITY_IMPORTS, RUNTIME_SHIM_IMPORTS, WorkerService};
 use clap::Parser as _;
 
 #[tokio::main]

--- a/crates/brain-env-worker/src/runtime.rs
+++ b/crates/brain-env-worker/src/runtime.rs
@@ -11,7 +11,7 @@ use wasmtime_wasi_http::{
     WasiHttpView,
 };
 
-use crate::{Access, EnvLimits, HostCall, NativeEnvironment, limits::ceiling};
+use brain_env::{Access, EnvLimits, HostCall, NativeEnvironment, NativeToolInput, ceiling};
 
 /// A long-running invocation yields to Tokio at this interval while retaining its fixed
 /// total fuel budget.
@@ -19,7 +19,7 @@ const FUEL_YIELD_INTERVAL: u64 = 10_000_000;
 
 mod bindings {
     wasmtime::component::bindgen!({
-        path: "wit/agentloop",
+        path: "../brain-env/wit/agentloop",
         world: "agentloop",
         imports: { default: async },
         exports: { default: async },
@@ -28,7 +28,7 @@ mod bindings {
 
 mod tool_bindings {
     wasmtime::component::bindgen!({
-        path: "wit/tool",
+        path: "../brain-env/wit/tool",
         world: "tool",
         imports: { default: async },
         exports: { default: async },
@@ -57,13 +57,6 @@ pub struct AdmittedAgentloop {
 pub struct AdmittedTool {
     pub digest: ToolId,
     pre: tool_bindings::ToolPre<HostState>,
-}
-
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct NativeToolInput {
-    pub input: serde_json::Value,
-    pub configuration: serde_json::Value,
-    pub deadline_at_ms: u64,
 }
 
 impl AdmissionEngine {
@@ -309,7 +302,7 @@ fn network_allowed(allow: &[String], uri: &http::Uri) -> bool {
             let origin = format!("{scheme}://{authority}");
             allow
                 .iter()
-                .any(|entry| crate::network_covers(entry, &origin))
+                .any(|entry| brain_env::network_covers(entry, &origin))
         })
 }
 
@@ -719,11 +712,11 @@ mod tests {
             &["https://*.example.com".into()],
             &"https://notexample.com/".parse().unwrap()
         ));
-        assert!(crate::network_covers(
+        assert!(brain_env::network_covers(
             "https://*.example.com",
             "https://*.api.example.com"
         ));
-        assert!(!crate::network_covers(
+        assert!(!brain_env::network_covers(
             "https://*.api.example.com",
             "https://*.example.com"
         ));

--- a/crates/brain-env-worker/src/service.rs
+++ b/crates/brain-env-worker/src/service.rs
@@ -13,11 +13,12 @@ use std::{
 use brain_protocol::{TurnError, TurnInput, codes};
 use tokio::sync::{Semaphore, mpsc, oneshot};
 
-use crate::{
-    AdmissionEngine, AdmittedAgentloop, AdmittedTool, ComponentKind, EnvLimits, GuestHost,
-    HostCall, NativeEnvironment, NativeToolInput, WorkerRequest, WorkerResponse,
-    wire::{read_frame, write_frame},
+use brain_env::{
+    ComponentKind, EnvLimits, HostCall, NativeEnvironment, NativeToolInput, WorkerRequest,
+    WorkerResponse, read_frame, write_frame,
 };
+
+use crate::{AdmissionEngine, AdmittedAgentloop, AdmittedTool, GuestHost};
 
 pub struct WorkerService {
     engine: Arc<AdmissionEngine>,

--- a/crates/brain-env-worker/tests/in_process.rs
+++ b/crates/brain-env-worker/tests/in_process.rs
@@ -4,10 +4,8 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use brain_env::{
-    AdmissionEngine, CAPABILITY_IMPORTS, EnvLimits, GuestHost, HostCall, NativeEnvironment,
-    NativeToolInput, RUNTIME_SHIM_IMPORTS,
-};
+use brain_env::{EnvLimits, HostCall, NativeEnvironment, NativeToolInput};
+use brain_env_worker::{AdmissionEngine, CAPABILITY_IMPORTS, GuestHost, RUNTIME_SHIM_IMPORTS};
 use brain_protocol::{RuntimeEnvelope, TurnError, TurnInput};
 
 #[derive(Default)]

--- a/crates/brain-env-worker/tests/worker_process.rs
+++ b/crates/brain-env-worker/tests/worker_process.rs
@@ -620,18 +620,18 @@ async fn host_calls_queued_before_cancel_are_not_answered_after_cancel() {
     let worker = tokio::spawn(async move {
         let mut stream = listener.accept().await.unwrap();
         assert!(matches!(
-            brain_env::worker_read(&mut stream, &EnvLimits::default())
+            brain_env_worker::worker_read(&mut stream, &EnvLimits::default())
                 .await
                 .unwrap(),
             WorkerRequest::Execute { .. }
         ));
         assert!(matches!(
-            brain_env::worker_read(&mut stream, &EnvLimits::default())
+            brain_env_worker::worker_read(&mut stream, &EnvLimits::default())
                 .await
                 .unwrap(),
             WorkerRequest::Cancel
         ));
-        brain_env::worker_write(
+        brain_env_worker::worker_write(
             &mut stream,
             &WorkerResponse::HostCall {
                 id: 1,
@@ -644,7 +644,7 @@ async fn host_calls_queued_before_cancel_are_not_answered_after_cancel() {
         )
         .await
         .unwrap();
-        brain_env::worker_write(
+        brain_env_worker::worker_write(
             &mut stream,
             &WorkerResponse::TurnFailed {
                 error: TurnError::new(brain_protocol::codes::failure::CANCELLED, "cancelled"),
@@ -654,7 +654,7 @@ async fn host_calls_queued_before_cancel_are_not_answered_after_cancel() {
         .await
         .unwrap();
         assert!(
-            brain_env::worker_read(&mut stream, &EnvLimits::default())
+            brain_env_worker::worker_read(&mut stream, &EnvLimits::default())
                 .await
                 .is_err()
         );

--- a/crates/brain-env/Cargo.toml
+++ b/crates/brain-env/Cargo.toml
@@ -4,31 +4,12 @@ version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-description = "Bounded Wasmtime Component host for Brain Agentloops"
+description = "Native Environment adapter and worker supervision for Brain"
 publish = false
-autobins = false
-
-[features]
-integration-tests = []
-
-[[bin]]
-name = "brain-env-worker"
-path = "src/worker/main.rs"
-
-[[test]]
-name = "worker_process"
-path = "tests/worker_process.rs"
-required-features = ["integration-tests"]
-
-[[test]]
-name = "in_process"
-path = "tests/in_process.rs"
-required-features = ["integration-tests"]
 
 [dependencies]
 brain = { workspace = true }
 brain-telemetry = { workspace = true }
-url = { workspace = true }
 brain-protocol = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -37,19 +18,10 @@ clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-http = { workspace = true }
-http-body-util = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "process", "net", "io-util", "sync", "macros", "rt-multi-thread"] }
-wasmtime = { workspace = true }
-wasmtime-wasi = { workspace = true }
-wasmtime-wasi-http = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
-
-[dev-dependencies]
-# Builds the smallest possible runaway guest for the fuel-exhaustion test. Already in the
-# lock file as a Wasmtime component dependency, so it costs no new crate.
-wasm-encoder = "0.254"

--- a/crates/brain-env/src/lib.rs
+++ b/crates/brain-env/src/lib.rs
@@ -1,72 +1,23 @@
-//! Native Environment adapter, Component admission, and worker process pool.
+//! Native Environment adapter, worker supervision, and the Brain↔worker wire.
+//!
+//! Guest code runs in a separate process: `brain-env-worker` owns the Wasmtime engine and
+//! everything that compiles or instantiates a Component. This crate is the server's side of
+//! that boundary — it starts workers, addresses them, and speaks the wire below — so a
+//! binary that links it carries no Wasm runtime.
 
 mod client;
 mod environment;
 pub use environment::{BrainEnvironment, NativePolicy};
 mod limits;
-mod runtime;
-mod service;
 mod socket;
 mod supervisor;
 mod wire;
 
 pub use client::{TurnBridge, WorkerClient};
-pub use limits::{EnvLimits, WorkerArgs};
-pub use runtime::{AdmissionEngine, AdmittedAgentloop, AdmittedTool, GuestHost, NativeToolInput};
-pub use service::WorkerService;
+pub use limits::{EnvLimits, WorkerArgs, ceiling};
 pub use socket::{Listener, listen};
 pub use supervisor::{LoopError, WorkerPool};
 pub use wire::{
-    Access, ComponentKind, HostCall, NativeEnvironment, WorkerRequest, WorkerResponse, Workspace,
-    network_covers,
+    Access, ComponentKind, HostCall, NativeEnvironment, NativeToolInput, WorkerRequest,
+    WorkerResponse, Workspace, max_request_bytes, network_covers, read_frame, write_frame,
 };
-
-/// The interfaces a guest may import: the contract's own types and the host services.
-pub const RUNTIME_SHIM_IMPORTS: &[&str] =
-    &["brain:agentloop/types@0.1.0", "brain:agentloop/host@0.1.0"];
-pub const CAPABILITY_IMPORTS: &[&str] = &[
-    "wasi:cli/environment@0.2.9",
-    "wasi:cli/exit@0.2.9",
-    "wasi:cli/stderr@0.2.9",
-    "wasi:cli/stdin@0.2.9",
-    "wasi:cli/stdout@0.2.9",
-    "wasi:cli/terminal-input@0.2.9",
-    "wasi:cli/terminal-output@0.2.9",
-    "wasi:cli/terminal-stderr@0.2.9",
-    "wasi:cli/terminal-stdin@0.2.9",
-    "wasi:cli/terminal-stdout@0.2.9",
-    "wasi:clocks/monotonic-clock@0.2.9",
-    "wasi:clocks/wall-clock@0.2.9",
-    "wasi:filesystem/types@0.2.9",
-    "wasi:filesystem/preopens@0.2.9",
-    "wasi:http/types@0.2.9",
-    "wasi:http/outgoing-handler@0.2.9",
-    "wasi:io/error@0.2.9",
-    "wasi:io/poll@0.2.9",
-    "wasi:io/streams@0.2.9",
-    "wasi:filesystem/types@0.2.12",
-    "wasi:filesystem/preopens@0.2.12",
-    "wasi:io/error@0.2.12",
-    "wasi:io/poll@0.2.12",
-    "wasi:io/streams@0.2.12",
-    "wasi:http/types@0.2.12",
-    "wasi:http/outgoing-handler@0.2.12",
-];
-pub const TOOL_IMPORTS: &[&str] = &["brain:tool/types@0.1.0", "brain:tool/host@0.1.0"];
-
-#[doc(hidden)]
-pub async fn worker_read<R: tokio::io::AsyncRead + Unpin>(
-    reader: &mut R,
-    limits: &EnvLimits,
-) -> Result<WorkerRequest, String> {
-    wire::read_frame(reader, limits.max_request_frame_bytes()).await
-}
-
-#[doc(hidden)]
-pub async fn worker_write<W: tokio::io::AsyncWrite + Unpin>(
-    writer: &mut W,
-    response: &WorkerResponse,
-    limits: &EnvLimits,
-) -> Result<(), String> {
-    wire::write_frame(writer, response, limits.max_response_frame_bytes()).await
-}

--- a/crates/brain-env/src/limits.rs
+++ b/crates/brain-env/src/limits.rs
@@ -97,19 +97,19 @@ impl EnvLimits {
 
     /// The largest request frame the worker accepts: a package arrives base64-encoded,
     /// everything else is a turn input plus its envelope.
-    pub(crate) fn max_request_frame_bytes(&self) -> usize {
+    pub fn max_request_frame_bytes(&self) -> usize {
         ceiling(self.max_package_bytes)
             .saturating_mul(2)
             .max(self.max_turn_frame_bytes())
     }
 
     /// A turn or Tool request frame: the input plus its envelope.
-    pub(crate) fn max_turn_frame_bytes(&self) -> usize {
+    pub fn max_turn_frame_bytes(&self) -> usize {
         ceiling(self.max_execution_input_bytes).saturating_add(1_024)
     }
 
     /// A response frame from the worker: the output plus its envelope.
-    pub(crate) fn max_response_frame_bytes(&self) -> usize {
+    pub fn max_response_frame_bytes(&self) -> usize {
         ceiling(self.max_execution_output_bytes).saturating_add(1_024)
     }
 }
@@ -124,7 +124,7 @@ pub struct WorkerArgs {
 }
 
 /// A byte or count ceiling as the code compares against it: zero means no bound.
-pub(crate) fn ceiling(value: usize) -> usize {
+pub fn ceiling(value: usize) -> usize {
     if value == 0 { usize::MAX } else { value }
 }
 

--- a/crates/brain-env/src/wire.rs
+++ b/crates/brain-env/src/wire.rs
@@ -145,7 +145,15 @@ pub enum WorkerResponse {
     },
 }
 
-pub(crate) async fn write_frame<W: AsyncWrite + Unpin, T: Serialize>(
+/// What a native Tool Component is handed for one call.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct NativeToolInput {
+    pub input: serde_json::Value,
+    pub configuration: serde_json::Value,
+    pub deadline_at_ms: u64,
+}
+
+pub async fn write_frame<W: AsyncWrite + Unpin, T: Serialize>(
     writer: &mut W,
     value: &T,
     max_bytes: usize,
@@ -167,7 +175,7 @@ pub(crate) async fn write_frame<W: AsyncWrite + Unpin, T: Serialize>(
     writer.flush().await.map_err(|error| error.to_string())
 }
 
-pub(crate) async fn read_frame<R: AsyncRead + Unpin, T: for<'de> Deserialize<'de>>(
+pub async fn read_frame<R: AsyncRead + Unpin, T: for<'de> Deserialize<'de>>(
     reader: &mut R,
     max_bytes: usize,
 ) -> Result<T, String> {
@@ -183,7 +191,7 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin, T: for<'de> Deserialize<'de
     serde_json::from_slice(&payload).map_err(|error| error.to_string())
 }
 
-pub(crate) fn max_request_bytes(request: &WorkerRequest, limits: &EnvLimits) -> usize {
+pub fn max_request_bytes(request: &WorkerRequest, limits: &EnvLimits) -> usize {
     match request {
         WorkerRequest::Ping | WorkerRequest::Cancel => 1_024,
         WorkerRequest::Admit { .. } => limits.max_request_frame_bytes(),

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -14,7 +14,7 @@ docker run --rm -p 127.0.0.1:8080:8080 \
 Or build both executables:
 
 ```sh
-cargo build --release -p brain-server --bin brain -p brain-env --bin brain-env-worker
+cargo build --release -p brain-server --bin brain -p brain-env-worker --bin brain-env-worker
 BRAIN_DATA_DIR="$PWD/brain-data" \
 BRAIN_ENV_WORKER="$PWD/target/release/brain-env-worker" \
 ./target/release/brain --listen 127.0.0.1:8080

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ executables:
 ```sh
 npm ci
 npm run build
-cargo build --release -p brain-server --bin brain -p brain-env --bin brain-env-worker
+cargo build --release -p brain-server --bin brain -p brain-env-worker --bin brain-env-worker
 ```
 
 Start Brain in one terminal:

--- a/references/adrs/2026-09-06-03-sessions-and-brain-env.md
+++ b/references/adrs/2026-09-06-03-sessions-and-brain-env.md
@@ -34,7 +34,8 @@ where the Environment runs, how many workers it has, or how it retains those res
 | --- | --- |
 | brain | One session's ordered execution, canonical journal, projections, and injected execution ports |
 | brain-sessions | Multi-session management: create, load, list, activate, suspend, end, delete, and decide when to call session-scoped Environment lifecycle operations |
-| brain-env | The built-in Environment adapter and lifecycle implementations, Component admission, worker pool and IPC, Wasmtime execution, capability enforcement, and Environment resources |
+| brain-env | The built-in Environment adapter and lifecycle implementations, worker pool and IPC, capability policy, and Environment resources. Links no Wasm runtime |
+| brain-env-worker | The worker process: Component admission, Wasmtime execution, and capability enforcement inside the guest sandbox. The only crate that links a Wasm engine |
 | brain-server | Deployment configuration and composition, concrete storage and credential wiring, process lifecycle, health, and the API facade delegating to the composed services |
 | brain-http | HTTP routes and transport for the server API |
 | brain-sdk | Client access and extension authoring |

--- a/tests/journeys/README.md
+++ b/tests/journeys/README.md
@@ -33,7 +33,7 @@ tests synchronize with actual model/Tool entry rather than guessing execution pr
 After `npm ci && npm run build`:
 
 ```sh
-cargo build -p brain-server --bin brain -p brain-env --bin brain-env-worker
+cargo build -p brain-server --bin brain -p brain-env-worker --bin brain-env-worker
 cargo build --manifest-path tests/fixtures/diagnostic-agentloop/Cargo.toml --target wasm32-wasip2 --release
 cargo build --manifest-path tests/fixtures/diagnostic-tool/Cargo.toml --target wasm32-wasip2 --release
 cargo build --manifest-path examples/reference-agentloop/Cargo.toml --target wasm32-wasip2 --release


### PR DESCRIPTION
Rebased onto main now that #190 has landed. Supersedes #191, which GitHub closed when its base branch `windows-worker` was deleted on merge.

## What

`brain-server` depends on `brain-env` for the Environment adapter and worker supervision, but the crate also carried the Wasmtime engine, so the server's dependency graph claimed a Wasm runtime it never calls. Admission, guest execution and the worker service move into a new `brain-env-worker` crate, which owns the binary of the same name and is now the only crate that links an engine.

`brain-env` keeps the client, supervisor, socket, wire and limits. Two mechanical consequences:

- `NativeToolInput` moves to `wire.rs` — the only type that crossed the cut, and genuinely a wire payload.
- The frame codec and the frame-size accessors on `EnvLimits` become public so the worker can reach them across the crate boundary.

The hand-written WIT stays at `crates/brain-env/wit/`. Eleven places reference that path — the docs site by public GitHub URL, the SDK generator, the fixture and example `bindgen!` macros — so the worker reads it relatively instead.

No behaviour change. Same two processes, same spawn, same wire protocol.

## Measurements

This started as a binary-size question, and **the size argument did not survive contact with the linker**: `brain` went 16,714,136 → 16,634,904 bytes, a 79 KB saving. `--gc-sections` and thin LTO were already stripping wasmtime out of `brain`, because nothing in the server reachably called into it. Section sizes show why there was never much to remove — `brain` `.text` is 11.7 MB of rustls, reqwest, tokio, serde and jsonschema; the entire live Cranelift + wasmtime + WASI in the worker is the ~3 MB by which its `.text` exceeds the server's.

What the split does buy, measured: **93 crates leave the server's dependency graph** (294 → 230), so `cargo check` and `cargo build --bin brain` no longer compile Cranelift at all. And the boundary becomes structural — the server crate cannot reach a Wasm engine by accident, because it does not link one.

## Verification

Re-run after the rebase onto main:

- Full workspace suite green, all 25 test binaries.
- `cargo test -p brain-env-worker --features integration-tests --test worker_process` — 7/7 through the real spawned worker process, against the built diagnostic and reference Components.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets --features brain-env-worker/integration-tests` clean.
- Release rebuild under Linux (`x86_64-unknown-linux-gnu`, `RUSTFLAGS=-C strip=symbols`, as the Dockerfile builds) for the numbers above.

Updated alongside: `Dockerfile`, `ci.yml` (3 invocations), `docs/quickstart.mdx`, `examples/README.md`, `tests/journeys/README.md`, and the crate responsibility table in ADR-044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)