### PR TITLE
extensions: implement the minimal extension contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,10 @@ jobs:
           node-version: "22.23.2"
           cache: npm
       - run: npm ci && npm run build
+      - name: Verify Python Environment preparation with a real isolated project
+        run: |
+          "$RUNNER_TEMP/python/venv/bin/pip" install --disable-pip-version-check uv==0.8.15
+          BRAIN_TEST_UV="$RUNNER_TEMP/python/venv/bin/uv" node --test examples/python-environment.test.mjs
       - run: cargo build -p brain-server --bin brain -p brain-env-worker --bin brain-env-worker
       - name: Exercise lazy providers, cold history, and retained sessions through HTTP
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,9 @@ npm test
 npm run package-smoke
 ```
 
-CI additionally runs real loop worker and HTTP lifecycle integration tests and an image smoke
-test. Performance probes are optional diagnostics during pre-launch iteration. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+CI additionally runs real loop worker and HTTP lifecycle integration tests, the locked Python
+Environment preparation test, and an image smoke test. Run the Python check with
+`BRAIN_TEST_UV=/path/to/uv node --test examples/python-environment.test.mjs`; CI installs uv 0.8.15. Performance probes are optional diagnostics during pre-launch iteration. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 
 [SDK user journeys](tests/journeys/README.md) run against real Linux servers and workers with four
 isolated suites in parallel. They cover the public SDK lifecycle, tools, placement, events, and

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The core mechanism that bridges the LLM, controls context and dispatches tools. 
 - Codex
 
 ### Tool Extensions
-The hands that let the LLM do work. A tool declares the resources it needs and how to act. [Write a tool](https://aex.dev/brain/docs/guides/write-a-tool).
+The hands that let the LLM do work. A tool declares its typed input/output and how to act. Its Environment prepares dependencies and enforces access. [Write a tool](https://aex.dev/brain/docs/guides/write-a-tool).
 - Bash
 - Inline function
 - Web_search/Web_fetch
@@ -57,7 +57,7 @@ An environment provides the resources a tool needs to complete its tasks. [Write
 Official extensions are written the same way you would write yours: [aexhq/extensions](https://github.com/aexhq/extensions).
 
 Brain ships two Environments of its own. `brainEnv` runs Components in a fresh Wasmtime instance
-per invocation, granted only what their `needs` name. `hostEnv` is your own process, for Tools that
+per invocation, with explicitly configured Environment grants bounded by server policy. `hostEnv` is your own process, for Tools that
 are plain functions. Any other Environment is reached over HTTP.
 
 ## Architecture

--- a/crates/brain-env-worker/src/runtime.rs
+++ b/crates/brain-env-worker/src/runtime.rs
@@ -327,9 +327,27 @@ impl bindings::brain::agentloop::host::Host for HostState {
         serde_json::from_str(&answer).map_err(|error| wit_error(host_failure(error)))
     }
 
-    async fn set_kv(&mut self, key: String, value_json: String) -> Result<u64, wit::TurnError> {
+    async fn kv_put(&mut self, key: String, value_json: String) -> Result<u64, wit::TurnError> {
         let answer = self
-            .call(HostCall::SetKv { key, value_json })
+            .call(HostCall::KvPut { key, value_json })
+            .await
+            .map_err(wit_error)?;
+        serde_json::from_str(&answer).map_err(|error| wit_error(host_failure(error)))
+    }
+
+    async fn kv_read(&mut self, key: String) -> Result<Option<String>, wit::TurnError> {
+        let answer = self
+            .call(HostCall::KvRead { key })
+            .await
+            .map_err(wit_error)?;
+        let value: serde_json::Value =
+            serde_json::from_str(&answer).map_err(|error| wit_error(host_failure(error)))?;
+        Ok(value.get("value").map(serde_json::Value::to_string))
+    }
+
+    async fn kv_delete(&mut self, key: String) -> Result<u64, wit::TurnError> {
+        let answer = self
+            .call(HostCall::KvDelete { key })
             .await
             .map_err(wit_error)?;
         serde_json::from_str(&answer).map_err(|error| wit_error(host_failure(error)))

--- a/crates/brain-env-worker/tests/in_process.rs
+++ b/crates/brain-env-worker/tests/in_process.rs
@@ -17,11 +17,20 @@ struct Answering {
 impl GuestHost for Answering {
     async fn call(&self, call: HostCall) -> Result<String, TurnError> {
         match call {
-            HostCall::SetKv { key, value_json } => {
+            HostCall::KvPut { key, value_json } => {
                 self.kv
                     .lock()
                     .unwrap()
                     .insert(key, serde_json::from_str(&value_json).unwrap());
+                Ok("7".into())
+            }
+            HostCall::KvRead { key } => Ok(match self.kv.lock().unwrap().get(&key) {
+                Some(value) => serde_json::json!({"value": value}),
+                None => serde_json::json!({}),
+            }
+            .to_string()),
+            HostCall::KvDelete { key } => {
+                self.kv.lock().unwrap().remove(&key);
                 Ok("7".into())
             }
             HostCall::SetTranscript { .. } => Ok("7".into()),

--- a/crates/brain-env-worker/tests/worker_process.rs
+++ b/crates/brain-env-worker/tests/worker_process.rs
@@ -14,6 +14,7 @@ use brain_protocol::{RuntimeEnvelope, TurnError, TurnInput};
 /// what the guest asked for.
 struct RecordingBridge {
     calls: Mutex<Vec<String>>,
+    kv: Mutex<std::collections::BTreeMap<String, serde_json::Value>>,
     cancelled: AtomicBool,
 }
 
@@ -21,11 +22,24 @@ struct RecordingBridge {
 impl TurnBridge for RecordingBridge {
     async fn call(&self, call: HostCall) -> Result<String, TurnError> {
         match call {
-            HostCall::SetKv { key, value_json } => {
+            HostCall::KvPut { key, value_json } => {
+                self.kv
+                    .lock()
+                    .unwrap()
+                    .insert(key.clone(), serde_json::from_str(&value_json).unwrap());
                 self.calls
                     .lock()
                     .unwrap()
                     .push(format!("kv {key} {value_json}"));
+                Ok("7".into())
+            }
+            HostCall::KvRead { key } => Ok(match self.kv.lock().unwrap().get(&key) {
+                Some(value) => serde_json::json!({"value": value}),
+                None => serde_json::json!({}),
+            }
+            .to_string()),
+            HostCall::KvDelete { key } => {
+                self.kv.lock().unwrap().remove(&key);
                 Ok("7".into())
             }
             HostCall::SetTranscript { messages_json } => {
@@ -113,8 +127,21 @@ async fn reference_loop_reads_interruptions_and_hands_tool_failures_to_the_model
     impl TurnBridge for Model {
         async fn call(&self, call: HostCall) -> Result<String, TurnError> {
             let answer = match call {
-                HostCall::SetKv { key, value_json } => {
+                HostCall::KvPut { key, value_json } => {
                     self.kv.lock().unwrap()[key] = serde_json::from_str(&value_json).unwrap();
+                    serde_json::json!(7)
+                }
+                HostCall::KvRead { key } => match self.kv.lock().unwrap().get(&key) {
+                    Some(value) => serde_json::json!({"value": value}),
+                    None => serde_json::json!({}),
+                },
+                HostCall::KvDelete { key } => {
+                    self.kv
+                        .lock()
+                        .unwrap()
+                        .as_object_mut()
+                        .unwrap()
+                        .remove(&key);
                     serde_json::json!(7)
                 }
                 HostCall::SetTranscript { messages_json } => {
@@ -221,7 +248,8 @@ async fn a_worker_crash_does_not_replay_or_stop_its_sibling_and_shutdown_reaps_b
     impl TurnBridge for Held {
         async fn call(&self, call: HostCall) -> Result<String, TurnError> {
             match call {
-                HostCall::SetKv { .. } => Ok("7".into()),
+                HostCall::KvPut { .. } => Ok("7".into()),
+                HostCall::KvRead { .. } => Ok("{}".into()),
                 HostCall::Events { after } => {
                     Ok(serde_json::json!({"events": [], "next_cursor": after}).to_string())
                 }
@@ -301,6 +329,7 @@ async fn a_worker_crash_does_not_replay_or_stop_its_sibling_and_shutdown_reaps_b
     assert_eq!(pid(1).await, second);
     let bridge = RecordingBridge {
         calls: Mutex::new(Vec::new()),
+        kv: Mutex::new(Default::default()),
         cancelled: AtomicBool::new(false),
     };
     for _ in 0..2 {
@@ -332,7 +361,8 @@ async fn saturated_parent_turns_can_all_invoke_native_tools() {
         }
         async fn call(&self, call: HostCall) -> Result<String, TurnError> {
             match call {
-                HostCall::SetKv { .. } => Ok("7".into()),
+                HostCall::KvPut { .. } => Ok("7".into()),
+                HostCall::KvRead { .. } => Ok("{}".into()),
                 HostCall::Events { after } => {
                     Ok(serde_json::json!({"events": [], "next_cursor": after}).to_string())
                 }
@@ -354,6 +384,7 @@ async fn saturated_parent_turns_can_all_invoke_native_tools() {
                             },
                             &RecordingBridge {
                                 calls: Mutex::new(Vec::new()),
+                                kv: Mutex::new(Default::default()),
                                 cancelled: AtomicBool::new(false),
                             },
                         )
@@ -441,10 +472,11 @@ async fn real_worker_admits_and_runs_a_turn_of_the_diagnostic_loop() {
     let digest = pool.admit(package).await.unwrap();
     let bridge = RecordingBridge {
         calls: Mutex::new(Vec::new()),
+        kv: Mutex::new(Default::default()),
         cancelled: AtomicBool::new(false),
     };
     let output = pool
-        .turn(digest, environment(), input("hello"), &bridge)
+        .turn(digest, environment(), input("kv"), &bridge)
         .await
         .unwrap();
     assert!(
@@ -457,7 +489,7 @@ async fn real_worker_admits_and_runs_a_turn_of_the_diagnostic_loop() {
     );
     assert_eq!(
         output.result,
-        Some(serde_json::json!({"turns": 1, "message": "hello"}))
+        Some(serde_json::json!({"turns": 1, "message": "kv"}))
     );
     // The diagnostic loop emits one note through the host before it finishes.
     let calls = bridge.calls.lock().unwrap();
@@ -481,6 +513,7 @@ async fn tool_workspaces_are_shared_within_a_session_and_isolated_between_sessio
     let digest = pool.admit_tool(component).await.unwrap();
     let bridge = RecordingBridge {
         calls: Mutex::new(Vec::new()),
+        kv: Mutex::new(Default::default()),
         cancelled: AtomicBool::new(false),
     };
     let invoke = |input: serde_json::Value| NativeToolInput {
@@ -546,6 +579,7 @@ async fn concurrent_turns_all_reach_the_agentloop() {
         turns.push(tokio::spawn(async move {
             let bridge = RecordingBridge {
                 calls: Mutex::new(Vec::new()),
+                kv: Mutex::new(Default::default()),
                 cancelled: AtomicBool::new(false),
             };
             let output = pool
@@ -600,6 +634,7 @@ async fn a_cancelled_turn_ends_at_its_next_host_call() {
     let digest = pool.admit(package).await.unwrap();
     let bridge = RecordingBridge {
         calls: Mutex::new(Vec::new()),
+        kv: Mutex::new(Default::default()),
         cancelled: AtomicBool::new(true),
     };
     let error = pool
@@ -661,6 +696,7 @@ async fn host_calls_queued_before_cancel_are_not_answered_after_cancel() {
     });
     let bridge = RecordingBridge {
         calls: Mutex::new(Vec::new()),
+        kv: Mutex::new(Default::default()),
         cancelled: AtomicBool::new(true),
     };
     let error = WorkerClient::new(socket, &EnvLimits::default())

--- a/crates/brain-env/src/environment.rs
+++ b/crates/brain-env/src/environment.rs
@@ -1,13 +1,6 @@
-//! Brain's native Environment adapter; guest code runs in managed worker processes.
-//!
-//! A Tool placed here is a Component admitted through `POST /v1/tools`; the Agentloop
-//! is one admitted through `POST /v1/agentloops`. Each runs in a fresh Wasmtime store
-//! with exactly the grants its needs name, bounded by the deployment's allow-lists:
-//! `file:///workspace` is the session's directory, `file:///scratch` lives for one
-//! invocation, both read-only unless the need says `?access=write`; an `https:` or
-//! `http:` origin, exact or `scheme://*.domain`, opens `wasi:http` to it. Secrets are the
-//! Environment's own option, `{ "secrets": [names] }`, read from the process environment
-//! and mounted under `/secrets`. Nothing is installed: `pkg:` is refused.
+//! Brain's native Environment adapter; guests run in managed worker processes.
+//! Each invocation receives its Environment's configured grants, bounded by the
+//! deployment policy. Components bring their own code; this runtime installs nothing.
 
 use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
@@ -47,6 +40,15 @@ pub struct BrainEnvironment {
 #[serde(default, deny_unknown_fields)]
 struct Configuration {
     secrets: Vec<String>,
+    network: Vec<String>,
+    filesystem: Filesystem,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct Filesystem {
+    workspace: Option<Access>,
+    scratch: Option<Access>,
 }
 
 impl BrainEnvironment {
@@ -67,14 +69,11 @@ impl BrainEnvironment {
         })
     }
 
-    /// The grants one invocation receives: its needs, bounded by the policy, plus the
-    /// Environment's secrets.
     async fn grants(
         &self,
         session: &SessionId,
         environment: &brain_protocol::EnvironmentName,
         configuration: &Configuration,
-        needs: &[String],
     ) -> Result<NativeEnvironment, brain::Error> {
         let mut granted = NativeEnvironment::default();
         for name in &configuration.secrets {
@@ -87,8 +86,39 @@ impl BrainEnvironment {
                 .map_err(|_| refused(format!("secret `{name}` is not configured")))?;
             granted.secrets.insert(name.clone(), value);
         }
-        for need in needs {
-            self.grant(session, environment, need, &mut granted)?;
+        if let Some(access) = configuration.filesystem.workspace {
+            self.filesystem_granted("workspace")?;
+            granted.workspace = Some(Workspace {
+                path: self
+                    .workspaces
+                    .join(session.as_str())
+                    .join(environment.as_str())
+                    .to_string_lossy()
+                    .into_owned(),
+                access,
+            });
+        }
+        if let Some(access) = configuration.filesystem.scratch {
+            self.filesystem_granted("scratch")?;
+            granted.scratch = Some(access);
+        }
+        for requested in &configuration.network {
+            let uri = url::Url::parse(requested)
+                .map_err(|error| refused(format!("network origin `{requested}`: {error}")))?;
+            let origin = network_origin(&uri).ok_or_else(|| {
+                refused(format!("network `{requested}` must be an HTTP(S) origin"))
+            })?;
+            if !self
+                .policy
+                .network
+                .iter()
+                .any(|grant| network_covers(grant, &origin))
+            {
+                return Err(refused(format!(
+                    "network `{requested}` is not granted by this server"
+                )));
+            }
+            granted.network_allow.push(origin);
         }
         if let Some(workspace) = &granted.workspace {
             tokio::fs::create_dir_all(&workspace.path)
@@ -98,94 +128,12 @@ impl BrainEnvironment {
         Ok(granted)
     }
 
-    fn grant(
-        &self,
-        session: &SessionId,
-        environment: &brain_protocol::EnvironmentName,
-        need: &str,
-        granted: &mut NativeEnvironment,
-    ) -> Result<(), brain::Error> {
-        let uri = url::Url::parse(need)
-            .map_err(|error| refused(format!("need `{need}` is not a URI: {error}")))?;
-        match uri.scheme() {
-            "file" => {
-                let access = file_access(&uri).ok_or_else(|| {
-                    refused(format!(
-                        "need `{need}` carries a query other than access=read or access=write"
-                    ))
-                })?;
-                let root = uri.path().trim_end_matches('/');
-                if uri.host_str().is_some_and(|host| !host.is_empty()) {
-                    return Err(refused(format!(
-                        "need `{need}` names a host; the brain env has file:///workspace and file:///scratch"
-                    )));
-                }
-                match root {
-                    "/workspace" => {
-                        self.filesystem_granted("workspace", need)?;
-                        let path = self
-                            .workspaces
-                            .join(session.as_str())
-                            .join(environment.as_str());
-                        granted.workspace = Some(Workspace {
-                            path: path.to_string_lossy().into_owned(),
-                            access: widest(granted.workspace.as_ref().map(|w| w.access), access),
-                        });
-                    }
-                    "/scratch" => {
-                        self.filesystem_granted("scratch", need)?;
-                        granted.scratch = Some(widest(granted.scratch, access));
-                    }
-                    _ => {
-                        return Err(refused(format!(
-                            "need `{need}` names a location the brain env does not have; it has file:///workspace and file:///scratch"
-                        )));
-                    }
-                }
-            }
-            "https" | "http" => {
-                let origin = network_origin(&uri).ok_or_else(|| {
-                    refused(format!(
-                        "need `{need}` must be an origin, `scheme://host[:port]`, with nothing after it"
-                    ))
-                })?;
-                if !self
-                    .policy
-                    .network
-                    .iter()
-                    .any(|grant| network_covers(grant, &origin))
-                {
-                    return Err(refused(format!(
-                        "need `{need}` is not within the network this server grants"
-                    )));
-                }
-                granted.network_allow.push(origin);
-            }
-            "pkg" => {
-                return Err(refused(format!(
-                    "need `{need}` cannot be met: the brain env installs nothing, a Component brings its own code"
-                )));
-            }
-            "wss" => {
-                return Err(refused(format!(
-                    "need `{need}` cannot be met: the brain env has no WebSocket, a Component reaches the network through wasi:http"
-                )));
-            }
-            _ => {
-                return Err(refused(format!(
-                    "need `{need}` names a scheme the brain env does not honour"
-                )));
-            }
-        }
-        Ok(())
-    }
-
-    fn filesystem_granted(&self, root: &str, need: &str) -> Result<(), brain::Error> {
+    fn filesystem_granted(&self, root: &str) -> Result<(), brain::Error> {
         if self.policy.filesystem.contains(root) {
             return Ok(());
         }
         Err(refused(format!(
-            "need `{need}` asks for a filesystem root this server does not grant"
+            "filesystem `{root}` is not granted by this server"
         )))
     }
 
@@ -197,7 +145,6 @@ impl BrainEnvironment {
     ) -> Result<EnvironmentReceipt, brain::Error> {
         let EnvironmentRequest::Execute {
             implementation,
-            needs,
             input,
             deadline_ms,
             ..
@@ -230,7 +177,6 @@ impl BrainEnvironment {
                 &operation.session_id,
                 &operation.environment,
                 &Self::configuration(environment)?,
-                needs,
             )
             .await?;
         let bridge = ServicesBridge(services);
@@ -291,12 +237,11 @@ impl EnvironmentAdapter for BrainEnvironment {
         services: Services,
     ) -> Result<EnvironmentReceipt, brain::Error> {
         match (&operation.request, services) {
-            (EnvironmentRequest::Setup { needs, .. }, _) => {
+            (EnvironmentRequest::Setup { .. }, _) => {
                 self.grants(
                     &operation.session_id,
                     &operation.environment,
                     &Self::configuration(environment)?,
-                    needs,
                 )
                 .await?;
                 Ok(EnvironmentReceipt::Accepted)
@@ -328,32 +273,11 @@ impl EnvironmentAdapter for BrainEnvironment {
     }
 }
 
-/// The access a `file:` need asks for: read unless it says `?access=write`; `None`
-/// for any other query.
-fn file_access(uri: &url::Url) -> Option<Access> {
-    let mut access = Access::Read;
-    for (key, value) in uri.query_pairs() {
-        match (&*key, &*value) {
-            ("access", "read") => {}
-            ("access", "write") => access = Access::Write,
-            _ => return None,
-        }
-    }
-    Some(access)
-}
-
-fn widest(current: Option<Access>, requested: Access) -> Access {
-    match (current, requested) {
-        (Some(Access::Write), _) | (_, Access::Write) => Access::Write,
-        _ => Access::Read,
-    }
-}
-
-/// `scheme://host[:port]`, lowercased, for a need that is exactly an origin. A host of
-/// `*.domain` is a family of hosts.
+/// An HTTP(S) origin, optionally naming a family of hosts with `*.domain`.
 fn network_origin(uri: &url::Url) -> Option<String> {
     let host = uri.host_str()?;
-    if !uri.username().is_empty()
+    if !matches!(uri.scheme(), "http" | "https")
+        || !uri.username().is_empty()
         || uri.password().is_some()
         || !matches!(uri.path(), "" | "/")
         || uri.query().is_some()
@@ -392,10 +316,12 @@ impl TurnBridge for ServicesBridge {
             |text: &str| serde_json::from_str(text).map_err(|e| bridge_error("invalid_request", e));
         let (method, input) = match call {
             HostCall::SetTranscript { messages_json } => ("set_transcript", parse(&messages_json)?),
-            HostCall::SetKv { key, value_json } => (
-                "set_kv",
+            HostCall::KvPut { key, value_json } => (
+                "kv_put",
                 serde_json::json!({"key": key, "value": parse(&value_json)?}),
             ),
+            HostCall::KvRead { key } => ("kv_read", serde_json::json!(key)),
+            HostCall::KvDelete { key } => ("kv_delete", serde_json::json!(key)),
             HostCall::Events { after } => ("events", serde_json::json!(after)),
             HostCall::Model { request_json } => ("model", parse(&request_json)?),
             HostCall::Dispatch { calls_json } => ("dispatch", parse(&calls_json)?),
@@ -489,7 +415,7 @@ mod tests {
             let entry = Environment {
                 name: brain_protocol::EnvironmentName::new(name),
                 driver: brain_protocol::Driver::Brain {},
-                configuration: serde_json::json!({}),
+                configuration: serde_json::json!({"filesystem": {"workspace": "write"}}),
             };
             let operation = EnvironmentOperation {
                 session_id: session(),
@@ -497,7 +423,6 @@ mod tests {
                 sequence: 1,
                 request: EnvironmentRequest::Setup {
                     configuration: serde_json::json!({}),
-                    needs: vec!["file:///workspace?access=write".into()],
                 },
             };
             brain.execute(&entry, &operation, None).await.unwrap();
@@ -539,7 +464,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn needs_become_grants_bounded_by_the_deployment_policy() {
+    async fn configured_grants_are_bounded_by_the_deployment_policy() {
         let root = tempfile::tempdir().unwrap();
         let brain = environment(
             NativePolicy {
@@ -553,16 +478,29 @@ mod tests {
             .grants(
                 &session(),
                 &brain_protocol::EnvironmentName::new("brain"),
-                &Configuration::default(),
-                &[
-                    "file:///workspace".into(),
-                    "file:///workspace?access=write".into(),
-                    "file:///scratch".into(),
-                    "https://API.example.com/".into(),
-                ],
+                &Configuration {
+                    filesystem: Filesystem {
+                        workspace: Some(Access::Write),
+                        scratch: Some(Access::Read),
+                    },
+                    network: vec!["https://API.example.com/".into()],
+                    ..Default::default()
+                },
             )
             .await
             .unwrap();
+        let empty = brain
+            .grants(
+                &session(),
+                &brain_protocol::EnvironmentName::new("other"),
+                &Configuration::default(),
+            )
+            .await
+            .unwrap();
+        assert!(empty.workspace.is_none());
+        assert!(empty.scratch.is_none());
+        assert!(empty.secrets.is_empty());
+        assert!(empty.network_allow.is_empty());
         let workspace = granted.workspace.unwrap();
         assert_eq!(workspace.access, Access::Write);
         assert!(std::path::Path::new(&workspace.path).is_dir());
@@ -584,8 +522,10 @@ mod tests {
                 .grants(
                     &session(),
                     &brain_protocol::EnvironmentName::new("brain"),
-                    &Configuration::default(),
-                    &[refused.into()],
+                    &Configuration {
+                        network: vec![refused.into()],
+                        ..Default::default()
+                    },
                 )
                 .await
                 .expect_err(refused)
@@ -603,8 +543,13 @@ mod tests {
                 .grants(
                     &session(),
                     &brain_protocol::EnvironmentName::new("brain"),
-                    &Configuration::default(),
-                    &["file:///scratch".into()]
+                    &Configuration {
+                        filesystem: Filesystem {
+                            scratch: Some(Access::Read),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }
                 )
                 .await
                 .is_err()
@@ -616,8 +561,8 @@ mod tests {
                     &brain_protocol::EnvironmentName::new("brain"),
                     &Configuration {
                         secrets: vec!["BRAIN_API_TOKEN".into()],
+                        ..Default::default()
                     },
-                    &[],
                 )
                 .await
                 .is_err()
@@ -629,7 +574,7 @@ mod tests {
         };
         assert!(
             BrainEnvironment::configuration(&entry).is_err(),
-            "the brain env has no options but secrets"
+            "network grants must be an array of origins"
         );
     }
 }

--- a/crates/brain-env/src/wire.rs
+++ b/crates/brain-env/src/wire.rs
@@ -19,7 +19,9 @@ use crate::EnvLimits;
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum HostCall {
     SetTranscript { messages_json: String },
-    SetKv { key: String, value_json: String },
+    KvPut { key: String, value_json: String },
+    KvRead { key: String },
+    KvDelete { key: String },
     Events { after: u64 },
     Model { request_json: String },
     Dispatch { calls_json: String },
@@ -52,7 +54,7 @@ pub enum WorkerRequest {
     Cancel,
 }
 
-/// What one invocation is granted: computed from what it declared it needs, bounded
+/// What one invocation is granted: its Environment configuration, bounded
 /// by the deployment's allow-lists, and nothing else.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct NativeEnvironment {

--- a/crates/brain-env/wit/agentloop/agentloop.wit
+++ b/crates/brain-env/wit/agentloop/agentloop.wit
@@ -54,7 +54,9 @@ interface host {
   // A finite EventPage after this sequence. Continue with next_cursor until empty.
   events: func(after: u64) -> result<string, turn-error>;
   set-transcript: func(messages-json: string) -> result<u64, turn-error>;
-  set-kv: func(key: string, value-json: string) -> result<u64, turn-error>;
+  kv-put: func(key: string, value-json: string) -> result<u64, turn-error>;
+  kv-read: func(key: string) -> result<option<string>, turn-error>;
+  kv-delete: func(key: string) -> result<u64, turn-error>;
 
   // One model call. `request-json` is a ModelRequest; the answer is a ModelResult.
   model: func(request-json: string) -> result<string, turn-error>;

--- a/crates/brain-http/generated/contract/session/v1/openapi.yaml
+++ b/crates/brain-http/generated/contract/session/v1/openapi.yaml
@@ -24,25 +24,12 @@ components:
       additionalProperties: false
       description: |-
         The admitted Agentloop a session runs: which one, how it is configured, which
-        Environment of the session runs it, and what it needs there.
+        Environment of the session runs it.
       properties:
         configuration: true
         environment:
           $ref: '#/components/schemas/EnvironmentName'
         implementation: true
-        needs:
-          default: []
-          description: |-
-            What the Agentloop needs from its Environment, as URIs. Brain hands them to the
-            Environment at setup and with every turn, and reads none of them.
-          items:
-            format: uri
-            maxLength: 2048
-            minLength: 1
-            type: string
-          maxItems: 64
-          type: array
-          uniqueItems: true
       required:
       - implementation
       - configuration
@@ -480,7 +467,7 @@ components:
       - sequence
       - outcome
       type: object
-    KvSetRequest:
+    KvPutRequest:
       additionalProperties: false
       properties:
         key:
@@ -802,16 +789,6 @@ components:
       additionalProperties: false
       properties:
         implementation: true
-        needs:
-          default: []
-          items:
-            format: uri
-            maxLength: 2048
-            minLength: 1
-            type: string
-          maxItems: 64
-          type: array
-          uniqueItems: true
       required:
       - implementation
       type: object

--- a/crates/brain-http/tests/routes.rs
+++ b/crates/brain-http/tests/routes.rs
@@ -223,12 +223,12 @@ impl BrainApi for Api {
 async fn exposes_every_v1_route_with_its_contract_status() {
     let digest = "a".repeat(64);
     let id = "ses_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    // A create request in the execution shape: a tool declaring what it needs and its
+    // A create request in the execution shape: a tool declaring its implementation and
     // implementation, placed in an environment reached over HTTP with a credential.
     let create = serde_json::json!({
         "agentloop": {"implementation": {"type": "brain_component", "entrypoint": "turn", "id": digest}, "configuration": {}, "environment": "env_1"},
         "model": {"provider":"vercel-ai-gateway","name":"test/model","api_key":"test-key"},
-        "tools": [{"name": "bash", "description": "Run a shell command.", "input_schema": {"type": "object"}, "placements": {"env_1": {"needs": ["pkg:apt/bash", "file:///workspace?access=write"], "implementation": {"kind": "test"}}}}],
+        "tools": [{"name": "bash", "description": "Run a shell command.", "input_schema": {"type": "object"}, "placements": {"env_1": {"implementation": {"kind": "test"}}}}],
         "environments": [{
             "name": "env_1",
             "driver": "http",
@@ -345,7 +345,7 @@ async fn request_bodies_reject_unknown_fields() {
     let create = serde_json::json!({
         "agentloop": {"implementation": {"type": "brain_component", "entrypoint": "turn", "id": digest}, "configuration": {}, "environment": "env_1"},
         "model": {"provider":"vercel-ai-gateway","name":"test/model","api_key":"test-key"},
-        "tools": [{"name": "bash", "description": "Run a shell command.", "input_schema": {"type": "object"}, "binding_names": [], "hosting": "resident", "host_id": "host_12345678901234567890", "placements": {"env_1": {"needs": [], "implementation": {"type": "host_function", "name": "bash"}}}}],
+        "tools": [{"name": "bash", "description": "Run a shell command.", "input_schema": {"type": "object"}, "binding_names": [], "hosting": "resident", "host_id": "host_12345678901234567890", "placements": {"env_1": {"implementation": {"type": "host_function", "name": "bash"}}}}],
         "environments": [{
             "name": "env_1",
             "driver": "brain"

--- a/crates/brain-protocol/generated/contract/environment/v1/schemas.json
+++ b/crates/brain-protocol/generated/contract/environment/v1/schemas.json
@@ -135,23 +135,11 @@
       ]
     },
     "EnvironmentRequest": {
-      "description": "What Brain asks an Environment to do. An Environment provides resources and learns\nwhat runs in it only when asked to run it: setup carries its configuration and the\nneeds of everything placed there; execute carries an opaque implementation and input.",
+      "description": "What Brain asks an Environment to do. An Environment provides resources and learns\nwhat runs in it only when asked to run it: setup carries its configuration;\nexecute carries an opaque implementation and input.",
       "oneOf": [
         {
           "properties": {
             "configuration": true,
-            "needs": {
-              "description": "Every need of every Tool and the Agentloop placed here, as URIs. The\nEnvironment refuses at setup what it cannot honour, naming the URI.",
-              "items": {
-                "format": "uri",
-                "maxLength": 2048,
-                "minLength": 1,
-                "type": "string"
-              },
-              "maxItems": 64,
-              "type": "array",
-              "uniqueItems": true
-            },
             "type": {
               "const": "setup",
               "type": "string"
@@ -159,8 +147,7 @@
           },
           "required": [
             "type",
-            "configuration",
-            "needs"
+            "configuration"
           ],
           "type": "object"
         },
@@ -198,17 +185,6 @@
               "description": "Interpreted only by the Environment; fixes the runtime entrypoint and configuration."
             },
             "input": true,
-            "needs": {
-              "items": {
-                "format": "uri",
-                "maxLength": 2048,
-                "minLength": 1,
-                "type": "string"
-              },
-              "maxItems": 64,
-              "type": "array",
-              "uniqueItems": true
-            },
             "type": {
               "const": "execute",
               "type": "string"
@@ -217,7 +193,6 @@
           "required": [
             "type",
             "implementation",
-            "needs",
             "input",
             "deadline_ms"
           ],

--- a/crates/brain-protocol/generated/contract/session/v1/schemas.json
+++ b/crates/brain-protocol/generated/contract/session/v1/schemas.json
@@ -31,26 +31,13 @@
     },
     "AgentloopRef": {
       "additionalProperties": false,
-      "description": "The admitted Agentloop a session runs: which one, how it is configured, which\nEnvironment of the session runs it, and what it needs there.",
+      "description": "The admitted Agentloop a session runs: which one, how it is configured, which\nEnvironment of the session runs it.",
       "properties": {
         "configuration": true,
         "environment": {
           "$ref": "#/$defs/EnvironmentName"
         },
-        "implementation": true,
-        "needs": {
-          "default": [],
-          "description": "What the Agentloop needs from its Environment, as URIs. Brain hands them to the\nEnvironment at setup and with every turn, and reads none of them.",
-          "items": {
-            "format": "uri",
-            "maxLength": 2048,
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 64,
-          "type": "array",
-          "uniqueItems": true
-        }
+        "implementation": true
       },
       "required": [
         "implementation",
@@ -635,7 +622,7 @@
       ],
       "type": "object"
     },
-    "KvSetRequest": {
+    "KvPutRequest": {
       "additionalProperties": false,
       "properties": {
         "key": {
@@ -1076,19 +1063,7 @@
     "ToolPlacement": {
       "additionalProperties": false,
       "properties": {
-        "implementation": true,
-        "needs": {
-          "default": [],
-          "items": {
-            "format": "uri",
-            "maxLength": 2048,
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 64,
-          "type": "array",
-          "uniqueItems": true
-        }
+        "implementation": true
       },
       "required": [
         "implementation"

--- a/crates/brain-protocol/generated/contract/tool/v1/schemas.json
+++ b/crates/brain-protocol/generated/contract/tool/v1/schemas.json
@@ -39,19 +39,7 @@
     "ToolPlacement": {
       "additionalProperties": false,
       "properties": {
-        "implementation": true,
-        "needs": {
-          "default": [],
-          "items": {
-            "format": "uri",
-            "maxLength": 2048,
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 64,
-          "type": "array",
-          "uniqueItems": true
-        }
+        "implementation": true
       },
       "required": [
         "implementation"

--- a/crates/brain-protocol/src/agentloop/services.rs
+++ b/crates/brain-protocol/src/agentloop/services.rs
@@ -13,7 +13,7 @@ pub struct TurnEmitRequest {
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct KvSetRequest {
+pub struct KvPutRequest {
     #[schemars(schema_with = "crate::schema::identifier")]
     pub key: String,
     pub value: serde_json::Value,

--- a/crates/brain-protocol/src/client/session.rs
+++ b/crates/brain-protocol/src/client/session.rs
@@ -10,18 +10,13 @@ use crate::{
 pub const SESSION_CONTRACT: &str = "session/v1";
 
 /// The admitted Agentloop a session runs: which one, how it is configured, which
-/// Environment of the session runs it, and what it needs there.
+/// Environment of the session runs it.
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AgentloopRef {
     pub implementation: serde_json::Value,
     pub configuration: serde_json::Value,
     pub environment: EnvironmentName,
-    /// What the Agentloop needs from its Environment, as URIs. Brain hands them to the
-    /// Environment at setup and with every turn, and reads none of them.
-    #[serde(default)]
-    #[schemars(schema_with = "crate::schema::needs")]
-    pub needs: Vec<String>,
 }
 
 #[derive(Clone, Deserialize, JsonSchema, Serialize)]

--- a/crates/brain-protocol/src/contract.rs
+++ b/crates/brain-protocol/src/contract.rs
@@ -57,7 +57,7 @@ pub fn session() -> Value {
             define::<SessionSummary>(generator);
             define::<crate::SessionTranscript>(generator);
             define::<TurnEmitRequest>(generator);
-            define::<crate::KvSetRequest>(generator);
+            define::<crate::KvPutRequest>(generator);
             marker(SESSION_CONTRACT)
         },
     )

--- a/crates/brain-protocol/src/environment/outcome.rs
+++ b/crates/brain-protocol/src/environment/outcome.rs
@@ -1,8 +1,7 @@
 //! The vocabulary between a Tool and the Environment that executes it.
 //!
 //! An environment is a place that executes Tools and offers resources. A tool
-//! declares its implementation and what it needs, as URIs; the environment honours or
-//! refuses them. Brain journals every call and never wraps the platform: inside the
+//! declares its implementation; the Environment prepares it and enforces configured access. Brain journals every call and never wraps the platform: inside the
 //! environment a program reaches its resources through the platform's own APIs, and
 //! policy is enforced at the platform boundary, not by Brain.
 

--- a/crates/brain-protocol/src/environment/wire.rs
+++ b/crates/brain-protocol/src/environment/wire.rs
@@ -69,17 +69,13 @@ pub struct EnvironmentResponse {
 }
 
 /// What Brain asks an Environment to do. An Environment provides resources and learns
-/// what runs in it only when asked to run it: setup carries its configuration and the
-/// needs of everything placed there; execute carries an opaque implementation and input.
+/// what runs in it only when asked to run it: setup carries its configuration;
+/// execute carries an opaque implementation and input.
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EnvironmentRequest {
     Setup {
         configuration: serde_json::Value,
-        /// Every need of every Tool and the Agentloop placed here, as URIs. The
-        /// Environment refuses at setup what it cannot honour, naming the URI.
-        #[schemars(schema_with = "crate::schema::needs")]
-        needs: Vec<String>,
     },
     Call {
         #[schemars(schema_with = "crate::schema::identifier")]
@@ -89,8 +85,6 @@ pub enum EnvironmentRequest {
     Execute {
         /// Interpreted only by the Environment; fixes the runtime entrypoint and configuration.
         implementation: serde_json::Value,
-        #[schemars(schema_with = "crate::schema::needs")]
-        needs: Vec<String>,
         input: serde_json::Value,
         #[schemars(range(min = 1))]
         deadline_ms: u64,

--- a/crates/brain-protocol/src/schema.rs
+++ b/crates/brain-protocol/src/schema.rs
@@ -16,14 +16,3 @@ pub(crate) fn json_object(_: &mut SchemaGenerator) -> Schema {
 pub(crate) fn environment_contract(_: &mut SchemaGenerator) -> Schema {
     json_schema!({ "const": crate::ENVIRONMENT_CONTRACT })
 }
-
-/// What a Tool or an Agentloop needs from its Environment: a bounded list of URIs.
-/// Brain checks the shape and nothing else; the Environment honours or refuses each one.
-pub(crate) fn needs(_: &mut SchemaGenerator) -> Schema {
-    json_schema!({
-        "type": "array",
-        "maxItems": 64,
-        "uniqueItems": true,
-        "items": { "type": "string", "format": "uri", "minLength": 1, "maxLength": 2048 }
-    })
-}

--- a/crates/brain-protocol/src/tool.rs
+++ b/crates/brain-protocol/src/tool.rs
@@ -53,9 +53,6 @@ pub struct Tool {
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ToolPlacement {
-    #[serde(default)]
-    #[schemars(schema_with = "crate::schema::needs")]
-    pub needs: Vec<String>,
     pub implementation: serde_json::Value,
 }
 

--- a/crates/brain-protocol/tests/conformance.rs
+++ b/crates/brain-protocol/tests/conformance.rs
@@ -89,9 +89,9 @@ fn checked_in_examples_validate() {
     );
 }
 
-/// A Tool has at least one placement; each has its own implementation and URI needs.
+/// A Tool has at least one placement; each has its own implementation.
 #[test]
-fn a_tool_names_one_environment_and_its_needs_as_uris() {
+fn a_tool_names_its_placement_and_refuses_obsolete_needs() {
     let schema =
         jsonschema::draft202012::new(&read_json("generated/contract/tool/v1/schemas.json"))
             .unwrap();
@@ -108,14 +108,9 @@ fn a_tool_names_one_environment_and_its_needs_as_uris() {
         old[deleted] = serde_json::json!("x");
         assert!(schema.validate(&old).is_err(), "{deleted} must be refused");
     }
-    let mut repeated = example.clone();
-    repeated["placements"]["sandbox"]["needs"] =
-        serde_json::json!(["pkg:apt/bash", "pkg:apt/bash"]);
-    assert!(schema.validate(&repeated).is_err());
-    let mut too_many = example.clone();
-    too_many["placements"]["sandbox"]["needs"] =
-        serde_json::json!((0..65).map(|i| format!("pkg:apt/p{i}")).collect::<Vec<_>>());
-    assert!(schema.validate(&too_many).is_err());
+    let mut obsolete = example.clone();
+    obsolete["placements"]["sandbox"]["needs"] = serde_json::json!([]);
+    assert!(schema.validate(&obsolete).is_err());
     let mut host_tool = example;
     host_tool["placements"]["sandbox"]
         .as_object_mut()
@@ -174,10 +169,6 @@ fn rust_views_round_trip_contract_examples() {
             .placements
             .contains_key(&session.environments[1].name)
     );
-    assert_eq!(
-        session.tools[0].placements.values().next().unwrap().needs,
-        vec!["file:///workspace"]
-    );
     assert!(
         session.tools[0]
             .placements
@@ -203,7 +194,7 @@ fn rust_views_round_trip_contract_examples() {
         serde_json::from_value(read_json("tests/examples/environment/setup.json")).unwrap();
     assert!(matches!(
         setup.operation.request,
-        EnvironmentRequest::Setup { ref needs, .. } if needs.len() == 3
+        EnvironmentRequest::Setup { .. }
     ));
     let response: EnvironmentResponse =
         serde_json::from_value(read_json("tests/examples/environment/execute-result.json"))

--- a/crates/brain-protocol/tests/examples/environment/execute.json
+++ b/crates/brain-protocol/tests/examples/environment/execute.json
@@ -9,9 +9,6 @@
       "implementation": {
         "artifact_id": "artifact_read_v1"
       },
-      "needs": [
-        "file:///workspace?access=write"
-      ],
       "input": {
         "path": "README.md"
       },

--- a/crates/brain-protocol/tests/examples/environment/setup.json
+++ b/crates/brain-protocol/tests/examples/environment/setup.json
@@ -8,12 +8,7 @@
       "type": "setup",
       "configuration": {
         "region": "eu"
-      },
-      "needs": [
-        "file:///workspace?access=write",
-        "pkg:apt/ripgrep",
-        "https://api.example.com"
-      ]
+      }
     }
   }
 }

--- a/crates/brain-protocol/tests/examples/session/create-session.json
+++ b/crates/brain-protocol/tests/examples/session/create-session.json
@@ -2,7 +2,6 @@
   "agentloop": {
     "configuration": {},
     "environment": "brain",
-    "needs": [],
     "implementation": {
       "type": "brain_component",
       "entrypoint": "turn",
@@ -24,9 +23,6 @@
       },
       "placements": {
         "sandbox": {
-          "needs": [
-            "file:///workspace"
-          ],
           "implementation": {
             "artifact_id": "artifact_read_v1"
           }

--- a/crates/brain-protocol/tests/examples/tool/tool.json
+++ b/crates/brain-protocol/tests/examples/tool/tool.json
@@ -17,10 +17,6 @@
   },
   "placements": {
     "sandbox": {
-      "needs": [
-        "pkg:apt/bash",
-        "file:///workspace?access=write"
-      ],
       "implementation": {
         "artifact_id": "artifact_bash_v1"
       }

--- a/crates/brain-server/src/config.rs
+++ b/crates/brain-server/src/config.rs
@@ -20,7 +20,7 @@ pub struct ServerConfig {
     /// OS worker processes in the built-in Environment pool.
     #[arg(long, env = "BRAIN_ENV_WORKERS", default_value = "2")]
     pub env_workers: std::num::NonZeroUsize,
-    /// Origins the brain env may grant a Component that needs them: exact, or
+    /// Origins the brain env may grant through Environment configuration: exact, or
     /// `https://*.example.com` for a family of hosts.
     #[arg(long, env = "BRAIN_ENV_NETWORK_ALLOW", value_delimiter = ',')]
     pub env_network_allow: Vec<String>,

--- a/crates/brain-server/src/environment/host.rs
+++ b/crates/brain-server/src/environment/host.rs
@@ -651,7 +651,6 @@ mod tests {
         operation(EnvironmentRequest::Execute {
             implementation: serde_json::json!({"type": "host_function", "name": "read_dom"}),
             callback: None,
-            needs: Vec::new(),
             input: serde_json::json!({}),
             deadline_ms: 5_000,
         })
@@ -686,7 +685,6 @@ mod tests {
             session_id: session.clone(),
             ..operation(EnvironmentRequest::Setup {
                 configuration: serde_json::json!({}),
-                needs: Vec::new(),
             })
         };
         hosts
@@ -738,7 +736,6 @@ mod tests {
         let registration = hosts.register().unwrap();
         let setup = operation(EnvironmentRequest::Setup {
             configuration: serde_json::json!({}),
-            needs: Vec::new(),
         });
         assert!(
             hosts

--- a/crates/brain-server/src/executions.rs
+++ b/crates/brain-server/src/executions.rs
@@ -190,7 +190,15 @@ mod tests {
                 .await
                 .is_err()
         );
-        for method in ["model", "dispatch", "events", "set_transcript", "set_kv"] {
+        for method in [
+            "model",
+            "dispatch",
+            "events",
+            "set_transcript",
+            "kv_put",
+            "kv_read",
+            "kv_delete",
+        ] {
             assert!(
                 executions
                     .call(&session, 4, &callback.token, call(method))

--- a/crates/brain-sessions/src/environment.rs
+++ b/crates/brain-sessions/src/environment.rs
@@ -20,18 +20,15 @@ impl EnvironmentRegistry {
         Self { adapter }
     }
 
-    /// Sets up one Environment as part of session admission: its own configuration and
-    /// the needs of everything placed in it, recorded before they are sent.
+    /// Sets up one Environment with its configuration, recorded before delivery.
     pub async fn setup(
         &self,
         creation: &mut CreatingSession,
         environment: &Environment,
-        needs: Vec<String>,
     ) -> Result<(), brain::Error> {
         let kind = codes::event::call::ENVIRONMENT_SETUP;
         let request = EnvironmentRequest::Setup {
             configuration: environment.configuration.clone(),
-            needs,
         };
         let sequence = creation.record(
             &format!("{kind}_started"),

--- a/crates/brain-sessions/src/execution.rs
+++ b/crates/brain-sessions/src/execution.rs
@@ -39,7 +39,6 @@ impl LoopExecutor for EnvironmentLoopExecutor {
             session_id: session.clone(),
             request: EnvironmentRequest::Execute {
                 implementation: agentloop.implementation.clone(),
-                needs: agentloop.needs.clone(),
                 input: serde_json::to_value(input).map_err(json_error)?,
                 deadline_ms: self.deadline_ms,
                 callback: None,
@@ -105,7 +104,6 @@ impl ToolExecutor for SessionToolExecutor {
             request: EnvironmentRequest::Execute {
                 implementation: dispatch.placement.implementation,
                 callback: None,
-                needs: dispatch.placement.needs,
                 input: dispatch.invocation.input,
                 deadline_ms: dispatch.deadline_ms,
             },
@@ -180,7 +178,9 @@ impl ExecutionServices for SessionServices {
                 "emit",
                 "telemetry",
                 "set_transcript",
-                "set_kv",
+                "kv_put",
+                "kv_read",
+                "kv_delete",
             ],
             Self::Tool(_) => &["emit", "telemetry"],
         }
@@ -195,9 +195,21 @@ impl ExecutionServices for SessionServices {
                     .set_transcript(serde_json::from_value(input).map_err(json_error)?)
                     .await?
             )),
-            (Self::Loop(services), "set_kv") => Ok(json!(
+            (Self::Loop(services), "kv_put") => Ok(json!(
                 services
-                    .set_kv(serde_json::from_value(input).map_err(json_error)?)
+                    .kv_put(serde_json::from_value(input).map_err(json_error)?)
+                    .await?
+            )),
+            (Self::Loop(services), "kv_read") => {
+                let key = serde_json::from_value(input).map_err(json_error)?;
+                Ok(match services.kv_read(key).await? {
+                    Some(value) => json!({"value": value}),
+                    None => json!({}),
+                })
+            }
+            (Self::Loop(services), "kv_delete") => Ok(json!(
+                services
+                    .kv_delete(serde_json::from_value(input).map_err(json_error)?)
                     .await?
             )),
             (Self::Loop(services), "events") => serde_json::to_value(

--- a/crates/brain-sessions/src/execution_tests.rs
+++ b/crates/brain-sessions/src/execution_tests.rs
@@ -25,8 +25,8 @@ impl ToolServices for Leaf {
 
 fn dispatch() -> ToolDispatch {
     serde_json::from_value(json!({
-        "sequence":1,"session_id":"ses_test", "tool":{"name":"test","description":"Test","input_schema":{},"placements":{"remote":{"implementation":{},"needs":[]}}},
-        "placement":{"implementation":{},"needs":[]}, "environment":{"name":"remote","driver":"http","url":"https://example.com"},
+        "sequence":1,"session_id":"ses_test", "tool":{"name":"test","description":"Test","input_schema":{},"placements":{"remote":{"implementation":{}}}},
+        "placement":{"implementation":{}}, "environment":{"name":"remote","driver":"http","url":"https://example.com"},
         "invocation":{"name":"test","environment":"remote","call_id":"one","input":{}},"deadline_ms":1000
     })).unwrap()
 }

--- a/crates/brain-sessions/src/service.rs
+++ b/crates/brain-sessions/src/service.rs
@@ -340,15 +340,12 @@ impl Sessions {
         };
         self.cache_store(&store)?;
         drop(store_guard);
-        // Each Environment is set up with the needs of everything placed in it, in
-        // declaration order; the first refusal fails the create and tears down the rest.
         let mut ready = Vec::with_capacity(config.environments.len());
         for environment in &config.environments {
-            let needs = needs_for(&config, &environment.name);
             if let Err(error) = self
                 .resources
                 .environments
-                .setup(&mut creation, environment, needs)
+                .setup(&mut creation, environment)
                 .await
             {
                 creation
@@ -571,27 +568,6 @@ impl Sessions {
     }
 }
 
-fn needs_for(config: &SessionConfig, environment: &EnvironmentName) -> Vec<String> {
-    let mut needs = Vec::new();
-    let placed = config
-        .tools
-        .iter()
-        .filter_map(|tool| tool.placements.get(environment))
-        .flat_map(|placement| placement.needs.iter())
-        .chain(
-            (&config.agentloop.environment == environment)
-                .then_some(config.agentloop.needs.iter())
-                .into_iter()
-                .flatten(),
-        );
-    for need in placed {
-        if !needs.contains(need) {
-            needs.push(need.clone());
-        }
-    }
-    needs
-}
-
 fn valid_identifier(value: &str) -> bool {
     !value.is_empty()
         && value.len() <= 128
@@ -615,35 +591,3 @@ fn internal(message: impl Into<String>) -> ApiError {
 #[cfg(test)]
 #[path = "session_tests.rs"]
 mod session_tests;
-
-#[cfg(test)]
-mod tests {
-    use super::needs_for;
-    /// An Environment sees the needs of exactly what is placed in it, once each, so
-    /// it provisions what this session uses and nothing else.
-    #[test]
-    fn an_environment_is_set_up_with_the_needs_of_what_is_placed_in_it() {
-        let config: brain_protocol::SessionConfig = serde_json::from_value(serde_json::json!({
-            "agentloop": {"implementation": {"type": "brain_component", "entrypoint": "turn", "id": "a".repeat(64)}, "configuration": {}, "environment": "brain", "needs": ["https://api.example.com"]},
-            "model": {"provider": "openai", "name": "gpt-5-mini"},
-            "tools": [
-                {"name": "read", "description": "d", "input_schema": {}, "placements": {"brain": {"needs": ["file:///workspace", "https://api.example.com"], "implementation": {}}}},
-                {"name": "bash", "description": "d", "input_schema": {}, "placements": {"sandbox": {"needs": ["pkg:apt/bash"], "implementation": {}}}},
-                {"name": "note", "description": "d", "input_schema": {}, "placements": {"sandbox": {"needs": [], "implementation": {}}}}
-            ],
-            "environments": [
-                {"name": "brain", "driver": "brain"},
-                {"name": "sandbox", "driver": "http", "url": "https://sandbox.example"},
-                {"name": "app", "driver": "host", "host_id": "host_12345678901234567890"}
-            ]
-        }))
-        .unwrap();
-        let needs = |name: &str| needs_for(&config, &brain_protocol::EnvironmentName::new(name));
-        assert_eq!(
-            needs("brain"),
-            vec!["file:///workspace", "https://api.example.com"]
-        );
-        assert_eq!(needs("sandbox"), vec!["pkg:apt/bash"]);
-        assert!(needs("app").is_empty());
-    }
-}

--- a/crates/brain-sessions/src/session_tests.rs
+++ b/crates/brain-sessions/src/session_tests.rs
@@ -32,7 +32,7 @@ async fn graceful_drain_keeps_turn_services_alive_and_refuses_new_work() {
                 .set_transcript(vec![Message::user_text("finished while draining")])
                 .await?;
             services
-                .set_kv(brain_protocol::KvSetRequest {
+                .kv_put(brain_protocol::KvPutRequest {
                     key: "saved".into(),
                     value: serde_json::json!(true),
                 })

--- a/crates/brain/src/journal/session_store.rs
+++ b/crates/brain/src/journal/session_store.rs
@@ -548,6 +548,7 @@ impl LocalSessionStore {
                 let kind = match entry {
                     JournalEntry::TranscriptDelta { .. } => "transcript_delta",
                     JournalEntry::KvSet { .. } => "kv_set",
+                    JournalEntry::KvDelete { .. } => "kv_delete",
                 };
                 let payload = serde_json::to_value(entry).map_err(json_error)?;
                 encode_unsequenced(kind, &payload)

--- a/crates/brain/src/journal/store.rs
+++ b/crates/brain/src/journal/store.rs
@@ -86,11 +86,14 @@ pub enum JournalEntry {
         key: String,
         value: serde_json::Value,
     },
+    KvDelete {
+        key: String,
+    },
 }
 
 impl JournalEntry {
     pub(crate) fn is_kind(kind: &str) -> bool {
-        matches!(kind, "transcript_delta" | "kv_set")
+        matches!(kind, "transcript_delta" | "kv_set" | "kv_delete")
     }
 }
 
@@ -112,6 +115,9 @@ impl Folded {
             }
             JournalEntry::KvSet { key, value } => {
                 self.kv.insert(key, value);
+            }
+            JournalEntry::KvDelete { key } => {
+                self.kv.remove(&key);
             }
         }
     }

--- a/crates/brain/src/session/actor.rs
+++ b/crates/brain/src/session/actor.rs
@@ -439,12 +439,8 @@ impl TurnServices for TurnHost {
         Ok(cursor.through_sequence)
     }
 
-    async fn set_kv(&self, request: brain_protocol::KvSetRequest) -> Result<u64, Error> {
-        if !valid_kind(&request.key) || request.key == LAST_ACTIVATION_KEY {
-            return Err(Error::InvalidState(
-                "kv key must be an identifier not reserved by Brain".into(),
-            ));
-        }
+    async fn kv_put(&self, request: brain_protocol::KvPutRequest) -> Result<u64, Error> {
+        validate_kv_key(&request.key)?;
         let mut cursor = self.cursor.lock().await;
         self.check_cancelled()?;
         if cursor.kv.get(&request.key) != Some(&request.value) {
@@ -454,6 +450,28 @@ impl TurnServices for TurnHost {
             };
             cursor.through_sequence = append_journal(self.store.clone(), vec![entry]).await?;
             cursor.kv.insert(request.key, request.value);
+        }
+        Ok(cursor.through_sequence)
+    }
+
+    async fn kv_read(&self, key: String) -> Result<Option<serde_json::Value>, Error> {
+        validate_kv_key(&key)?;
+        let cursor = self.cursor.lock().await;
+        self.check_cancelled()?;
+        Ok(cursor.kv.get(&key).cloned())
+    }
+
+    async fn kv_delete(&self, key: String) -> Result<u64, Error> {
+        validate_kv_key(&key)?;
+        let mut cursor = self.cursor.lock().await;
+        self.check_cancelled()?;
+        if cursor.kv.contains_key(&key) {
+            cursor.through_sequence = append_journal(
+                self.store.clone(),
+                vec![JournalEntry::KvDelete { key: key.clone() }],
+            )
+            .await?;
+            cursor.kv.remove(&key);
         }
         Ok(cursor.through_sequence)
     }
@@ -924,6 +942,15 @@ pub(crate) fn delta(recorded: &[Message], wanted: &[Message]) -> Option<JournalE
         keep: keep as u64,
         append: wanted[keep..].to_vec(),
     })
+}
+
+fn validate_kv_key(key: &str) -> Result<(), Error> {
+    if !valid_kind(key) || key == LAST_ACTIVATION_KEY {
+        return Err(Error::InvalidState(
+            "kv key must be an identifier not reserved by Brain".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn valid_kind(kind: &str) -> bool {

--- a/crates/brain/src/session/mod.rs
+++ b/crates/brain/src/session/mod.rs
@@ -341,25 +341,6 @@ fn validate_session_contract(config: &SessionConfig) -> Result<(), Error> {
             "Environment name is not an identifier".into(),
         ));
     }
-    // Needs are handed to the Environment unread; Brain checks only that they are a
-    // bounded list of distinct URIs, so a malformed one is refused here rather than
-    // silently ignored there.
-    let declared = config
-        .tools
-        .iter()
-        .flat_map(|tool| {
-            tool.placements
-                .values()
-                .map(|placement| (tool.name.as_str(), &placement.needs))
-        })
-        .chain(std::iter::once(("agentloop", &config.agentloop.needs)));
-    for (subject, needs) in declared {
-        if !needs_valid(needs) {
-            return Err(Error::InvalidState(format!(
-                "`{subject}` names an invalid or repeated need"
-            )));
-        }
-    }
     // The server seals an Environment credential beside the model key; a configuration
     // still carrying one would write it into the journal.
     if config.environments.iter().any(|environment| {
@@ -423,35 +404,6 @@ fn identifier_valid(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
 }
 
-/// At most 64 distinct URIs, each with a scheme and no whitespace or control characters.
-fn needs_valid(needs: &[String]) -> bool {
-    needs.len() <= 64
-        && needs.iter().all(|need| uri_shaped(need))
-        && needs
-            .iter()
-            .enumerate()
-            .all(|(index, need)| !needs[..index].contains(need))
-}
-
-fn uri_shaped(value: &str) -> bool {
-    let Some((scheme, rest)) = value.split_once(':') else {
-        return false;
-    };
-    let scheme_valid = scheme
-        .bytes()
-        .next()
-        .is_some_and(|byte| byte.is_ascii_alphabetic())
-        && scheme
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'));
-    scheme_valid
-        && !rest.is_empty()
-        && value.len() <= 2_048
-        && !value
-            .chars()
-            .any(|character| character.is_whitespace() || character.is_control())
-}
-
 pub fn random_id(prefix: &str) -> String {
     let mut bytes = [0_u8; 16];
     rand::rng().fill_bytes(&mut bytes);
@@ -502,7 +454,6 @@ mod tests {
             placements: std::collections::BTreeMap::from([(
                 EnvironmentName::new("workspace"),
                 brain_protocol::ToolPlacement {
-                    needs: Vec::new(),
                     implementation: serde_json::json!({"kind": "test"}),
                 },
             )]),
@@ -524,7 +475,6 @@ mod tests {
             agentloop: AgentloopRef {
                 configuration: serde_json::json!({}),
                 environment: EnvironmentName::new("workspace"),
-                needs: Vec::new(),
                 implementation: serde_json::json!({"type": "brain_component", "entrypoint": "turn", "id": AgentloopId::new(digest())}),
             },
             model: ModelBinding {
@@ -573,15 +523,6 @@ mod tests {
         placed_elsewhere.tools[0]
             .placements
             .insert(EnvironmentName::new("sandbox"), placement);
-        placed_elsewhere.tools[0]
-            .placements
-            .values_mut()
-            .next()
-            .unwrap()
-            .needs = vec![
-            "file:///workspace?access=write".into(),
-            "pkg:pypi/numpy".into(),
-        ];
         validate_session_contract(&placed_elsewhere).unwrap();
     }
 
@@ -651,35 +592,6 @@ mod tests {
                 "Environment name",
             ),
             (
-                "a Tool need that is not a URI",
-                |request| {
-                    request.tools[0]
-                        .placements
-                        .values_mut()
-                        .next()
-                        .unwrap()
-                        .needs = vec!["../fs".into()]
-                },
-                "invalid or repeated need",
-            ),
-            (
-                "a Tool need repeated",
-                |request| {
-                    request.tools[0]
-                        .placements
-                        .values_mut()
-                        .next()
-                        .unwrap()
-                        .needs = vec!["pkg:apt/ffmpeg".into(), "pkg:apt/ffmpeg".into()];
-                },
-                "invalid or repeated need",
-            ),
-            (
-                "an Agentloop need with whitespace",
-                |request| request.agentloop.needs = vec!["https://api.example.com /".into()],
-                "invalid or repeated need",
-            ),
-            (
                 "an Environment credential left unsealed",
                 |request| {
                     request.environments.push(environment(
@@ -741,32 +653,5 @@ mod tests {
         assert!(!identifier_valid("has/slash"));
         assert!(!identifier_valid("../escape"));
         assert!(!identifier_valid("na\u{ef}ve"));
-    }
-
-    #[test]
-    fn a_need_is_any_uri_and_nothing_else() {
-        for valid in [
-            "pkg:apt/ffmpeg",
-            "pkg:pypi/numpy@2.1.0",
-            "https://api.example.com",
-            "https://*.example.com",
-            "wss://stream.example.com",
-            "file:///workspace?access=write",
-            "aws:iam",
-        ] {
-            assert!(uri_shaped(valid), "{valid}");
-        }
-        for invalid in [
-            "",
-            "fs",
-            "../fs",
-            "https://a b",
-            "1pkg:x",
-            "pkg:",
-            ":x",
-            "a\tb:c",
-        ] {
-            assert!(!uri_shaped(invalid), "{invalid}");
-        }
     }
 }

--- a/crates/brain/src/session/services.rs
+++ b/crates/brain/src/session/services.rs
@@ -16,7 +16,11 @@ pub trait TurnServices: Send + Sync {
     /// Replaces conversation state and returns its durable journal sequence.
     async fn set_transcript(&self, messages: Vec<brain_protocol::Message>) -> Result<u64, Error>;
     /// Saves one value and returns its durable journal sequence.
-    async fn set_kv(&self, request: brain_protocol::KvSetRequest) -> Result<u64, Error>;
+    async fn kv_put(&self, request: brain_protocol::KvPutRequest) -> Result<u64, Error>;
+    /// Reads current state; absence is distinct from JSON null.
+    async fn kv_read(&self, key: String) -> Result<Option<serde_json::Value>, Error>;
+    /// Removes one key durably. Missing keys are a no-op.
+    async fn kv_delete(&self, key: String) -> Result<u64, Error>;
     /// One model call. What the request leaves unsaid is what the session was created
     /// with. The request is journaled independently of conversation state.
     async fn model(&self, request: ModelRequest) -> Result<ModelResult, Error>;

--- a/crates/brain/tests/common/mod.rs
+++ b/crates/brain/tests/common/mod.rs
@@ -182,7 +182,6 @@ pub fn config() -> SessionConfig {
         agentloop: AgentloopRef {
             configuration: serde_json::json!({}),
             environment: EnvironmentName::new("workspace"),
-            needs: Vec::new(),
             implementation: serde_json::json!({"type": "brain_component", "entrypoint": "turn", "id": AgentloopId::new("a".repeat(64))}),
         },
         model: ModelBinding {

--- a/crates/brain/tests/protocol_freeze.rs
+++ b/crates/brain/tests/protocol_freeze.rs
@@ -2,7 +2,7 @@ mod common;
 
 use brain::{Error, LocalSessionStore, SessionStore, ToolExecutor, ToolServices};
 use brain_protocol::{
-    EventOrigin, KvSetRequest, Message, MessageRequest, ModelRequest, Outcome, ToolCancellation,
+    EventOrigin, KvPutRequest, Message, MessageRequest, ModelRequest, Outcome, ToolCancellation,
     ToolDispatch, ToolInvocation, TurnOutput,
 };
 use common::{Runtime, ScriptedModel, config, scripted, temporary_directory};
@@ -51,14 +51,39 @@ async fn inline_state_and_execution_provenance_survive_a_failed_turn_and_reopen(
         scripted(|_, services| async move {
             services.set_transcript(conversation()).await?;
             services
-                .set_kv(KvSetRequest {
+                .kv_put(KvPutRequest {
                     key: "phase".into(),
                     value: json!("saved"),
                 })
                 .await?;
+            assert_eq!(services.kv_read("missing".into()).await?, None);
+            let written = services
+                .kv_put(KvPutRequest {
+                    key: "deleted".into(),
+                    value: json!(null),
+                })
+                .await?;
+            assert_eq!(services.kv_read("deleted".into()).await?, Some(json!(null)));
+            let deleted = services.kv_delete("deleted".into()).await?;
+            assert!(deleted > written);
+            assert_eq!(services.kv_read("deleted".into()).await?, None);
+            assert_eq!(services.kv_delete("deleted".into()).await?, deleted);
             assert!(
                 services
-                    .set_kv(KvSetRequest {
+                    .kv_delete("brain.last_activation".into())
+                    .await
+                    .is_err()
+            );
+            assert!(
+                services
+                    .kv_read("brain.last_activation".into())
+                    .await
+                    .is_err()
+            );
+            assert!(services.kv_delete("../bad".into()).await.is_err());
+            assert!(
+                services
+                    .kv_put(KvPutRequest {
                         key: "brain.last_activation".into(),
                         value: json!(0)
                     })
@@ -106,7 +131,7 @@ async fn inline_state_and_execution_provenance_survive_a_failed_turn_and_reopen(
         Arc::new(EmittingTool),
     );
     let mut config = config();
-    config.tools = vec![serde_json::from_value(json!({"name":"emit", "description":"Emit", "input_schema":{"type":"object"}, "placements":{"workspace":{"implementation":{}, "needs":[]}}})).unwrap()];
+    config.tools = vec![serde_json::from_value(json!({"name":"emit", "description":"Emit", "input_schema":{"type":"object"}, "placements":{"workspace":{"implementation":{}}}})).unwrap()];
     let session = runtime.create(&config, &[]).unwrap();
     let mut live = runtime.feed.subscribe(session.id());
     session
@@ -117,6 +142,7 @@ async fn inline_state_and_execution_provenance_survive_a_failed_turn_and_reopen(
     let folded = store.fold().unwrap();
     assert_eq!(folded.transcript, conversation());
     assert_eq!(folded.kv["phase"], "saved");
+    assert!(!folded.kv.contains_key("deleted"));
     let records = store.records_after(0, 100).unwrap();
     let activation = records
         .iter()

--- a/crates/brain/tests/session.rs
+++ b/crates/brain/tests/session.rs
@@ -22,8 +22,7 @@ use brain_protocol::{
 };
 use brain_telemetry::telemetry_channel;
 use common::{
-    NoModels, NoTools, Runtime, ScriptedModel, SlowModel, config, echo_loop, scripted,
-    temporary_directory,
+    NoModels, NoTools, Runtime, ScriptedModel, SlowModel, config, scripted, temporary_directory,
 };
 
 fn user(text: &str) -> Message {
@@ -60,8 +59,8 @@ fn invocation(name: &str, call_id: &str) -> ToolInvocation {
     }
 }
 
-/// A configuration placing one Tool with the given `needs` in the Agentloop's Environment.
-fn tool_config(tool_name: &str, needs: Vec<&str>) -> SessionConfig {
+/// A configuration placing one Tool in the Agentloop's Environment.
+fn tool_config(tool_name: &str) -> SessionConfig {
     let mut config = config();
     config.tools = vec![Tool {
         name: tool_name.into(),
@@ -71,7 +70,6 @@ fn tool_config(tool_name: &str, needs: Vec<&str>) -> SessionConfig {
         placements: std::collections::BTreeMap::from([(
             EnvironmentName::new("workspace"),
             brain_protocol::ToolPlacement {
-                needs: needs.into_iter().map(String::from).collect(),
                 implementation: serde_json::json!({"kind": "test"}),
             },
         )]),
@@ -98,7 +96,6 @@ fn host_tool_config(tool_name: &str) -> SessionConfig {
         placements: std::collections::BTreeMap::from([(
             EnvironmentName::new("app"),
             brain_protocol::ToolPlacement {
-                needs: Vec::new(),
                 implementation: serde_json::json!({"type": "host_function", "name": tool_name}),
             },
         )]),
@@ -327,7 +324,7 @@ async fn cancel_forwards_inflight_tool_cancellation_to_the_environment_port() {
         done(&*services, transcript).await
     });
     let runtime = runtime_with_deadline(&data_dir, loop_executor, tools.clone(), 120);
-    let handle = runtime.create(&tool_config("slow", vec![]), &[]).unwrap();
+    let handle = runtime.create(&tool_config("slow"), &[]).unwrap();
     let turning = {
         let handle = handle.clone();
         tokio::spawn(async move { handle.message(MessageRequest { input: "go".into() }).await })
@@ -386,7 +383,7 @@ async fn wall_deadline_keeps_completed_tool_results_and_records_unknown_cancella
         .unwrap()
         .limits
         .max_turn_secs = 2;
-    let session = runtime.create(&tool_config("lookup", vec![]), &[]).unwrap();
+    let session = runtime.create(&tool_config("lookup"), &[]).unwrap();
     let turning = tokio::spawn({
         let session = session.clone();
         async move { session.message(MessageRequest { input: "go".into() }).await }
@@ -614,35 +611,6 @@ async fn the_journal_is_the_only_thing_written() {
     assert!(!found.iter().any(|name| name.contains("/events/")));
 }
 
-/// What a Tool needs is the Environment's business: Brain admits the declaration and
-/// hands it over unread, so a need it could never satisfy itself is not a reason to
-/// refuse the session.
-#[tokio::test]
-async fn needs_are_admitted_unread() {
-    let data_dir = temporary_directory("needs");
-    let runtime = runtime(
-        &data_dir,
-        echo_loop(),
-        Arc::new(NoModels),
-        Arc::new(NoTools),
-    );
-    let handle = runtime
-        .create(
-            &tool_config(
-                "bash",
-                vec!["pkg:apt/ffmpeg", "file:///workspace?access=write"],
-            ),
-            &[],
-        )
-        .unwrap();
-    assert!(matches!(
-        runtime.session(handle.id()).status,
-        brain_protocol::SessionStatus::Idle
-    ));
-    drop(handle);
-    settle(runtime, data_dir).await;
-}
-
 /// The started record identifies the authorized placement used for this invocation.
 #[tokio::test]
 async fn a_tool_call_record_names_the_tool_and_nothing_else_about_it() {
@@ -662,9 +630,7 @@ async fn a_tool_call_record_names_the_tool_and_nothing_else_about_it() {
         done(&*services, input.transcript).await
     });
     let runtime = runtime_with_deadline(&data_dir, loop_executor, tools, 5);
-    let handle = runtime
-        .create(&tool_config("bash", vec!["pkg:apt/ffmpeg"]), &[])
-        .unwrap();
+    let handle = runtime.create(&tool_config("bash"), &[]).unwrap();
     handle
         .message(MessageRequest { input: "go".into() })
         .await
@@ -737,7 +703,7 @@ async fn invoke_outcomes_map_onto_tool_results() {
             })
         };
         let runtime = runtime_with_deadline(&data_dir, loop_executor, tools, 5);
-        let handle = runtime.create(&tool_config("tool", vec![]), &[]).unwrap();
+        let handle = runtime.create(&tool_config("tool"), &[]).unwrap();
         handle
             .message(MessageRequest { input: "go".into() })
             .await
@@ -785,7 +751,7 @@ async fn an_overdue_invoke_is_cancelled_and_recorded_as_unknown() {
         })
     };
     let runtime = runtime_with_deadline(&data_dir, loop_executor, tools.clone(), 1);
-    let handle = runtime.create(&tool_config("slow", vec![]), &[]).unwrap();
+    let handle = runtime.create(&tool_config("slow"), &[]).unwrap();
     let started = std::time::Instant::now();
     handle
         .message(MessageRequest { input: "go".into() })
@@ -904,7 +870,7 @@ async fn the_transcript_folds_back_from_its_deltas() {
         transcript.push(second.message);
         services.set_transcript(transcript).await?;
         services
-            .set_kv(brain_protocol::KvSetRequest {
+            .kv_put(brain_protocol::KvPutRequest {
                 key: "memory".into(),
                 value: serde_json::json!({"turns": 1}),
             })

--- a/crates/brain/tests/session_store.rs
+++ b/crates/brain/tests/session_store.rs
@@ -481,3 +481,43 @@ fn committed_completion_prefix_survives_without_inventing_turn_success() {
         assert!(!reopened.interrupt_unfinished_turn().unwrap());
     }
 }
+
+#[test]
+fn kv_deletion_replays_from_the_unchanged_journal_without_a_checkpoint() {
+    let directory = temporary("kv-delete");
+    let writer = Writer::spawn();
+    let store = created(&directory, &writer);
+    store
+        .append_journal_sync(&[
+            JournalEntry::KvSet {
+                key: "removed".into(),
+                value: serde_json::Value::Null,
+            },
+            JournalEntry::KvSet {
+                key: "kept".into(),
+                value: serde_json::Value::Null,
+            },
+        ])
+        .unwrap();
+    store.checkpoint().unwrap();
+    let sequence = store
+        .append_journal_sync(&[JournalEntry::KvDelete {
+            key: "removed".into(),
+        }])
+        .unwrap();
+    let expected = store.fold().unwrap();
+    assert!(!expected.kv.contains_key("removed"));
+    assert_eq!(expected.kv.get("kept"), Some(&serde_json::Value::Null));
+    assert_eq!(expected.through_sequence, sequence);
+    drop(store);
+    let path = directory.join("ses_1");
+    let store = LocalSessionStore::open(&path, writer.clone(), feed()).unwrap();
+    assert_eq!(store.fold().unwrap(), expected);
+    drop(store);
+    fs::write(path.join("checkpoint"), b"damaged").unwrap();
+    let store = LocalSessionStore::open(&path, writer.clone(), feed()).unwrap();
+    assert_eq!(store.fold().unwrap(), expected);
+    drop(store);
+    drop(writer);
+    fs::remove_dir_all(directory).unwrap();
+}

--- a/docs/concepts/agent-loop.mdx
+++ b/docs/concepts/agent-loop.mdx
@@ -20,7 +20,6 @@ import { z } from "zod";
 const assistant = agentloop({
   options: z.object({ compactAt: z.number().min(0).max(1) }),
   implementation: component(new URL("./assistant.wasm", import.meta.url)),
-  needs: ["https://models.example.com"],
 });
 
 const placed = assistant({ env: brainEnv({ name: "brain" }), compactAt: 0.8 });
@@ -28,8 +27,8 @@ const placed = assistant({ env: brainEnv({ name: "brain" }), compactAt: 0.8 });
 
 `component(...)` accepts a `URL` or `Uint8Array`. The client reads the raw bytes, admits them, and
 creates the session with the resulting id, the parsed options, and the Environment. Every Agentloop
-factory is placed with `{ env, ...options }`, and the loop declares `needs` exactly as a Tool does:
-they join the others at setup, and its id and needs arrive with every turn.
+factory is placed with `{ env, ...options }`. Dependencies are packaged with the implementation
+or prepared by its Environment; resource grants belong to that Environment’s configuration.
 
 ## The Component contract
 
@@ -42,9 +41,13 @@ The Component exports one `turn` function. Its input contains:
 - its configuration, system prompt, Tool definitions, and deterministic runtime envelope.
 
 During the activation it may call Brain's `events`, `model`, `dispatch`, `emit`, `set-transcript`,
-`set-kv`, and `telemetry` imports.
+`kv-read`, `kv-put`, `kv-delete`, and `telemetry` imports.
 `model`, `dispatch`, and `emit` cross the Brain boundary. Brain commits an external-effect intent
 before dispatch, sends it once, and commits its terminal or unknown outcome before returning it.
+
+KV reads distinguish absence from JSON null. Put creates or replaces one value; delete removes a
+key from the current projection without erasing journal history. Missing-key deletion is a no-op.
+JavaScript bindings expose `ctx.kv.read(key)`, `ctx.kv.put(key, value)`, and `ctx.kv.delete(key)`.
 
 The Component saves transcript and kv changes inline through the state imports, each committed
 before returning. Turn output carries only the result. Every turn uses a fresh Wasm instance,
@@ -53,7 +56,7 @@ while compiled and prelinked code is reused.
 ## Where it runs
 
 An Agentloop may be placed in any Environment. The brain env runs it in a fresh Wasmtime instance
-per activation with exactly the grants its `needs` name, the same way it runs a Tool. An
+per activation with its Environment’s configured grants, the same way it runs a Tool. An
 Environment reached over HTTP receives each turn with the address of Brain's turn routes for that
 turn and the token that opens them, and reaches the same services through them; Brain
 journals every call the same way. The factory always requires an explicit `env` so the placement

--- a/docs/concepts/environment.mdx
+++ b/docs/concepts/environment.mdx
@@ -12,24 +12,33 @@ Environment's concern. Brain ships two, and any other is an extension.
 
 `brainEnv({ name })` is Brain's own Environment, managed by the server in a separate pool of OS worker processes. A Tool placed here is a
 Component admitted through `POST /v1/tools`; the Agentloop is one admitted through
-`POST /v1/agentloops`. Each invocation runs in a fresh Wasmtime instance granted exactly what its
-`needs` name, bounded by the deployment's allow-lists:
+`POST /v1/agentloops`. Each invocation receives this Environment's configured grants,
+bounded by the deployment's allow-lists:
 
-- `file:///workspace` is the directory for this session and Environment name, retained until teardown;
-  `file:///scratch` lives for one invocation. Both are read-only unless the need says
-  `?access=write`. The root must appear in `BRAIN_ENV_FILESYSTEM_ALLOW`.
-- An `https:` or `http:` origin, exact or `https://*.example.com`, opens `wasi:http` to it. It must be
-  within `BRAIN_ENV_NETWORK_ALLOW`.
-- `pkg:` is refused: a Component brings its own code.
+- `filesystem.workspace` is `"read"` or `"write"` for the session and Environment's retained
+  `/workspace`; `filesystem.scratch` grants an invocation-local `/scratch`. The root must
+  appear in `BRAIN_ENV_FILESYSTEM_ALLOW`.
+- `network` lists HTTP(S) origins, optionally `https://*.example.com`, within
+  `BRAIN_ENV_NETWORK_ALLOW`.
+- `secrets` names process environment variables within `BRAIN_ENV_SECRET_ALLOW`, mounted
+  read-only under `/secrets`.
 
 ```ts
 import { brainEnv } from "@aexhq/brain";
 
-const brain = brainEnv({ name: "brain", secrets: ["MODEL_TOKEN"] });
+const writer = brainEnv({
+  name: "writer",
+  filesystem: { workspace: "write", scratch: "read" },
+  network: ["https://api.example.com"],
+  secrets: ["SERVICE_TOKEN"],
+});
 ```
 
-`secrets` is the brain env's one option: process environment variables named in
-`BRAIN_ENV_SECRET_ALLOW`, mounted read-only under `/secrets`. Every server grant is empty by default.
+Omitted access is denied, and all server allow-lists are empty by default. Tools in the same
+Environment share its grants; use separate named bindings for different authority. Do not
+silently union old per-Tool grants. Components bring their own code; this Environment installs
+no OS packages or interpreters.
+
 By default each invocation receives 10 billion Wasmtime fuel units for guest computation; model, Tool,
 HTTP, and filesystem waits consume no fuel. `BRAIN_MAX_TURN_SECS` still bounds the whole turn.
 
@@ -76,11 +85,15 @@ const session = await brain.sessions.create({
 
 ## What an Environment is told
 
-Setup carries the Environment's configuration and one flat list: the `needs` of every Tool and the
-Agentloop placed in it. The Environment provisions what this session uses and refuses what it
-cannot honour, naming the URI; a refusal fails the create. Every execution carries an opaque
-implementation descriptor, needs, input, deadline, and optional invocation-scoped service grants.
-An Environment learns what runs in it only when asked to run it.
+Setup carries only the Environment's configuration. Execute carries an opaque implementation,
+input, deadline, and optional invocation-scoped service grants. There is no universal dependency
+manifest. The Environment's loader may prepare a project before its first execution, using
+normal lockfiles, scripts, or images. Preparation finishes before imports and the entrypoint.
+Concurrent first uses share preparation of one installation; reuse follows the actual resource
+lifetime, not a turn or automatically a session. Setup code cannot widen configured authority.
+
+A lazy preparation failure can happen after session creation succeeds. It is an ordinary
+execution failure; Brain does not retry, change placement, or claim partial effects were undone.
 
 ## Lifecycle and delivery
 

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -51,7 +51,8 @@ The Agentloop owns transcript contents while Brain owns persistence. `set-transc
 difference from the saved transcript. Appends store only the tail; summaries, edits, and reorders
 restart at the first changed item. Recovery folds those deltas in journal order.
 
-`set-kv` commits one key/value change. Each operation is durable before it returns, independently
+`kv-put` commits one key/value change; `kv-delete` commits removal from current state without
+erasing history. `kv-read` distinguishes a missing key from stored JSON null. Each operation is durable before it returns, independently
 of turn success. Every invocation uses a fresh Wasm instance; save state through these services.
 Turn completion cannot overwrite saved state with a returned snapshot.
 

--- a/docs/concepts/tool.mdx
+++ b/docs/concepts/tool.mdx
@@ -1,12 +1,12 @@
 ---
 title: Tools
-description: One typed contract, what it needs, and the Environment that runs it.
+description: One typed contract, its implementation, and the Environment that runs it.
 ---
 
 A Tool is the model-visible contract for one action: a name, description, input schema, and
 optional output schema. A Tool can have placements in several Environments of its session,
 each declared with `{ env, ...options }`. Each `(Tool name, Environment name)` pair has one
-implementation and its own needs. Where that Environment is, and how Brain reaches it, is the
+implementation. Where that Environment is, and how Brain reaches it, is the
 Environment's concern; the Tool's declaration is the same everywhere.
 
 ## A function this process holds
@@ -53,10 +53,9 @@ const inspect = tool({
   input: z.object({ path: z.string() }),
   options: z.object({ depth: z.number().int().positive() }),
   implementation: component(new URL("./inspect.wasm", import.meta.url)),
-  needs: ["file:///workspace"],
 });
 
-const placed = inspect({ env: brainEnv({ name: "brain" }), depth: 2 });
+const placed = inspect({ env: brainEnv({ name: "reader", filesystem: { workspace: "read" } }), depth: 2 });
 ```
 
 `implementation` may be a Component, an opaque object the Environment understands, or a function of
@@ -65,20 +64,18 @@ the parsed options that returns that object. A Component implements
 it receives JSON input, its configuration, and a deadline, and can emit committed extension events
 through its host import.
 
-## What a Tool needs
+## Dependencies and resource access
 
-`needs` is a list of URIs, the same list for every kind of Environment:
+Package dependencies with the implementation or let the chosen Environment prepare them using
+its loader, lockfile, or optional setup script. Preparation must finish before import-time
+dependencies or the entrypoint are used. Brain has no universal `needs` declaration and installs
+nothing in its own process.
 
-- `pkg:` names software as a [Package URL](https://github.com/package-url/purl-spec), for example
-  `pkg:apt/ffmpeg` or `pkg:pypi/numpy@2.1.0`;
-- `https:` or `wss:` names a network destination, with `https://*.example.com` for a family of hosts;
-- `file:` names a filesystem location, read-only unless it carries `?access=write`.
-
-Brain checks the shape and hands the list to the Environment: all of them at setup, so the
-Environment provisions what this session uses, and the Tool's own with every invoke. The
-Environment honours what it can and refuses the rest at setup, naming the URI. Brain reads none
-of them and carries nothing at run time on the Tool's behalf: the code obtains what it needs
-through the platform of its Environment.
+The application configures access through the Environment. For example,
+`brainEnv({ name: "reader", filesystem: { workspace: "read" } })` requests a workspace within
+the server's allow-list. Use separate Environment bindings for different grants; every Tool in
+one native binding receives that binding's authority. A denied grant or unsupported runtime
+fails explicitly. Setup failures reach the ordinary Tool error path, without automatic retry.
 
 ## One execution rule
 

--- a/docs/guides/write-a-loop.mdx
+++ b/docs/guides/write-a-loop.mdx
@@ -18,7 +18,9 @@ The Component exports `turn` and imports these Brain services:
 - `dispatch` invokes one or more Tools;
 - `emit` appends an extension Event and returns its committed sequence;
 - `set-transcript` durably replaces the saved conversation with the supplied messages;
-- `set-kv` durably sets one Agentloop key to a JSON value;
+- `kv-read(key)` returns an optional JSON string, distinguishing absence from stored null;
+- `kv-put(key, value-json)` durably creates or replaces one value;
+- `kv-delete(key)` durably removes a key; deleting an absent key is a no-op;
 - `telemetry` publishes best-effort operational telemetry.
 
 JSON strings on the WIT boundary use the generated session contract, also packaged as
@@ -29,6 +31,8 @@ It returns only an optional result. Old transcript/kv fields in turn output are 
 
 Await state services at the point the change should become durable. Each write returns its
 committed sequence; later failure preserves completed writes. Separate writes are not a transaction.
+Bindings expose `ctx.kv.read/put/delete`; the initial KV snapshot is a transport detail, not a
+second mutable author API. KV deletion changes the projection, never earlier journal records.
 Model calls record their actual request and result without changing the saved conversation, so an
 auxiliary classification or summary request cannot replace it accidentally. Save the selected
 conversation explicitly. Neither guest memory nor an unsubmitted local mutation survives activation.
@@ -46,7 +50,6 @@ import { z } from "zod";
 export const assistant = agentloop({
   options: z.object({ compactAt: z.number().min(0).max(1) }),
   implementation: component(new URL("./assistant.wasm", import.meta.url)),
-  needs: ["https://models.example.com"],
 });
 
 const loop = assistant({ env: brainEnv({ name: "brain" }), compactAt: 0.8 });
@@ -115,6 +118,6 @@ the default eight instances cannot hold their interpreter and generated adapters
 
 These small examples use `--stub-wasi`: they demonstrate Python computation and Brain callbacks,
 and do not provide Python filesystem or network APIs. A package that needs WASI must link only
-the worker's supported interfaces and declare the corresponding needs. Brain does not install
+the worker's supported interfaces and be placed in an Environment with the corresponding grants. Brain does not install
 Python or pip packages at runtime. Every execution has a fresh interpreter; persist Agentloop
-state through `set-kv` and retain files only in an explicitly granted Environment workspace.
+state through `kv-put` and `kv-delete` and retain files only in an explicitly granted Environment workspace.

--- a/docs/guides/write-a-tool.mdx
+++ b/docs/guides/write-a-tool.mdx
@@ -1,6 +1,6 @@
 ---
 title: Write a Tool
-description: Declare one typed contract, what it needs, and place it where it runs.
+description: Declare one typed contract, its implementation, and place it where it runs.
 ---
 
 Every Tool has a model-visible name, description, input schema, and optional output schema, and is
@@ -94,10 +94,9 @@ export const inspect = tool({
   input: z.object({ path: z.string() }),
   options: z.object({ depth: z.number().int().positive() }),
   implementation: component(new URL("./inspect.wasm", import.meta.url)),
-  needs: ["file:///workspace"],
 });
 
-const placed = inspect({ env: brainEnv({ name: "brain" }), depth: 2 });
+const placed = inspect({ env: brainEnv({ name: "reader", filesystem: { workspace: "read" } }), depth: 2 });
 ```
 
 The Component implements
@@ -123,7 +122,6 @@ const fetchIssue = tool({
     method: "GET",
     path: `/repos/${repository}/issues/{number}`,
   }),
-  needs: ["https://api.github.com"],
 });
 
 const placed = fetchIssue({ env: github, repository: "aexhq/brain" });
@@ -131,15 +129,18 @@ const placed = fetchIssue({ env: github, repository: "aexhq/brain" });
 
 Brain treats the descriptor as opaque and hands it to the Environment with every invoke.
 
-## What a Tool needs
+## Dependencies and resource access
 
-`needs` is a list of URIs the Environment receives and Brain never reads: `pkg:` for software as a
-Package URL, `https:` or `wss:` for a network destination with `https://*.example.com` for a family
-of hosts, and `file:` for a filesystem location, read-only unless it says `?access=write`. Brain
-hands every placed Tool's needs to the Environment at setup, so it provisions what this session
-uses, and the Tool's own with each invoke. The Environment refuses at setup what it cannot honour,
-naming the URI, and the create fails. Anything a Tool needs beyond that, it loads itself through
-the platform of its Environment.
+Package dependencies with the implementation or let the chosen Environment prepare them using
+its loader, lockfile, or optional setup script. Preparation must finish before import-time
+dependencies or the entrypoint are used. Brain has no universal `needs` declaration and installs
+nothing in its own process.
+
+The application configures access through the Environment. For example,
+`brainEnv({ name: "reader", filesystem: { workspace: "read" } })` requests a workspace within
+the server's allow-list. Use separate Environment bindings for different grants; every Tool in
+one native binding receives that binding's authority. A denied grant or unsupported runtime
+fails explicitly. Setup failures reach the ordinary Tool error path, without automatic retry.
 
 ## Execution context
 

--- a/docs/guides/write-an-environment.mdx
+++ b/docs/guides/write-an-environment.mdx
@@ -35,8 +35,8 @@ The response carries the same contract and sequence and a receipt.
 
 | Request | Responsibility |
 | --- | --- |
-| `setup { configuration, needs }` | Accept the union of needs placed here, or reject with the unmet URI. Allocation can be lazy. |
-| `execute { implementation, needs, input, deadline_ms, callback? }` | Resolve the opaque descriptor and execute with only these grants. |
+| `setup { configuration }` | Validate Environment-owned options and establish the binding. Allocation can be lazy. |
+| `execute { implementation, input, deadline_ms, callback? }` | Prepare and run the opaque implementation within configured authority. |
 | `call { name, input }` | An Environment-specific operation, such as explicit workspace reset. |
 | `cancel { target_sequence }` | Best-effort cancellation of the named invocation. |
 | `detach` | Release session attachment mechanisms while retaining owned resources. |
@@ -57,14 +57,17 @@ not retry or restore failed resources automatically.
 An execution may receive `callback: { url, token, methods }`. POST `{ method, input }` to that
 URL with its bearer token. The response is the method's JSON result. Only listed methods are
 granted. A Tool receives `emit` and `telemetry`; an Agentloop also receives `events`, `model`,
-`dispatch`, `set_transcript`, and `set_kv`. Dispatch input is an array of `{ call_id, name, environment, input }`; model
+`dispatch`, `set_transcript`, `kv_read`, `kv_put`, and `kv_delete`. Dispatch input is an array of `{ call_id, name, environment, input }`; model
 input is `ModelRequest`; events input is a cursor number; emit input is `{ event_type, data }`;
 telemetry input is the diagnostic record. Results are respectively Tool results, ModelResult,
 EventPage, committed sequence, and null.
 
-`set_transcript` takes a message array and `set_kv` takes `{ key, value }`. Both return the committed
-sequence. These services belong only to the Agentloop. Turn output is `{ result? }`, with no
-transcript or kv snapshot.
+`set_transcript` takes a message array. `kv_put` takes `{ key, value }`; `kv_delete` takes
+an identifier string. Mutations return the committed sequence. `kv_read` takes an identifier
+string and returns `{}` for absence or `{ value }` for a stored value, including JSON null.
+The author binding exposes these as `ctx.kv.read/put/delete`; reads after an awaited mutation
+observe it. These services belong only to the Agentloop. Turn output is `{ result? }`, with
+no transcript or KV snapshot. Deletion appends a journal mutation, preserving earlier records.
 
 The token belongs to one invocation and is revoked on completion or cancellation. It is never
 part of the journal. It grants no lifecycle or general session API access. Cancellation makes
@@ -87,3 +90,22 @@ tests concurrent first allocation and caller-controlled cleanup. The
 [remote Agentloop example](https://github.com/aexhq/brain/blob/main/examples/loop-environment.mjs)
 resolves a JavaScript implementation and calls granted Brain services. Both bind loopback and
 are authoring examples; they do not isolate untrusted code.
+
+## Optional implementation preparation
+
+Keep dependency details inside the implementation's package and this Environment's loader.
+The descriptor can select a project with a lockfile and optional setup script. Bootstrap the
+interpreter and import-time dependencies before loading setup or run functions. A setup function
+written in Python cannot install the Python interpreter required to invoke itself.
+
+The [Python Environment example](https://github.com/aexhq/brain/blob/main/examples/python-environment.mjs)
+uses operator-selected projects, `uv sync --locked`, an optional setup module, then
+`uv run --no-sync`. Concurrent first use shares preparation by installation directory, even
+across sessions. Detach and teardown release the binding, not the externally owned installation.
+A failed preparation remains failed until the operator replaces the loader; no request silently
+retries it. A preprepared package needs no custom setup hook.
+
+This helper is an OS-runtime example, not a sandbox. The operator must supply an isolated
+runtime, package-network policy, and appropriately limited process credentials. Project paths
+and module names are operator configuration, not arbitrary session input. Brain does not
+run these commands, resolve dependencies, or fall back from incompatible Wasm placement.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -21,7 +21,7 @@ and there is no upgrade path from earlier builds.
 | --- | --- | --- |
 | [Agentloop](/brain/docs/concepts/agent-loop) | A raw WebAssembly Component placed in an Environment | Activates it there and performs its model and Tool requests |
 | [Model](/brain/docs/concepts/model) | A provider, model name, and credential | Seals the credential for the session and makes calls |
-| [Tool](/brain/docs/concepts/tool) | A typed contract, what it needs, and where it runs | Commits the call before dispatch and records its outcome |
+| [Tool](/brain/docs/concepts/tool) | A typed contract, its implementation, and where it runs | Commits the call before dispatch and records its outcome |
 | [Environment](/brain/docs/concepts/environment) | A named place that runs Tools and the loop | Sets it up, invokes, cancels, detaches, and tears it down |
 
 Application code composes these values explicitly. `component(...)` wraps already-built Wasm,

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -16,7 +16,7 @@ its output token ceiling, is not here: Brain neither sets nor overrides it.
 | `BRAIN_DATA_DIR` | `--data-dir` | `brain-data` | Where journals, admitted Components, and local state live |
 | `BRAIN_ENV_WORKER` | `--env-worker` | `brain-env-worker` | Path to the loop worker executable |
 | `BRAIN_ENV_WORKERS` | `--env-workers` | `2` | OS worker processes in the built-in Environment pool |
-| `BRAIN_ENV_NETWORK_ALLOW` | `--env-network-allow` | none | Origins the brain env may grant a Component that needs them: exact, or `https://*.example.com` for a family of hosts |
+| `BRAIN_ENV_NETWORK_ALLOW` | `--env-network-allow` | none | Origins the brain env may grant through Environment configuration: exact, or `https://*.example.com` for a family of hosts |
 | `BRAIN_ENV_SECRET_ALLOW` | `--env-secret-allow` | none | Process environment variable names the brain env may mount under `/secrets` |
 | `BRAIN_ENV_FILESYSTEM_ALLOW` | `--env-filesystem-allow` | none | Filesystem roots the brain env may grant: `scratch` or `workspace` |
 | `BRAIN_MODEL_BASE_URL` | `--model-base-url` | `https://ai-gateway.vercel.sh/v1` | Endpoint for the `vercel-ai-gateway` provider. Kept under its historic name because deploys and tests already set it |
@@ -98,7 +98,7 @@ Brain refuses to start on a non-loopback address without `BRAIN_API_TOKEN`. Bind
 no token is a mistake worth failing on rather than serving.
 
 The three `BRAIN_ENV_*` allow-lists are the ceiling on what the brain env may grant a Component
-whose needs ask for it. Keep them empty in a multi-tenant deployment unless its control plane
+whose Environment configuration explicitly requests it. Keep them empty in a multi-tenant deployment unless its control plane
 supplies the corresponding tenant custody, egress, and storage boundary. Never place Brain's own
 API or cloud credentials in the secret allow-list. A session can make the server call any
 Environment URL it names with the session's own credential; a hosted multi-tenant deployment may

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ These examples use the public TypeScript SDK and HTTP API against a locally runn
 | `raw-http.mjs` | Admit raw Agentloop Component bytes and run a session using only HTTP. |
 | `example-brain.mjs` | Wrap a compiled Agentloop Component in the SDK factory. |
 | `reference-agentloop/` | A Rust Agentloop Component written against Brain's public contracts alone. |
-| `lazy-environment.mjs` | A standalone Environment: logical setup with needs, lazy allocation, idle expiry, explicit restart. |
+| `lazy-environment.mjs` | A standalone Environment: logical setup with configuration, lazy allocation, caller-controlled cleanup, explicit restart. |
 | `loop-environment.mjs` | A standalone Environment that runs an Agentloop on another server, calling Brain's turn routes back. |
 
 On Linux, from the repository root, install dependencies, build the SDK, and build the two Brain
@@ -74,3 +74,23 @@ process: set `BRAIN_PUBLIC_URL` when that is not the listen address.
 `session.events(cursor)` reads the public Event projection from the canonical journal. It is not an external
 queue or an at-least-once delivery guarantee. Applications that forward events own their queue,
 cursor persistence, retries, and deduplication.
+
+### Python project preparation
+
+`python-environment.mjs` exports an Environment handler for operator-selected projects. Supply
+`{ projects: { name: { directory, module, setup? } }, uv? }`, then serve its `handle` function
+over the Environment protocol in an isolated OS runtime. An implementation descriptor is
+`{ type: "python_project", name }`; session setup accepts an empty configuration. Python and
+`uv` are Environment bootstrap prerequisites, not dependencies resolved by Brain.
+
+The loader runs `uv sync --locked`, optionally runs a setup module, then invokes the module with
+JSON stdin and reads JSON stdout. Preparation is shared by installation directory across
+concurrent invocations and sessions. Setup failure prevents execution and remains an explicit
+failure until the operator replaces the loader. Bindings can detach without deleting the installation.
+No custom setup hook is required for ordinary packaged dependencies.
+
+Run the real preparation tests with `BRAIN_TEST_UV=/path/to/uv node --test examples/python-environment.test.mjs`
+from the repository root. CI runs this gate with uv 0.8.15. The locked fixture imports an installed
+package, proves setup-before-entrypoint, rejects incompatible placement, and checks concurrency
+and failure without mocked Python execution. This example does not itself sandbox processes,
+filter network access, or provide durable background jobs.

--- a/examples/lazy-environment.mjs
+++ b/examples/lazy-environment.mjs
@@ -5,7 +5,7 @@ const accepted = () => ({ type: "accepted" });
 const failure = (code, message) => ({ type: "failure", code, message, retryable: false });
 const identifier = (value) => typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(value);
 
-// Setup records needs; the first execution allocates the workspace. The caller
+// Setup records configuration; the first execution allocates the workspace. The caller
 // decides when to detach or tear it down; this Environment has no idle policy.
 export function lazyEnvironment({ allocate = async () => new Map() } = {}) {
   const environments = new Map();
@@ -20,9 +20,12 @@ export function lazyEnvironment({ allocate = async () => new Map() } = {}) {
     let env = environments.get(key(op));
     let receipt;
     if (request?.type === "setup") {
-      const unmet = (request.needs ?? []).find((need) => !need.startsWith("file:"));
-      if (unmet !== undefined) receipt = failure("unmet_need", `this Environment offers a workspace only; it cannot honour ${unmet}`);
-      else if (env) receipt = failure("already_exists", "Environment already exists");
+      const options = request.configuration;
+      if (!options || typeof options !== "object" || Array.isArray(options)
+        || Object.keys(options).some((key) => key !== "label")
+        || (options.label !== undefined && typeof options.label !== "string")) {
+        receipt = failure("invalid_configuration", "this Environment accepts only an optional label string");
+      } else if (env) receipt = failure("already_exists", "Environment already exists");
       else {
         environments.set(key(op), { active: 0 });
         receipt = accepted();

--- a/examples/lazy-environment.test.mjs
+++ b/examples/lazy-environment.test.mjs
@@ -8,9 +8,9 @@ test("setup allocates nothing; concurrent calls share allocation and teardown is
   let sequence = 0;
   const send = (request, session = "ses_one") => env.handle({ contract: "environment/v1",
     operation: { environment: "east", session_id: session, sequence: ++sequence, request } });
-  assert.equal((await send({ type: "setup", configuration: {}, needs: ["file:///workspace?access=write"] })).receipt.type, "accepted");
+  assert.equal((await send({ type: "setup", configuration: {} })).receipt.type, "accepted");
   assert.equal(allocations, 0);
-  const invoke = (input) => send({ type: "execute", implementation: { type: "reference_echo" }, needs: [], input, deadline_ms: 1000 });
+  const invoke = (input) => send({ type: "execute", implementation: { type: "reference_echo" }, input, deadline_ms: 1000 });
   const outcomes = await Promise.all([invoke("one"), invoke("two")]);
   assert(outcomes.every(({ receipt }) => receipt.type === "result"));
   assert.equal(allocations, 1);
@@ -22,8 +22,8 @@ test("setup allocates nothing; concurrent calls share allocation and teardown is
   assert.equal(allocations, 2);
   await send({ type: "teardown" });
   assert.equal((await invoke("after teardown")).receipt.code, "unavailable");
-  assert.equal((await send({ type: "execute", implementation: { type: "reference_echo" }, needs: [], input: {}, deadline_ms: 1 }, "ses_other")).receipt.code, "unavailable");
-  const refused = await send({ type: "setup", configuration: {}, needs: ["pkg:apt/ffmpeg"] }, "ses_other");
-  assert.equal(refused.receipt.code, "unmet_need");
-  assert.match(refused.receipt.message, /pkg:apt\/ffmpeg/u);
+  assert.equal((await send({ type: "execute", implementation: { type: "reference_echo" }, input: {}, deadline_ms: 1 }, "ses_other")).receipt.code, "unavailable");
+  const refused = await send({ type: "setup", configuration: { package: "ffmpeg" } }, "ses_other");
+  assert.equal(refused.receipt.code, "invalid_configuration");
+  assert.match(refused.receipt.message, /label/u);
 });

--- a/examples/loop-environment.mjs
+++ b/examples/loop-environment.mjs
@@ -20,13 +20,19 @@ export function loopEnvironment({ fetch = globalThis.fetch } = {}) {
     return response.json();
   };
   async function turn(callback, input) {
+    const kv = {
+      read: async (key) => (await call(callback, "kv_read", key)).value,
+      put: (key, value) => call(callback, "kv_put", { key, value }),
+      delete: (key) => call(callback, "kv_delete", key),
+    };
+    const turns = (await kv.read("turns") ?? 0) + 1;
     const transcript = [...input.transcript, { role: "user", content: [{ type: "text", text: input.input.message }, ...(input.input.media ?? [])] }];
     await call(callback, "set_transcript", transcript);
-    await call(callback, "emit", { event_type: "remote_note", data: { turns: (input.kv.turns ?? 0) + 1 } });
+    await call(callback, "emit", { event_type: "remote_note", data: { turns: turns } });
     const result = await call(callback, "model", { messages: transcript });
     transcript.push(result.message);
     await call(callback, "set_transcript", transcript);
-    await call(callback, "set_kv", { key: "turns", value: (input.kv.turns ?? 0) + 1 });
+    await kv.put("turns", turns);
     return { result: { stop_reason: result.stop_reason } };
   }
   async function handle(command) {
@@ -39,9 +45,10 @@ export function loopEnvironment({ fetch = globalThis.fetch } = {}) {
     const key = `${op.session_id}/${op.environment}`;
     let receipt;
     if (request?.type === "setup") {
-      const unmet = (request.needs ?? []).find((need) => !need.startsWith("https://"));
-      if (unmet !== undefined) receipt = failure("unmet_need", `this Environment reaches the network only; it cannot honour ${unmet}`);
-      else { sessions.add(key); receipt = accepted(); }
+      if (!request.configuration || typeof request.configuration !== "object"
+        || Array.isArray(request.configuration) || Object.keys(request.configuration).length !== 0) {
+        receipt = failure("invalid_configuration", "this Environment accepts no options");
+      } else { sessions.add(key); receipt = accepted(); }
     } else if (request?.type === "teardown") {
       sessions.delete(key);
       receipt = accepted();

--- a/examples/loop-environment.test.mjs
+++ b/examples/loop-environment.test.mjs
@@ -6,7 +6,8 @@ test("a turn outside Brain calls back through its token and returns what the loo
   const calls = [];
   const env = loopEnvironment({ fetch: async (url, init) => {
     calls.push({ url, authorization: init.headers.authorization, body: JSON.parse(init.body) });
-    if (["set_transcript", "set_kv"].includes(JSON.parse(init.body).method)) return Response.json(4);
+    if (JSON.parse(init.body).method === "kv_read") return Response.json({});
+    if (["set_transcript", "kv_put"].includes(JSON.parse(init.body).method)) return Response.json(4);
     if (JSON.parse(init.body).method === "emit") return Response.json({ sequence: 5 });
     if (JSON.parse(init.body).method === "model") {
       return Response.json({ message: { role: "assistant", content: [{ type: "text", text: "hello back" }] }, stop_reason: "end_turn", usage: {} });
@@ -14,21 +15,20 @@ test("a turn outside Brain calls back through its token and returns what the loo
     return new Response("no such route", { status: 404 });
   } });
   const command = (request) => env.handle({ contract: "environment/v1", operation: { sequence: 3, environment: "loop", session_id: "ses_one", request } });
-  assert.equal((await command({ type: "setup", configuration: {}, needs: ["https://models.example.com"] })).receipt.type, "accepted");
+  assert.equal((await command({ type: "setup", configuration: {} })).receipt.type, "accepted");
   const turned = await command({
     type: "execute",
     implementation: { type: "reference_agentloop" },
-    needs: [],
     input: { input: { message: "hello" }, transcript: [], kv: {}, events: [], configuration: {}, system: "", tools: [], runtime: { logical_time_ms: 3, deterministic_seed: [] } },
-    callback: { url: "http://brain.example/v1/sessions/ses_one/executions/3/call", token: "execution-token", methods: ["model", "emit", "set_transcript", "set_kv"] },
+    callback: { url: "http://brain.example/v1/sessions/ses_one/executions/3/call", token: "execution-token", methods: ["model", "emit", "set_transcript", "kv_put", "kv_read", "kv_delete"] },
   });
   assert.equal(turned.receipt.type, "result");
   assert.equal(calls.filter(({ body }) => body.method === "set_transcript").at(-1).body.input.length, 2);
-  assert.deepEqual(calls.find(({ body }) => body.method === "set_kv").body.input, { key: "turns", value: 1 });
+  assert.deepEqual(calls.find(({ body }) => body.method === "kv_put").body.input, { key: "turns", value: 1 });
   assert.ok(calls.every(({ url }) => url === "http://brain.example/v1/sessions/ses_one/executions/3/call"));
   assert.ok(calls.every(({ authorization }) => authorization === "Bearer execution-token"));
   assert.equal(calls.find(({ body }) => body.method === "model").body.input.messages.length, 1);
-  const refused = await command({ type: "setup", configuration: {}, needs: ["file:///workspace"] });
-  assert.equal(refused.receipt.code, "unmet_need");
-  assert.equal((await command({ type: "execute", implementation: { type: "unknown" }, needs: [], input: {}, deadline_ms: 1 })).receipt.code, "unsupported");
+  const refused = await command({ type: "setup", configuration: { filesystem: "workspace" } });
+  assert.equal(refused.receipt.code, "invalid_configuration");
+  assert.equal((await command({ type: "execute", implementation: { type: "unknown" }, input: {}, deadline_ms: 1 })).receipt.code, "unsupported");
 });

--- a/examples/python-environment.mjs
+++ b/examples/python-environment.mjs
@@ -1,0 +1,78 @@
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+
+function command(executable, args, cwd, input) {
+  return new Promise((accept, reject) => {
+    const child = spawn(executable, args, { cwd, stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8").on("data", (chunk) => { stdout += chunk; });
+    child.stderr.setEncoding("utf8").on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.stdin.on("error", reject);
+    child.on("close", (code) => code === 0 ? accept(stdout) : reject(new Error(`command exited ${code}: ${stderr}`)));
+    child.stdin.end(input === undefined ? undefined : JSON.stringify(input));
+  });
+}
+
+// Projects are provisioned by this Environment's operator, not paths supplied by a
+// Tool or a session. Run this example inside an appropriately isolated OS environment.
+export function pythonEnvironment({ projects, uv = "uv" }) {
+  const programs = new Map(Object.entries(projects).map(([name, project]) => [name, {
+    ...project, directory: resolve(project.directory),
+  }]));
+  const installations = new Map();
+  const sessions = new Set();
+  const invoke = (project, module, input) => command(uv,
+    ["run", "--no-sync", "--project", project.directory, "python", "-m", module], project.directory, input);
+  async function prepare(project) {
+    await command(uv, ["sync", "--locked", "--project", project.directory], project.directory);
+    if (project.setup) await invoke(project, project.setup);
+  }
+  return {
+    async handle({ contract, operation }) {
+      if (contract !== "environment/v1" || !operation || !Number.isSafeInteger(operation.sequence) || operation.sequence < 1
+        || ![operation.session_id, operation.environment].every((value) => typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(value))) {
+        throw new TypeError("invalid Environment command");
+      }
+      const { request } = operation;
+      const session = `${operation.session_id}/${operation.environment}`;
+      let receipt;
+      const failure = (code, message) => ({ type: "failure", code, message, retryable: false });
+      if (request.type === "setup") {
+        if (!request.configuration || typeof request.configuration !== "object" || Array.isArray(request.configuration)
+          || Object.keys(request.configuration).length !== 0) {
+          receipt = failure("invalid_configuration", "this Environment accepts no session options");
+        } else { sessions.add(session); receipt = { type: "accepted" }; }
+      } else if (request.type === "detach" || request.type === "teardown") {
+        sessions.delete(session);
+        receipt = { type: "accepted" };
+      } else if (!sessions.has(session)) {
+        receipt = failure("unavailable", "Environment is not attached");
+      } else if (request.type === "execute") {
+        const descriptor = request.implementation;
+        const project = descriptor?.type === "python_project" && programs.get(descriptor.name);
+        if (!project) receipt = failure("unsupported", "unknown Python project implementation");
+        else {
+          try {
+            // A failed preparation stays failed until the operator replaces this
+            // loader. Neither a later invocation nor a new session retries it silently.
+            if (!installations.has(project.directory)) installations.set(project.directory, prepare(project));
+            await installations.get(project.directory);
+          } catch (error) {
+            receipt = failure("preparation_failed", error.message);
+          }
+          if (!receipt) {
+            try {
+              const output = JSON.parse(await invoke(project, project.module, request.input));
+              receipt = { type: "result", output };
+            } catch (error) {
+              receipt = failure("execution_failed", error.message);
+            }
+          }
+        }
+      } else receipt = failure("unsupported", "operation is not supported by this example");
+      return { contract, sequence: operation.sequence, receipt };
+    },
+  };
+}

--- a/examples/python-environment.test.mjs
+++ b/examples/python-environment.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { cp, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { pythonEnvironment } from "./python-environment.mjs";
+
+async function fixture(t, setup = "prepare", module = "run") {
+  const directory = await mkdtemp(join(tmpdir(), "brain-python-project-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  await cp(new URL("../tests/fixtures/python-project/", import.meta.url), directory, { recursive: true });
+  const env = pythonEnvironment({ uv: process.env.BRAIN_TEST_UV ?? "uv", projects: { example: { directory, setup, module } } });
+  let sequence = 0;
+  const send = async (request, session_id = "ses_one") => (await env.handle({ contract: "environment/v1",
+    operation: { sequence: ++sequence, session_id, environment: "python", request } })).receipt;
+  const attach = (session) => send({ type: "setup", configuration: {} }, session);
+  const execute = (input, session) => send({ type: "execute", implementation: { type: "python_project", name: "example" }, input, deadline_ms: 30_000 }, session);
+  await attach();
+  return { directory, send, attach, execute };
+}
+
+test("Python imports follow locked preparation; concurrent first use shares setup across sessions", { timeout: 60_000 }, async (t) => {
+  const f = await fixture(t);
+  await f.attach("ses_two");
+  const results = await Promise.all([f.execute("one"), f.execute("two", "ses_two")]);
+  assert.deepEqual(results.map(({ output }) => output), [
+    { echo: "one", dependency: "1.17.0" }, { echo: "two", dependency: "1.17.0" },
+  ]);
+  await f.send({ type: "teardown" });
+  await f.attach();
+  assert.equal((await f.execute("again")).type, "result");
+  assert.equal(await readFile(join(f.directory, ".venv/prepared"), "utf8"), "1.17.0");
+});
+
+test("failed setup prevents imports and is not silently retried", { timeout: 60_000 }, async (t) => {
+  const f = await fixture(t, "fail_setup");
+  for (const result of await Promise.all([f.execute("one"), f.execute("two")])) {
+    assert.equal(result.code, "preparation_failed");
+    assert.match(result.message, /fixture setup failure/u);
+  }
+  assert.equal((await f.execute("explicit new invocation")).code, "preparation_failed");
+  assert.equal(await readFile(join(f.directory, ".venv/setup_attempts"), "utf8"), "attempt\n");
+  await assert.rejects(readFile(join(f.directory, ".venv/prepared")), { code: "ENOENT" });
+});
+
+test("standard packaging needs no custom hook and unknown placement fails explicitly", { timeout: 60_000 }, async (t) => {
+  const f = await fixture(t, null, "plain");
+  assert.deepEqual(await f.execute({}), { type: "result", output: { dependency: "1.17.0" } });
+  assert.equal((await f.send({ type: "execute", implementation: { type: "python_project", name: "unknown" }, input: {} })).code, "unsupported");
+  await assert.rejects(readFile(join(f.directory, ".venv/prepared")), { code: "ENOENT" });
+});

--- a/examples/reference-agentloop/src/lib.rs
+++ b/examples/reference-agentloop/src/lib.rs
@@ -36,7 +36,7 @@ impl Guest for Reference {
             after = page.next_cursor;
         }
         kv.insert("observed_sequence".into(), after.into());
-        brain::agentloop::host::set_kv("observed_sequence", &after.to_string())?;
+        brain::agentloop::host::kv_put("observed_sequence", &after.to_string())?;
         let tools: Vec<brain_protocol::ActivationTool> = decode(&input.tools_json)?;
         let input: brain_protocol::UserInput = decode(&input.input_json)?;
         let mut message = Message::user_text(input.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -309,7 +309,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/packages/brain-sdk/README.md
+++ b/packages/brain-sdk/README.md
@@ -54,18 +54,22 @@ const inspect = tool({
   description: "Inspect the workspace.",
   input: z.object({ path: z.string() }),
   implementation: component(new URL("./inspect.wasm", import.meta.url)),
-  needs: ["file:///workspace"],
 });
 
-const env = brainEnv({ name: "brain" });
+const env = brainEnv({ name: "reader", filesystem: { workspace: "read" } });
 const placedLoop = loop({ env });
 const placedTool = inspect({ env });
 ```
 
-`needs` is a list of URIs interpreted by the selected Environment: `pkg:` for software,
-`https:` or `wss:` for a network destination, `file:` for a filesystem location. The brain env
-grants each invocation exactly what its needs name, bounded by the server's `BRAIN_ENV_*`
-allow-lists; the deployment above must include `workspace` in `BRAIN_ENV_FILESYSTEM_ALLOW`.
+Resource grants are Environment options. `brainEnv` accepts `filesystem: { workspace?, scratch? }`
+with `"read"` or `"write"` access, `network` as HTTP(S) origins, and `secrets` as server-variable
+names. Omitted access stays denied; the server's `BRAIN_ENV_*` allow-lists remain the ceiling.
+The example requires `workspace` in `BRAIN_ENV_FILESYSTEM_ALLOW`. Use separate bindings if the
+loop and Tool should receive different grants.
+
+There is no universal `needs`. Dependencies belong to packages and Environment-owned preparation,
+which completes before imports or execution. Unsupported placement and setup failure are explicit
+errors, never a reason for Brain to install packages or choose another Environment.
 
 A Tool with `run` is a function this process holds and is placed in `hostEnv`. The SDK registers
 this process as a host over SSE, receives commands, validates inputs and outputs, and posts one
@@ -102,3 +106,14 @@ Agentloop authors can import generated `ModelRequest`, `ModelResult`, `ToolResul
 at `@aexhq/brain/contracts/agentloop.wit` and `@aexhq/brain/contracts/tool.wit`. `events(after)` reads
 history during an activation, and `emit` appends extension Events. Model, Tool, and Environment
 failures are never retried by Brain.
+
+## Upgrading to 0.20
+
+Upgrade the server and SDK together and rebuild Agentloop Components against the packaged WIT.
+Replace `set_kv` with `kv_put`; bindings expose `kv.read/put/delete`. Remove `needs` from
+extension declarations and configure native resource grants explicitly on their Environment.
+Do not translate per-Tool grants into a shared union without choosing that authority boundary.
+
+This pre-stable change does not migrate retained 0.19 sessions or old Agentloop binaries.
+Keep their matching server/artifacts for recovery; use a separately admitted new session for
+the new contract. Deployment must not discard or rewrite existing session data implicitly.

--- a/packages/brain-sdk/contracts/agentloop.wit
+++ b/packages/brain-sdk/contracts/agentloop.wit
@@ -54,7 +54,9 @@ interface host {
   // A finite EventPage after this sequence. Continue with next_cursor until empty.
   events: func(after: u64) -> result<string, turn-error>;
   set-transcript: func(messages-json: string) -> result<u64, turn-error>;
-  set-kv: func(key: string, value-json: string) -> result<u64, turn-error>;
+  kv-put: func(key: string, value-json: string) -> result<u64, turn-error>;
+  kv-read: func(key: string) -> result<option<string>, turn-error>;
+  kv-delete: func(key: string) -> result<u64, turn-error>;
 
   // One model call. `request-json` is a ModelRequest; the answer is a ModelResult.
   model: func(request-json: string) -> result<string, turn-error>;

--- a/packages/brain-sdk/contracts/session.json
+++ b/packages/brain-sdk/contracts/session.json
@@ -31,26 +31,13 @@
     },
     "AgentloopRef": {
       "additionalProperties": false,
-      "description": "The admitted Agentloop a session runs: which one, how it is configured, which\nEnvironment of the session runs it, and what it needs there.",
+      "description": "The admitted Agentloop a session runs: which one, how it is configured, which\nEnvironment of the session runs it.",
       "properties": {
         "configuration": true,
         "environment": {
           "$ref": "#/$defs/EnvironmentName"
         },
-        "implementation": true,
-        "needs": {
-          "default": [],
-          "description": "What the Agentloop needs from its Environment, as URIs. Brain hands them to the\nEnvironment at setup and with every turn, and reads none of them.",
-          "items": {
-            "format": "uri",
-            "maxLength": 2048,
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 64,
-          "type": "array",
-          "uniqueItems": true
-        }
+        "implementation": true
       },
       "required": [
         "implementation",
@@ -635,7 +622,7 @@
       ],
       "type": "object"
     },
-    "KvSetRequest": {
+    "KvPutRequest": {
       "additionalProperties": false,
       "properties": {
         "key": {
@@ -1076,19 +1063,7 @@
     "ToolPlacement": {
       "additionalProperties": false,
       "properties": {
-        "implementation": true,
-        "needs": {
-          "default": [],
-          "items": {
-            "format": "uri",
-            "maxLength": 2048,
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 64,
-          "type": "array",
-          "uniqueItems": true
-        }
+        "implementation": true
       },
       "required": [
         "implementation"

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/packages/brain-sdk/src/client.ts
+++ b/packages/brain-sdk/src/client.ts
@@ -442,7 +442,7 @@ function compileSession(
       if (Object.hasOwn(known.placements, environment)) throw new TypeError(`Tool ${definition.name} is duplicated in Environment ${environment}`);
     }
     const entry = known ?? { ...definition, placements: Object.create(null) as WireTool["placements"] };
-    entry.placements[environment] = { needs: [...tool.needs], implementation: structuredClone(implementations.get(selected)) };
+    entry.placements[environment] = { implementation: structuredClone(implementations.get(selected)) };
     tools.set(definition.name, entry);
   }
   const loop = inspectAgentloop(options.agentloop);
@@ -451,7 +451,6 @@ function compileSession(
       implementation: structuredClone(agentloopImplementation),
       configuration: structuredClone(loop.configuration),
       environment: inspectEnvironment(loop.environment).name,
-      needs: [...loop.needs],
     },
     model: { provider: options.model.provider, name: options.model.name, api_key: options.model.apiKey },
     system: options.system ?? "",

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -30,14 +30,12 @@ interface AgentloopSource {
   readonly kind: "agentloop";
   readonly implementation: Component | Readonly<Record<string, unknown>>;
   readonly configuration: unknown;
-  readonly needs: readonly string[];
   readonly environment: Environment;
 }
 
 interface ToolSource {
   readonly kind: "tool";
   readonly definition: ToolDefinition;
-  readonly needs: readonly string[];
   /** What the Environment interprets: a Component to admit, a descriptor, or nothing
    * when the Tool is a function this process holds. */
   readonly implementation: Component | Readonly<Record<string, unknown>> | undefined;
@@ -102,24 +100,37 @@ export function environment<OptionsSchema extends Schema | undefined = undefined
 
 export interface BrainEnvOptions {
   readonly name: string;
-  /** Process environment variables the server mounts under `/secrets`, by name. */
+  /** Server environment variables mounted under `/secrets`, by name. */
   readonly secrets?: readonly string[];
+  /** HTTP(S) origins, optionally `scheme://*.domain`, within server policy. */
+  readonly network?: readonly string[];
+  readonly filesystem?: {
+    readonly workspace?: "read" | "write";
+    readonly scratch?: "read" | "write";
+  };
 }
 
-/** Brain's own Environment, hosted inside brain-server: a fresh Wasmtime instance per
- * invocation, granted exactly what the Tool or loop placed there needs. */
+const brainOptions = z.strictObject({
+  name: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u),
+  secrets: z.array(z.string()).optional(),
+  network: z.array(z.string().refine((value) => {
+    try {
+      const url = new URL(value);
+      return ["http:", "https:"].includes(url.protocol) && url.username === "" && url.password === ""
+        && ["", "/"].includes(url.pathname) && url.search === "" && url.hash === "";
+    } catch { return false; }
+  }, "network must contain HTTP(S) origins")).optional(),
+  filesystem: z.strictObject({ workspace: z.enum(["read", "write"]).optional(), scratch: z.enum(["read", "write"]).optional() }).optional(),
+});
+
+/** A fresh Wasmtime instance per invocation, with this Environment's configured grants.
+ * The server's policy is the ceiling; omitted access stays denied. */
 export function brainEnv(options: BrainEnvOptions): Environment {
-  if (!isRecord(options)) throw new TypeError("brainEnv needs { name }");
-  identifier(options.name, "Environment name");
-  const secrets = uniqueNames(options.secrets ?? [], "brainEnv secrets", identifierPattern);
-  for (const key of Object.keys(options)) {
-    if (key !== "name" && key !== "secrets") throw new TypeError(`brainEnv does not accept ${key}`);
-  }
+  const { name, secrets, ...configuration } = brainOptions.parse(options);
+  if (secrets !== undefined) uniqueNames(secrets, "brainEnv secrets", identifierPattern);
   return branded({
-    kind: "environment",
-    name: options.name,
-    driver: { driver: "brain" },
-    configuration: secrets.length === 0 ? {} : { secrets: [...secrets] },
+    kind: "environment", name, driver: { driver: "brain" },
+    configuration: { ...configuration, ...(secrets === undefined ? {} : { secrets }) },
   });
 }
 
@@ -134,8 +145,6 @@ export function hostEnv(options: { readonly name: string }): Environment {
 export interface AgentloopContract<OptionsSchema extends Schema | undefined = undefined> {
   readonly options?: OptionsSchema;
   readonly implementation: Component | Readonly<Record<string, unknown>> | ((options: Options<OptionsSchema>) => Readonly<Record<string, unknown>>);
-  /** What the loop needs from its Environment, as URIs. */
-  readonly needs?: readonly string[];
 }
 
 type Placement<OptionsSchema extends Schema | undefined> = { readonly env: Environment } &
@@ -144,14 +153,12 @@ type Placement<OptionsSchema extends Schema | undefined> = { readonly env: Envir
 export function agentloop<OptionsSchema extends Schema | undefined = undefined>(
   contract: AgentloopContract<OptionsSchema>,
 ): (placement: Placement<OptionsSchema>) => PlacedAgentloop {
-  const needs = uniqueNeeds(contract.needs ?? [], "Agentloop needs");
   return ((raw: unknown) => {
     const { env, options } = placedOptions(contract.options, raw);
     return branded({
       kind: "agentloop",
       implementation: typeof contract.implementation === "function" ? clone(contract.implementation(options as never)) : isComponent(contract.implementation) ? contract.implementation : clone(contract.implementation),
       configuration: clone(options),
-      needs,
       environment: env,
     });
   }) as (placement: Placement<OptionsSchema>) => PlacedAgentloop;
@@ -162,7 +169,7 @@ export interface ToolRunContext<Options> extends HostToolCall {
   emit(kind: string, data: unknown): Promise<number>;
 }
 
-/** One Tool: what the model is told, what it needs from its Environment, and either a
+/** One Tool: what the model is told and either a
  * function this process runs or an implementation its Environment interprets. Where it
  * runs is decided at placement, `{ env }`. */
 export interface ToolContract<OptionsSchema extends Schema | undefined, InputSchema extends Schema, OutputSchema extends Schema | undefined> {
@@ -171,9 +178,6 @@ export interface ToolContract<OptionsSchema extends Schema | undefined, InputSch
   readonly input: InputSchema;
   readonly output?: OutputSchema;
   readonly options?: OptionsSchema;
-  /** URIs: `pkg:` for software, `https:` or `wss:` for a network destination, `file:`
-   * for a filesystem location. The Environment honours or refuses them. */
-  readonly needs?: readonly string[];
   readonly run?: (
     input: SchemaOutput<InputSchema>,
     context: ToolRunContext<Options<OptionsSchema>>,
@@ -185,7 +189,6 @@ export function tool<OptionsSchema extends Schema | undefined = undefined, Input
   contract: ToolContract<OptionsSchema, InputSchema, OutputSchema>,
 ): (placement: Placement<OptionsSchema>) => PlacedTool<SchemaInput<InputSchema>, OutputSchema extends Schema ? SchemaOutput<OutputSchema> : unknown> {
   const definition = toolDefinition(contract);
-  const needs = uniqueNeeds(contract.needs ?? [], "Tool needs");
   if ((typeof contract.run === "function") === ("implementation" in contract && contract.implementation !== undefined)) {
     throw new TypeError("tool needs exactly one of run or implementation");
   }
@@ -202,7 +205,6 @@ export function tool<OptionsSchema extends Schema | undefined = undefined, Input
       return branded({
         kind: "tool",
         definition,
-        needs,
         implementation: undefined,
         handler: (input: unknown, call: HostToolCall) => run(input as never, { ...call, options } as never),
         contract: hostContract,
@@ -216,7 +218,6 @@ export function tool<OptionsSchema extends Schema | undefined = undefined, Input
     return branded({
       kind: "tool",
       definition,
-      needs,
       implementation: isComponent(implementation) ? implementation : clone(implementation as Readonly<Record<string, unknown>>),
       configuration: clone(options),
       environment: env,
@@ -317,19 +318,6 @@ function identifier(value: unknown, subject: string): asserts value is string {
 function uniqueNames(values: readonly string[], subject: string, pattern: RegExp): readonly string[] {
   if (!Array.isArray(values) || values.some((value) => typeof value !== "string" || !pattern.test(value))) {
     throw new TypeError(`${subject} contains an invalid name`);
-  }
-  if (new Set(values).size !== values.length) throw new TypeError(`${subject} contains a duplicate`);
-  return Object.freeze([...values]);
-}
-
-/** A need is a URI: it has a scheme, and nothing Brain reads beyond that. */
-function uniqueNeeds(values: readonly string[], subject: string): readonly string[] {
-  if (!Array.isArray(values) || values.length > 64) throw new TypeError(`${subject} must be at most 64 URIs`);
-  for (const value of values) {
-    if (typeof value !== "string" || value.length === 0 || value.length > 2_048 || /[\s\p{Cc}]/u.test(value) || !/^[A-Za-z][A-Za-z0-9+.-]*:./u.test(value)) {
-      throw new TypeError(`${subject} contains ${JSON.stringify(value)}, which is not a URI`);
-    }
-    try { new URL(value); } catch { throw new TypeError(`${subject} contains ${value}, which is not a URI`); }
   }
   if (new Set(values).size !== values.length) throw new TypeError(`${subject} contains a duplicate`);
   return Object.freeze([...values]);

--- a/packages/brain-sdk/src/generated/session.ts
+++ b/packages/brain-sdk/src/generated/session.ts
@@ -214,7 +214,7 @@ export interface ApiError {
 }
 /**
  * The admitted Agentloop a session runs: which one, how it is configured, which
- * Environment of the session runs it, and what it needs there.
+ * Environment of the session runs it.
  *
  * This interface was referenced by `BrainSessionAPIV1`'s JSON-Schema
  * via the `definition` "AgentloopRef".
@@ -223,13 +223,6 @@ export interface AgentloopRef {
   configuration: unknown;
   environment: EnvironmentName;
   implementation: unknown;
-  /**
-   * What the Agentloop needs from its Environment, as URIs. Brain hands them to the
-   * Environment at setup and with every turn, and reads none of them.
-   *
-   * @maxItems 64
-   */
-  needs?: string[];
 }
 /**
  * This interface was referenced by `BrainSessionAPIV1`'s JSON-Schema
@@ -307,10 +300,6 @@ export interface Tool {
  */
 export interface ToolPlacement {
   implementation: unknown;
-  /**
-   * @maxItems 64
-   */
-  needs?: string[];
 }
 /**
  * This interface was referenced by `BrainSessionAPIV1`'s JSON-Schema
@@ -452,9 +441,9 @@ export interface OutcomeError {
 }
 /**
  * This interface was referenced by `BrainSessionAPIV1`'s JSON-Schema
- * via the `definition` "KvSetRequest".
+ * via the `definition` "KvPutRequest".
  */
-export interface KvSetRequest {
+export interface KvPutRequest {
   key: string;
   value: unknown;
 }

--- a/packages/brain-sdk/test/client-tools.test.mjs
+++ b/packages/brain-sdk/test/client-tools.test.mjs
@@ -101,7 +101,7 @@ test("one host runs the Tools placed in it and commits ctx.emit before its resul
   const createRequest = requests.find((request) => new URL(request.url).pathname === "/v1/sessions");
   const body = await createRequest.json();
   assert.deepEqual(body.environments[1], { name: "app", driver: "host", host_id: "host_12345678901234567890", configuration: {} });
-  assert.deepEqual(body.tools[0].placements.app, { needs: [], implementation: { type: "host_function", name: "lookup" } });
+  assert.deepEqual(body.tools[0].placements.app, { implementation: { type: "host_function", name: "lookup" } });
   assert.equal("implementation" in body.tools[0], false);
   const eventRequest = requests.find((request) => new URL(request.url).pathname.endsWith("/events"));
   const resultRequest = requests.find((request) => new URL(request.url).pathname.endsWith("/results"));

--- a/packages/brain-sdk/test/client.test.mjs
+++ b/packages/brain-sdk/test/client.test.mjs
@@ -56,21 +56,19 @@ test("session creation admits Components and names every placement", async () =>
     credential: ({ token }) => token,
     configure: ({ region }) => ({ region }),
   })({ name: "sandbox", url: "https://sandbox.example", region: "eu", token: "sandbox-key" });
-  const pi = agentloop({ implementation: component(new Uint8Array([1])), needs: ["https://api.example.com"] });
+  const pi = agentloop({ implementation: component(new Uint8Array([1])) });
   const read = tool({
     name: "read",
     description: "Read one file.",
     input: z.object({ path: z.string() }),
     implementation: component(new Uint8Array([2])),
-    needs: ["file:///workspace"],
-  });
+    });
   const bash = tool({
     name: "bash",
     description: "Run a command.",
     input: z.object({ command: z.string() }),
     implementation: { artifact: "bash_v1" },
-    needs: ["pkg:apt/bash", "file:///workspace?access=write"],
-  });
+    });
   const client = new Brain({ baseUrl: "https://brain.example/", token: "brain-token", fetch: fetchStub });
   const session = await client.sessions.create({
     model: { provider: "openai", name: "gpt-5", apiKey: "model-token" },
@@ -87,17 +85,15 @@ test("session creation admits Components and names every placement", async () =>
     { name: "brain", driver: "brain", configuration: { secrets: ["MODEL_TOKEN"] } },
     { name: "sandbox", driver: "http", url: "https://sandbox.example", credential: "sandbox-key", configuration: { region: "eu" } },
   ]);
-  assert.deepEqual(body.agentloop, { implementation: { type: "brain_component", entrypoint: "turn", id: "a".repeat(64) }, configuration: {}, environment: "brain", needs: ["https://api.example.com"] });
+  assert.deepEqual(body.agentloop, { implementation: { type: "brain_component", entrypoint: "turn", id: "a".repeat(64) }, configuration: {}, environment: "brain" });
   assert.deepEqual(body.tools[0], {
     name: "read",
     description: "Read one file.",
     input_schema: body.tools[0].input_schema,
-    placements: { brain: { needs: ["file:///workspace"],
-    implementation: { type: "brain_component", entrypoint: "run", id: "b".repeat(64), configuration: {} } } },
+    placements: { brain: { implementation: { type: "brain_component", entrypoint: "run", id: "b".repeat(64), configuration: {} } } },
   });
   assert.deepEqual(Object.keys(body.tools[1].placements), ["sandbox"]);
   assert.deepEqual(body.tools[1].placements.sandbox.implementation, { artifact: "bash_v1" });
-  assert.deepEqual(body.tools[1].placements.sandbox.needs, ["pkg:apt/bash", "file:///workspace?access=write"]);
 });
 
 test("one name for two different Environments is refused before any request", async () => {

--- a/packages/brain-sdk/test/execution.test.mjs
+++ b/packages/brain-sdk/test/execution.test.mjs
@@ -18,10 +18,9 @@ test("extensions are immutable factories with explicit placement", () => {
   });
   assert.deepEqual(inspectEnvironment(hostEnv({ name: "app" })).driver, { driver: "host" });
 
-  const pi = agentloop({ options: z.object({ compactAt: z.number() }), implementation: wasm, needs: ["https://*.example.com"] });
+  const pi = agentloop({ options: z.object({ compactAt: z.number() }), implementation: wasm });
   const loop = pi({ env: native, compactAt: 0.8 });
   assert.deepEqual(inspectAgentloop(loop).configuration, { compactAt: 0.8 });
-  assert.deepEqual(inspectAgentloop(loop).needs, ["https://*.example.com"]);
   assert.equal(inspectAgentloop(loop).environment, native);
   assert.equal("use" in loop, false);
 
@@ -30,11 +29,9 @@ test("extensions are immutable factories with explicit placement", () => {
     description: "Read a file.",
     input: z.object({ path: z.string() }),
     implementation: wasm,
-    needs: ["file:///workspace"],
   });
   const placed = read({ env: native });
   assert.equal(inspectTool(placed).implementation, wasm);
-  assert.deepEqual(inspectTool(placed).needs, ["file:///workspace"]);
   assert.equal(inspectTool(placed).handler, undefined);
   assert.equal(Object.isFrozen(placed), true);
 });
@@ -84,16 +81,25 @@ test("an environment extension configures each instance and says how it is reach
   assert.throws(() => environment({ url: () => "https://user:pw@tool.example" })({ name: "x" }), /credentials/u);
 });
 
-test("needs are URIs and the built-in Environments take only their own options", () => {
+test("the built-in Environments validate their own grant options", () => {
   const wasm = component(new Uint8Array([1]));
-  assert.throws(() => tool({ name: "t", description: "d", input: z.object({}), implementation: wasm, needs: ["fs"] }), /not a URI/u);
-  assert.throws(() => tool({ name: "t", description: "d", input: z.object({}), implementation: wasm, needs: ["https://a b"] }), /not a URI/u);
-  assert.throws(() => tool({ name: "t", description: "d", input: z.object({}), implementation: wasm, needs: ["pkg:apt/x", "pkg:apt/x"] }), /duplicate/u);
-  assert.throws(() => agentloop({ implementation: wasm, needs: ["../fs"] }), /not a URI/u);
   assert.throws(() => tool({ name: "t", description: "d", input: z.object({}) }), /exactly one of run or implementation/u);
   assert.throws(() => tool({ name: "t", description: "d", input: z.object({}), implementation: wasm, run: async () => null }), /exactly one of run or implementation/u);
   assert.throws(() => brainEnv({ name: "brain", secrets: ["bad/name"] }), /invalid name/u);
-  assert.throws(() => brainEnv({ name: "brain", network: { allow: [] } }), /does not accept network/u);
-  assert.throws(() => brainEnv({}), /identifier/u);
+  assert.throws(() => brainEnv({ name: "brain", network: { allow: [] } }), /array/u);
+  assert.throws(() => brainEnv({}), /name/u);
   assert.throws(() => hostEnv({ name: "../x" }), /identifier/u);
+});
+
+test("native grants are explicit, validated, and independent between bindings", () => {
+  const configured = brainEnv({ name: "writer", filesystem: { workspace: "write", scratch: "read" }, network: ["https://*.example.com"] });
+  assert.deepEqual(inspectEnvironment(configured).configuration, {
+    filesystem: { workspace: "write", scratch: "read" }, network: ["https://*.example.com"],
+  });
+  assert.deepEqual(inspectEnvironment(brainEnv({ name: "other" })).configuration, {});
+  for (const network of [["file:///workspace"], ["https://example.com/path"], ["https://user:password@example.com"], ["https://example.com?x"]]) {
+    assert.throws(() => brainEnv({ name: "bad", network }), /HTTP\(S\) origins/u);
+  }
+  assert.throws(() => brainEnv({ name: "bad", filesystem: { workspace: "root" } }), /read/u);
+  assert.throws(() => brainEnv({ name: "bad", filesystem: { home: "read" } }), /Unrecognized/u);
 });

--- a/references/adrs/2026-09-05-10-one-execution-model.md
+++ b/references/adrs/2026-09-05-10-one-execution-model.md
@@ -10,6 +10,10 @@ and callers own lifecycle policy. The built-in implementation moves into brain-e
 
 Extends: [ADR-022: Let Environments execute implementations using their own platform APIs](2026-09-02-05-resources.md), whose create-time check of Tool needs against declared resources this record removes; [ADR-033: Distinguish resident Tools from explicitly placed extensions](2026-09-05-02-placement.md); [ADR-040: Identify records by session and sequence, and everything inside a session by name](2026-09-05-09-session-names.md).
 
+Amended by [ADR-046](2026-09-09-01-minimal-extension-contract.md): dependency preparation and
+resource grants belong to Environments, universal `needs` is removed, and Agentloop KV uses
+read/put/delete with inline durable mutations.
+
 ## Context
 
 Brain describes two ways a Tool can run: placed in an Environment that Brain reaches over HTTP, or inside the application that created the session, reached over a connection the application holds open. The distinction leaks into every layer. A Tool carries a `hosting` flag, a `host_id` beside an optional `environment_id`, and six cross-field validation rules that say which of those may be present together. The dispatcher branches on the flag. The host registration table is an Environment lifecycle in disguise: it tracks the sessions each registered host serves, adds one at create, and removes it at end. Where an HTTP Environment lives is decided by a routes file the server operator writes, so an Environment extension cannot let the application configure its own address.

--- a/references/adrs/2026-09-06-03-sessions-and-brain-env.md
+++ b/references/adrs/2026-09-06-03-sessions-and-brain-env.md
@@ -12,6 +12,10 @@ own Environment ordinary at the session boundary. Revises the single-worker impl
 described by [ADR-034](2026-09-05-03-wasm-worker.md) and revises the Environment-owned TTL
 and cleanup policy in [ADR-037](2026-09-05-06-ephemeral.md).
 
+Amended by [ADR-046](2026-09-09-01-minimal-extension-contract.md): dependency preparation and
+resource grants belong to Environments, universal `needs` is removed, and Agentloop KV uses
+read/put/delete with inline durable mutations.
+
 ## Context
 
 Loophost was named for hosting the Agentloop. It now runs both Agentloop and Tool Components,

--- a/references/adrs/2026-09-07-01-protocol-freeze.md
+++ b/references/adrs/2026-09-07-01-protocol-freeze.md
@@ -9,6 +9,10 @@ decisions, alternatives, and validation requirements together.
 The model-state decision refines [ADR-012](2026-08-30-01-provider-model.md). This does not declare
 the entire v1 API frozen. The original reproductions below describe the pre-change revision.
 
+Amended by [ADR-046](2026-09-09-01-minimal-extension-contract.md): dependency preparation and
+resource grants belong to Environments, universal `needs` is removed, and Agentloop KV uses
+read/put/delete with inline durable mutations.
+
 ## 1. Attribute extension Events to their originating execution
 
 ### Context

--- a/references/adrs/2026-09-09-01-minimal-extension-contract.md
+++ b/references/adrs/2026-09-09-01-minimal-extension-contract.md
@@ -1,0 +1,300 @@
+# ADR-046: Keep dependency preparation in Environments and give Agentloop KV one API
+
+- Proposal date: 2026-09-09
+- Status: Accepted
+- Implementation: Implemented; coordinated release verification in progress
+
+This record covers the KV and dependency-setup decisions from the extension-interface
+review. It does not specify the separately discussed long-lived callback and transcript
+submission changes.
+
+This record replaces the universal `needs` declaration in
+[ADR-041](2026-09-05-10-one-execution-model.md) and its carriage through setup,
+execution, and placements in [ADR-044](2026-09-06-03-sessions-and-brain-env.md).
+It refines the Agentloop KV interface in
+[ADR-045](2026-09-07-01-protocol-freeze.md#3-persist-author-directed-operations-inline-within-the-turn),
+while preserving its inline durable-commit semantics. Their other decisions remain
+unchanged.
+
+## Context
+
+The Agentloop reads a KV snapshot from `TurnInput.kv` and writes individual values
+through `set_kv`. The split is functional but gives authors two ways to interact with
+one state store. There is no deletion operation: writing JSON null stores a value
+rather than removing a key. The journal currently has `KvSet` but no KV deletion entry.
+
+Agentloops and Tool placements also declare `needs: string[]`. Brain aggregates those
+URIs for Environment setup and forwards them again during execution. The list mixes
+software preparation (`pkg:apt/ripgrep`) with resource access
+(`file:///workspace?access=write`, `https://api.example.com`). Each Environment must
+interpret the same vocabulary despite having different runtimes and capabilities.
+
+A package URI does not resolve interpreter bootstrap, package versions and lockfiles,
+native libraries, installation order, or conflicting dependencies. These remain the
+Environment's responsibility. The built-in Environment installs nothing and rejects
+`pkg:`; it instead uses filesystem and network needs to derive invocation grants,
+bounded by deployment policy. Removing `needs` is therefore also a change to grant
+configuration, not merely removal of dependency metadata.
+
+Brain already has the useful boundary: an application places an opaque implementation
+in an explicitly chosen Environment. That Environment can use its platform's existing
+packaging and installation mechanisms. The core does not need another dependency
+language to mediate between them.
+
+## Decision
+
+### 1. Expose one Agentloop KV interface
+
+The author-facing interface is:
+
+```ts
+await ctx.kv.read(key);
+await ctx.kv.put(key, value);
+await ctx.kv.delete(key);
+```
+
+Its semantics are:
+
+- KV belongs to the session's Agentloop. This does not grant Tools access to it or
+  introduce a shared, multi-writer database.
+- `read` returns the current value or absence. In JavaScript, absence is `undefined`;
+  JSON null remains an ordinary stored value. Other bindings represent absence
+  explicitly rather than conflating it with null.
+- `put` creates or replaces one JSON value. `delete` removes one key from the current
+  state. Deleting an absent key is a no-op.
+- Awaited mutations resolve with a committed journal sequence, as `set_kv` does today.
+  A no-op may return the already committed sequence. A successful subsequent read in
+  the same execution observes the completed mutation.
+- Each mutation commits independently. A later turn failure does not undo it. There
+  is no explicit author-controlled commit or automatic end-of-turn flush.
+- Deletion appends a journal mutation; it does not remove an earlier record. Recovery
+  folds put and delete operations to reconstruct current state. Existing reserved-key
+  restrictions continue to apply.
+
+The runtime/SDK can initialize its KV view from the existing turn snapshot and update
+that view only after successful commits. Under the current single-writer scope, this
+does not require a remote request for every read. The snapshot may remain a transport
+detail; it is not a second mutable authoring API. Remote and native bindings must
+provide equivalent semantics.
+
+Do not add listing, transactions, compare-and-swap, expiry, cross-session access, or
+background KV writers for this change. Exact wire encodings are defined in the source
+contracts during implementation, not by treating this illustrative TypeScript as an
+already exported interface.
+
+### 2. Remove universal `needs`
+
+Remove `needs` from the common Agentloop and Tool authoring contracts, placed session
+definitions, and Environment setup and execute requests. Remove its aggregation and
+URI validation from Brain. Do not replace it with a structured universal package or
+resource manifest.
+
+Keep the existing separation:
+
+- The Tool definition describes the model-visible input and output.
+- The implementation descriptor identifies what the selected Environment should run.
+- Extension packages carry their normal dependency metadata, lockfiles, setup code,
+  or prebuilt artifacts.
+- Environment configuration describes the resources and access the application has
+  authorized there.
+
+Brain validates fixed placement and the protocol envelope. It does not resolve
+packages, choose a language runtime, negotiate compatibility, or select a different
+Environment when execution fails. An Environment may document its own descriptor
+schema without making that schema part of Brain's universal contract.
+
+### 3. Keep resource authority explicit in Environment configuration
+
+Removing dependency declarations does not grant unrestricted access. The application
+configures filesystem, network, secrets, and other access through its chosen
+Environment before session creation, within deployment policy. The Environment
+enforces those boundaries during preparation and execution. Setup code cannot widen
+them by declaring that it needs more access.
+
+For the built-in Environment, move grant selection from `needs` to explicit
+Environment-owned configuration, retaining deployment ceilings and deny-by-default
+behavior when access is absent. Do not infer permissions from package metadata or
+enable broad access to make a failing installation succeed.
+
+This changes the default granularity: extensions in one Environment may share its
+configured grants. An Environment can impose finer restrictions itself; applications
+can use separate Environment bindings when different access is required. Translating
+old per-placement needs into one union of grants must not silently give every Tool
+the union's authority. Callers must choose the intended boundary explicitly.
+
+The format of those options belongs to each Environment. Brain does not introduce a
+replacement cross-runtime authorization DSL. The existing session boundary and
+prohibition on access to unrelated tenants or control-plane resources remain intact.
+
+### 4. Let the Environment prepare an extension before running it
+
+Support optional extension setup through the Environment's implementation loader.
+An Environment may build or prepare eagerly, or prepare lazily before the first
+execution. Preparation must complete successfully before the extension entrypoint
+runs. Extensions that already ship everything they need require no setup hook.
+
+The Environment supplies the bootstrap mechanism: a runtime, command runner, image
+builder, or another platform facility. A Python setup function cannot install the
+interpreter required to execute itself. Dependencies required when importing a module
+must likewise be prepared before that module is loaded. Setup can be a script,
+function, or package-manager operation supported by that Environment; it is not a
+JavaScript closure that Brain somehow executes in every language runtime.
+
+Use the existing opaque implementation descriptor to identify preparation and
+execution where needed. Do not add a Tool-specific Brain setup operation, require
+all implementation descriptors in Environment setup, or add a separate readiness
+protocol. The generic Environment `setup` operation still establishes the configured
+Environment. Its `execute` implementation may prepare the selected extension before
+invoking it. The same mechanism applies to Agentloops.
+
+Preparation reuse belongs to the actual installation and resource lifetime, not to a
+model turn or automatically to a session. Concurrent first executions must not race
+mutating preparation of the same installation; the Environment coordinates that
+work using its own runtime/package-management mechanisms. A resource replacement or
+explicit installation change can require preparation again. This is not an
+exactly-once setup guarantee across crashes.
+
+All setup code runs in the chosen Environment, never in the Brain session-engine
+process. Preparation uses only configured authority. Environments must not assume
+permission to alter an application's host installation merely because a Tool has a
+setup hook.
+
+### 5. Reuse standard packaging for official integrations
+
+Official integrations are ordinary extensions and Environment helpers. For Python
+on a supported OS, a helper can use `pyproject.toml`, a lockfile, and `uv` to prepare
+an isolated project environment and invoke the extension. A standalone script can
+use standard inline dependency metadata. A prebuilt image is an alternative when
+runtime installation is undesirable or system dependencies are significant.
+
+These are packaging choices, not Brain requirements. Neither `uv`, a Python version,
+nor a container format becomes mandatory in the core. Package managers handle their
+own dependency semantics; Brain does not duplicate them in `needs`.
+
+The built-in Wasm Environment remains a Wasm Environment. This decision does not add
+native process execution or automatic Python installation to it. A Python extension
+needs an Environment that supports it, or a separately built compatible artifact.
+An unsupported implementation fails explicitly instead of triggering a fallback.
+
+### 6. Report preparation failures through existing outcomes
+
+Brain records the Environment operation intent before delivery. Preparation inside
+that operation does not bypass the commit-before-effect boundary. Failure prevents
+entrypoint execution and is returned through the ordinary operation/turn/Tool error
+path, with useful details about what could not be prepared. If the result is lost,
+the outcome remains unknown rather than being assumed not to have happened.
+
+Neither a failed setup nor an interrupted execution triggers automatic replay by
+Brain. A caller or Agentloop may explicitly request another attempt where applicable.
+Partial files or other external effects are not automatically rolled back, and a
+successful session creation is not proof that every lazily loaded extension is
+compatible. Lazy preparation deliberately moves some failures to first use.
+
+## Alternatives considered
+
+- **Keep URI needs or replace them with typed dependency objects.** Both require a
+  cross-runtime vocabulary while leaving bootstrap, dependency resolution, and
+  installation to the Environment. Typed Environment options and existing package
+  formats already cover the respective concerns.
+- **Make every Tool self-install from its run function.** This can work in a suitable
+  Environment but cannot bootstrap a missing interpreter or imports needed to load
+  the function. Optional preparation allows those prerequisites to be handled first.
+- **Require a container image for every extension.** Useful for some deployments, but
+  unnecessarily excludes host functions, Wasm Components, and ordinary package runners.
+- **Have Brain run setup scripts or choose an appropriate Environment.** Violates the
+  execution boundary and fixed placement, and makes Brain own runtime-specific policy.
+- **Keep snapshot reads and `set_kv`, treating null as deletion.** Avoids an operation
+  but loses the distinction between a stored null and a missing key. A coherent KV
+  interface with explicit deletion is small and unambiguous.
+
+## Consequences and implementation boundary
+
+The public protocol becomes smaller around dependencies and more complete around
+durable Agentloop state. Environment authors gain freedom to use normal packaging,
+but compatibility is an explicit responsibility of the selected implementation and
+Environment, not a portability promise made by Brain.
+
+Implementation requires a coordinated change to:
+
+- Rust protocol types, SDK authoring, and generated session/Environment contracts to
+  remove `needs`; session creation must stop aggregating it.
+- The built-in Environment's configuration and grant enforcement, plus official Tool
+  declarations, examples, and tests. Removing declarations must not remove enforcement.
+- Agentloop service bindings and wrappers, including native and HTTP paths, for the
+  KV interface; journal mutation representation and recovery for deletion.
+- The official loops, which currently read `input.kv` and call `setKv`.
+- Authoring and Environment documentation, plus the corresponding resource-declaration
+  wording in the workspace's `platform/docs/core.md`.
+
+Apply the existing pre-stable contract-change policy; regenerate contracts from their
+owning sources rather than editing generated files. Do not retain two permanent
+authoring APIs or silently reinterpret old grant declarations. This decision authorizes
+no deletion or conversion of existing session data.
+
+## Validation required for implementation
+
+1. KV distinguishes missing from null, supports put/read/delete and absent-key delete,
+   observes completed writes within a turn, and recovers committed mutations after
+   interruption/restart without deleting historical journal entries. Native and HTTP
+   Agentloops have the same behavior. Tools gain no KV access.
+2. Generated contracts, SDK factories, examples, and official extensions agree on
+   removal of `needs`; explicit placement remains enforced.
+3. Configured filesystem, network, and secret access works in the built-in Environment;
+   absent and deployment-denied access stays denied during setup and execution. A
+   separate Environment binding does not inherit another binding's grants.
+4. A real supported Python Environment prepares a package before imports and execution.
+   Setup failure prevents the entrypoint, and concurrent first calls cannot execute
+   against a partially prepared shared installation. A preprepared extension needs no
+   redundant custom hook; unsupported placement fails honestly.
+5. Lost responses and setup failures produce explicit errors/unknown outcomes without
+   automatic replay, replacement placement, or a claim that partial effects were undone.
+6. Run the affected existing tests and required CI gates, including real Linux runtime,
+   HTTP, journal recovery, SDK, and official-extension integration coverage. A draft
+   document or isolated helper test is not evidence that the implementation is complete.
+
+## Out of scope
+
+Long-lived callback authorization, queued Tool transcript submissions, the proposed
+`tool_returned` vocabulary, and callback wakeup semantics need their own record. This
+ADR does not reintroduce universal Tool sync/async or timeout options. It does not add
+Tool KV access, per-message transcript CRUD, durable workflows, dynamic placement, a
+new Environment retention policy, or a universal installer.
+
+## Sources
+
+- [Current Agentloop input](../../crates/brain-protocol/src/agentloop/turn.rs),
+  [state services](../../crates/brain/src/session/services.rs), and
+  [journal projection](../../crates/brain/src/journal/store.rs).
+- [SDK extension factories](../../packages/brain-sdk/src/extensions.ts) and
+  [Environment wire types](../../crates/brain-protocol/src/environment/wire.rs).
+- [Native grants and package refusal](../../crates/brain-env/src/environment.rs).
+- [Environment lifecycle coordination](../../crates/brain-sessions/src/environment.rs)
+  and [execution adapters](../../crates/brain-sessions/src/execution.rs).
+- [uv Python management](https://docs.astral.sh/uv/concepts/python-versions/) and
+  [project synchronization](https://docs.astral.sh/uv/concepts/projects/sync/): existing
+  mechanisms for interpreter discovery/installation and locked project preparation.
+- [uv script support](https://docs.astral.sh/uv/guides/scripts/): existing script
+  dependency metadata and isolated execution, without a Brain-specific needs list.
+- [Docker's Python guide](https://docs.docker.com/guides/python/): an image-based
+  preparation alternative.
+- User discussion, 2026-09-09: requests a cohesive KV API, removal of universal needs,
+  Environment-executed setup, standard runtime tooling, and a smaller Brain contract.
+
+[Index](README.md)
+
+## Implemented bindings
+
+Native WIT imports are `kv-read(key) -> option<string>`, `kv-put(key, value-json) -> u64`,
+and `kv-delete(key) -> u64`, each returning the ordinary turn-error result. HTTP methods
+are `kv_read`, `kv_put`, and `kv_delete`. Read/delete take an identifier string; put takes
+`{ key, value }`. HTTP read returns `{}` for absence or `{ value }`, including null.
+Official JavaScript loops expose `ctx.kv.read/put/delete` and no `setKv` authoring API.
+
+Native Environment configuration accepts `filesystem: { workspace?, scratch? }` with
+`read`/`write` values, `network: string[]` of HTTP(S) origins, and `secrets: string[]`.
+Omitted grants stay denied and deployment allow-lists remain the ceiling.
+
+The Python project example uses pinned standard tooling and tests actual setup/import order,
+concurrent preparation, retained installations, explicit failures, and unsupported descriptors.
+This pre-stable contract cut requires rebuilt Agentloop Components and matching SDK/server
+versions. It does not migrate retained sessions or authorize deleting them during deployment.

--- a/references/adrs/README.md
+++ b/references/adrs/README.md
@@ -42,6 +42,8 @@ remain in [the contracts](../../contracts), [user docs](../../docs), and
 
 - [ADR-044: Separate session management from the built-in execution Environment](2026-09-06-03-sessions-and-brain-env.md)
 
+- [ADR-046: Keep dependency preparation in Environments and give Agentloop KV one API](2026-09-09-01-minimal-extension-contract.md)
+
 ## Chronological index
 
 | Date | Record | Status |
@@ -91,6 +93,7 @@ remain in [the contracts](../../contracts), [user docs](../../docs), and
 | 2026-09-06 | [ADR-043: Make every limit a deployment default injected at server start](2026-09-06-02-deployment-limits.md) | Accepted |
 | 2026-09-06 | [ADR-044: Separate session management from the built-in execution Environment](2026-09-06-03-sessions-and-brain-env.md) | Accepted |
 | 2026-09-07 | [ADR-045: Resolve protocol gaps before stable v1](2026-09-07-01-protocol-freeze.md) | Accepted |
+| 2026-09-09 | [ADR-046: Keep dependency preparation in Environments and give Agentloop KV one API](2026-09-09-01-minimal-extension-contract.md) | Accepted |
 
 ## Important reversals
 

--- a/tests/fixtures/diagnostic-agentloop/src/lib.rs
+++ b/tests/fixtures/diagnostic-agentloop/src/lib.rs
@@ -8,7 +8,10 @@ struct Diagnostic;
 impl Guest for Diagnostic {
     fn turn(input: TurnInput) -> Result<TurnOutput, TurnError> {
         brain::agentloop::host::events(0)?;
-        let mut kv: serde_json::Value = serde_json::from_str(&input.kv_json).map_err(error)?;
+        let mut kv = serde_json::json!({
+            "memory": brain::agentloop::host::kv_read("memory")?
+                .map(|value| serde_json::from_str::<serde_json::Value>(&value)).transpose().map_err(error)?
+        });
         let turns = kv
             .get("memory")
             .and_then(|value| value.get("turns"))
@@ -16,7 +19,7 @@ impl Guest for Diagnostic {
             .unwrap_or(0)
             + 1;
         kv["memory"] = serde_json::json!({"turns": turns});
-        brain::agentloop::host::set_kv("memory", &kv["memory"].to_string())?;
+        brain::agentloop::host::kv_put("memory", &kv["memory"].to_string())?;
         brain::agentloop::host::emit("note", &serde_json::json!({"turns": turns}).to_string())?;
         let message = serde_json::from_str::<serde_json::Value>(&input.input_json)
             .map_err(error)?
@@ -24,6 +27,14 @@ impl Guest for Diagnostic {
             .and_then(serde_json::Value::as_str)
             .unwrap_or_default()
             .to_owned();
+        if message == "kv" {
+        assert!(brain::agentloop::host::kv_read("deleted")?.is_none());
+        brain::agentloop::host::kv_put("deleted", "null")?;
+        assert_eq!(brain::agentloop::host::kv_read("deleted")?.as_deref(), Some("null"));
+        brain::agentloop::host::kv_delete("deleted")?;
+        assert!(brain::agentloop::host::kv_read("deleted")?.is_none());
+        brain::agentloop::host::kv_delete("deleted")?;
+        }
         Ok(TurnOutput {
             result_json: Some(serde_json::json!({"turns": turns, "message": message}).to_string()),
         })

--- a/tests/fixtures/python-project/fail_setup.py
+++ b/tests/fixtures/python-project/fail_setup.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import six
+
+with Path(".venv/setup_attempts").open("a") as attempts:
+    attempts.write("attempt\n")
+raise RuntimeError("fixture setup failure")

--- a/tests/fixtures/python-project/plain.py
+++ b/tests/fixtures/python-project/plain.py
@@ -1,0 +1,4 @@
+import json
+import six
+
+print(json.dumps({"dependency": six.__version__}))

--- a/tests/fixtures/python-project/prepare.py
+++ b/tests/fixtures/python-project/prepare.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+import six
+
+with Path(".venv/prepared").open("x") as marker:
+    marker.write(six.__version__)

--- a/tests/fixtures/python-project/pyproject.toml
+++ b/tests/fixtures/python-project/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "brain-python-environment-fixture"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = ["six==1.17.0"]

--- a/tests/fixtures/python-project/run.py
+++ b/tests/fixtures/python-project/run.py
@@ -1,0 +1,7 @@
+import json
+from pathlib import Path
+import sys
+import six
+
+assert Path(".venv/prepared").read_text() == six.__version__
+print(json.dumps({"echo": json.load(sys.stdin), "dependency": six.__version__}))

--- a/tests/fixtures/python-project/uv.lock
+++ b/tests/fixtures/python-project/uv.lock
@@ -1,0 +1,23 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "brain-python-environment-fixture"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "six" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "six", specifier = "==1.17.0" }]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]

--- a/tests/fixtures/python/agentloop.py
+++ b/tests/fixtures/python/agentloop.py
@@ -8,6 +8,6 @@ class WitWorld(WitWorld):
     def turn(self, input):
         kv = json.loads(input.kv_json)
         kv["calls"] = kv.get("calls", 0) + 1
-        host.set_kv("calls", json.dumps(kv["calls"]))
+        host.kv_put("calls", json.dumps(kv["calls"]))
         sequence = host.emit("python_ran", json.dumps({"calls": kv["calls"]}))
         return TurnOutput(json.dumps({"sequence": sequence, "calls": kv["calls"]}))

--- a/tests/journeys/README.md
+++ b/tests/journeys/README.md
@@ -20,7 +20,7 @@ Linux worker job, then runs all journeys as a required part of `build-test`.
 | `events`, `stream`, client `stream` | Durable cursors, a full page boundary, replay-to-live delivery, reconnect, abort, authentication, session isolation |
 | `tool` with `run` in `hostEnv`, options, schemas, context | Progress ordering, input/output errors, handler errors, deadlines/signals, the call's sequence, concurrent sessions, protected Event rejection |
 | `register`, `credentials`, reattachment | Save credentials, close the host connection, reject mismatched placements, restore matching handlers, preserve active-call cancellation on creation replay |
-| `environment`, `brainEnv`, placed Tools, `needs` | Independent authenticated Environments per instance, lazy allocation, expiry without retry, needs at setup, a refused need failing the create, native workspace persistence/isolation, a need the brain env cannot grant |
+| `environment`, `brainEnv`, placed Tools | Independent authenticated Environments, lazy allocation, configuration validation, explicit native grants and denied access, workspace persistence/isolation |
 | An Agentloop placed in an Environment reached over HTTP | The turn's model call, emit, and dispatch through Brain's turn routes, a dispatched Tool running in the host env, and the routes closing with the turn |
 | `timeoutMs` | Explicit client timeout leaves the server's execution observable and does not retry the model call |
 
@@ -49,3 +49,6 @@ Missing binaries or Components fail the suite; no journeys are conditionally ski
 and worker run natively on Windows too (the worker listens on a named pipe there), but the journey
 harness stops servers by process group, so run the journeys themselves in WSL on Windows. Portable
 SDK unit tests still run with `npm test`.
+
+HTTP Agentloop journeys also exercise `kv_read`, `kv_put`, and `kv_delete` across a failed
+turn and server restart, preserving the distinction between absent keys and JSON null.

--- a/tests/journeys/loops.test.mjs
+++ b/tests/journeys/loops.test.mjs
@@ -19,10 +19,40 @@ const dispatching = loopEnvironment({ fetch: async (url, init) => {
   }
   return fetch(url, init);
 } });
-const f = fixture({ providers: { loop: remote.handle, dispatcher: dispatching.handle } });
+async function kvEnvironment(command) {
+  const op = command.operation;
+  if (op.request.type !== "execute") return { contract: command.contract, sequence: op.sequence, receipt: { type: "accepted" } };
+  const callback = op.request.callback;
+  const call = async (method, input) => {
+    assert.ok(callback.methods.includes(method));
+    const response = await fetch(callback.url, { method: "POST", headers: { authorization: `Bearer ${callback.token}`, "content-type": "application/json" }, body: JSON.stringify({ method, input }) });
+    assert.equal(response.status, 200);
+    return response.json();
+  };
+  let receipt;
+  if (op.request.input.input.message === "save") {
+    assert.deepEqual(await call("kv_read", "removed"), {});
+    const put = await call("kv_put", { key: "removed", value: null });
+    assert.deepEqual(await call("kv_read", "removed"), { value: null });
+    const removed = await call("kv_delete", "removed");
+    assert.ok(removed > put);
+    assert.equal(await call("kv_delete", "removed"), removed);
+    assert.deepEqual(await call("kv_read", "removed"), {});
+    await call("kv_put", { key: "kept", value: null });
+    receipt = { type: "failure", code: "after_commit", message: "failed after KV commits", retryable: false };
+  } else {
+    assert.deepEqual(await call("kv_read", "removed"), {});
+    assert.deepEqual(await call("kv_read", "kept"), { value: null });
+    await call("kv_delete", "kept");
+    assert.deepEqual(await call("kv_read", "kept"), {});
+    receipt = { type: "result", output: { result: "recovered" } };
+  }
+  return { contract: command.contract, sequence: op.sequence, receipt };
+}
+const f = fixture({ providers: { loop: remote.handle, dispatcher: dispatching.handle, kv: kvEnvironment } });
 
 test("an Agentloop placed in an Environment reached over HTTP runs its turn through Brain's granted execution services", { timeout: 30_000 }, async (t) => {
-  const loop = agentloop({ implementation: { type: "reference_agentloop" }, needs: ["https://models.example.com"] })({ env: f.provider("loop") });
+  const loop = agentloop({ implementation: { type: "reference_agentloop" } })({ env: f.provider("loop") });
   const session = await f.create(t, { agentloop: loop });
   await session.send("hello from afar");
   assert.equal(f.modelRequests.length, 1, "the model call went through Brain, which journaled it");
@@ -57,4 +87,16 @@ test("a Tool the remote loop dispatches runs where it was placed, and the invoca
     body: JSON.stringify({ method: "emit", input: { event_type: "late", data: {} } }) });
   assert.equal(closed.status, 404, "a finished invocation's callbacks answer nothing");
   await assert.rejects(f.brain.withToken("wrong").request("POST", new URL(callback.base).pathname, { method: "emit", input: { event_type: "late", data: {} } }), failure(404));
+});
+
+test("HTTP KV commits survive a failed turn and server restart; deletion preserves missing versus null", { timeout: 60_000 }, async (t) => {
+  const session = await f.create(t, { agentloop: agentloop({ implementation: { type: "kv_test" } })({ env: f.provider("kv") }) });
+  await session.send("save");
+  assert.equal((await collect(session.events())).at(-1).type, "turn_failed");
+  await f.stop();
+  await f.start();
+  await session.send("recover");
+  const ended = (await collect(session.events())).at(-1);
+  assert.equal(ended.type, "turn_ended");
+  assert.equal(ended.data.result, "recovered");
 });

--- a/tests/journeys/placement.test.mjs
+++ b/tests/journeys/placement.test.mjs
@@ -10,14 +10,14 @@ const east = lazyEnvironment({ allocate: async () => { allocations++; return new
 const west = lazyEnvironment({ allocate: async () => { allocations++; return new Map(); } });
 const f = fixture({ providers: { east: east.handle, west: west.handle } });
 const dispatch = (calls) => (request, response) => request.messages.at(-1).role === "tool" ? reply(response) : callTools(response, calls);
-const echo = (name, needs = []) => tool({ name, description: "Echo in a provider", input: z.object({ value: z.string() }), implementation: { type: "reference_echo" }, needs });
+const echo = (name) => tool({ name, description: "Echo in a provider", input: z.object({ value: z.string() }), implementation: { type: "reference_echo" } });
 
 test("compose separately configured environments and allocate only on first invocation", { timeout: 30_000 }, async (t) => {
   const eastEnv = f.provider("east", { label: "east workspace" });
   const westEnv = f.provider("west");
   assert.equal(inspectEnvironment(eastEnv).configuration.label, "east workspace");
   assert.equal(inspectEnvironment(eastEnv).driver.url, `${f.upstreamUrl}/east`);
-  const first = echo("first", ["file:///workspace?access=write"])({ env: eastEnv });
+  const first = echo("first")({ env: eastEnv });
   assert.equal(inspectTool(first).environment, eastEnv);
   const before = allocations;
   const session = await f.create(t, { tools: [first, echo("second")({ env: westEnv })] });
@@ -30,16 +30,19 @@ test("compose separately configured environments and allocate only on first invo
   const started = events.find(({ type }) => type === "tool_call_started");
   assert.deepEqual(Object.keys(started.data).sort(), ["deadline_ms", "environment", "invocation", "tool"]);
   const setup = events.find(({ type, data }) => type === "environment_setup_started" && data.environment === "east");
-  assert.deepEqual(setup.data.request.needs, ["file:///workspace?access=write"]);
+  assert.deepEqual(setup.data.request.configuration, { label: "east workspace" });
+  assert.equal("needs" in setup.data.request, false);
   assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("east"));
   assert.ok(JSON.stringify(f.modelRequests.at(-1).messages).includes("west"));
 });
 
-test("a need the environment cannot honour fails the create naming the need", { timeout: 30_000 }, async (t) => {
-  await assert.rejects(
-    f.create(t, { tools: [echo("first", ["pkg:apt/ffmpeg"])({ env: f.provider("east") })] }),
-    (error) => { assert.match(error.message, /pkg:apt\/ffmpeg/u); return true; },
-  );
+test("the environment validates its own configuration at setup", { timeout: 30_000 }, async () => {
+  const result = await east.handle({ contract: "environment/v1", operation: {
+    sequence: 1, environment: "east", session_id: "ses_invalid_config",
+    request: { type: "setup", configuration: { label: 123 } },
+  } });
+  assert.equal(result.receipt.type, "failure");
+  assert.equal(result.receipt.code, "invalid_configuration");
 });
 
 test("caller teardown is visible without replacement allocation", { timeout: 30_000 }, async (t) => {
@@ -70,8 +73,8 @@ test("admit a native tool and use it from a model-driven conversation", { timeou
 
 test("native workspaces persist between turns but remain separate between sessions", { timeout: 30_000 }, async (t) => {
   const workspace = tool({ name: "workspace", description: "Read and write a marker", input: z.object({ workspace: z.boolean(), write: z.string().optional() }),
-    implementation: f.toolComponent, needs: ["file:///workspace?access=write"] });
-  const placed = workspace({ env: brainEnv({ name: "brain" }) });
+    implementation: f.toolComponent });
+  const placed = workspace({ env: brainEnv({ name: "workspace", filesystem: { workspace: "write" } }) });
   const first = await f.create(t, { tools: [placed] });
   const second = await f.create(t, { tools: [placed] });
   f.model = dispatch([{ name: "workspace", input: { workspace: true, write: "private marker" } }]);
@@ -97,9 +100,9 @@ test("a native tool that needs no workspace cannot write one", { timeout: 30_000
 });
 
 test("the brain env refuses at create what it cannot grant", { timeout: 30_000 }, async (t) => {
-  const fetcher = tool({ name: "fetcher", description: "Reach the network", input: z.object({}), implementation: f.toolComponent, needs: ["https://api.example.com"] });
+  const fetcher = tool({ name: "fetcher", description: "Reach the network", input: z.object({}), implementation: f.toolComponent });
   await assert.rejects(
-    f.create(t, { tools: [fetcher({ env: brainEnv({ name: "brain" }) })] }),
+    f.create(t, { tools: [fetcher({ env: brainEnv({ name: "network", network: ["https://api.example.com"] }) })] }),
     (error) => { assert.match(error.message, /https:\/\/api\.example\.com/u); return true; },
   );
 });

--- a/tests/release/runtime.mjs
+++ b/tests/release/runtime.mjs
@@ -88,7 +88,7 @@ try {
   const artifact = component(pathToFileURL(process.env.BRAIN_TEST_REFERENCE_AGENTLOOP));
   await brain.admitAgentloop(artifact);
   const loop = agentloop({ implementation: artifact });
-  const provider = environment({ options: z.object({ url: z.url(), token: z.string() }), url: ({ url }) => url, credential: ({ token }) => token });
+  const provider = environment({ options: z.object({ url: z.url(), token: z.string() }), url: ({ url }) => url, credential: ({ token }) => token, configure: () => ({}) });
   const tools = ["first", "second"].map((name) => tool({ name, input: z.object({ value: z.string() }),
     implementation: { type: "reference_echo" }, description: "Echo input" })({ env: provider({ name, url: providers[name], token: name }) }));
   const options = { model: { provider: "vercel-ai-gateway", name: "test/scripted", apiKey: "test" }, agentloop: loop({ env: brainEnv({ name: "brain" }) }), tools };


### PR DESCRIPTION
## Changes

- Implement ADR-046: remove universal `needs`; keep preparation and explicit resource grants in Environments.
- Expose Agentloop KV read/put/delete over native WIT and HTTP, preserving missing versus JSON null and durable append-only deletion.
- Keep native grants deny-by-default and bounded by deployment policy; separate bindings do not inherit grants.
- Exercise real locked Python project preparation before imports, concurrent first use, optional setup and explicit failures.
- Update source-generated contracts, SDK 0.20.0, examples, authoring documentation and ADR cross-references.
- Patch the transitive development-only YAML parser to clear the required audit gate.

## Verification

Local Linux: workspace tests and doctests; both normally ignored journal probes; clippy; regenerated-contract diff; SDK/example tests; package smoke; 12 real native/Python worker tests; 46 HTTP SDK journeys; release fixtures; and three real Python preparation tests. No selected tests skipped.

This is a pre-stable SDK/WIT contract cut. Retained old sessions and old Agentloop Components are not migrated or deleted implicitly. Long-lived callback/transcript submissions remain separately scoped, not introduced by this ADR.
