### PR TITLE
sdk: add prompt-based structured output to session sends

### DIFF
--- a/docs/guides/meta.json
+++ b/docs/guides/meta.json
@@ -4,6 +4,7 @@
     "write-a-loop",
     "write-a-tool",
     "subagents",
+    "structured-output",
     "write-an-environment",
     "embed"
   ]

--- a/docs/guides/structured-output.mdx
+++ b/docs/guides/structured-output.mdx
@@ -11,7 +11,8 @@ session-state return value.
 
 The executable [structured-output example](https://github.com/aexhq/brain/blob/main/examples/structured-output.mjs)
 extracts a person's name and age. It uses the same server and compiled Agentloop
-setup as the other repository examples.
+setup as the other repository examples. Set `BRAIN_AGENTLOOP_WASM` to a Component
+that emits assistant output, such as the published Pi or Codex Component.
 
 ## Validation and corrections
 
@@ -56,7 +57,7 @@ and validation feedback are identical. This is not an atomic server operation or
 a cross-process retry scheduler; nondeterministic validation can conflict on replay.
 
 The loop must emit `output_emitted` with an Agentloop-origin
-`{ type: "assistant_message", message: string }` payload. Pi, Codex and the reference
-loop use this convention. The SDK selects the last such message in the exact
+`{ type: "assistant_message", message: string }` payload. Pi and Codex use this
+convention; the minimal reference loop does not. The SDK selects the last such message in the exact
 completed turn and fails clearly if it is absent. It does not scrape internal model
 calls or classify refusals from arbitrary output text.

--- a/docs/guides/structured-output.mdx
+++ b/docs/guides/structured-output.mdx
@@ -1,0 +1,62 @@
+---
+title: Structured output
+description: Request a typed answer on an individual send using a Zod schema.
+---
+
+Pass `output: { type: schema, maxRetries: 2 }` in the second argument to
+`session.send`. The SDK adds the schema to the prompt, reads that completed turn's
+assistant output, parses JSON, and validates it locally with Zod. The returned
+value has the schema's inferred output type. Omitting `output` preserves the normal
+session-state return value.
+
+The executable [structured-output example](https://github.com/aexhq/brain/blob/main/examples/structured-output.mjs)
+extracts a person's name and age. It uses the same server and compiled Agentloop
+setup as the other repository examples.
+
+## Validation and corrections
+
+`maxRetries` counts additional correction turns and defaults to two: one initial
+answer and at most two corrections. Zero validates only the first answer. Invalid
+JSON or Zod validation issues cause a follow-up message asking for a complete
+corrected answer. Fenced JSON and surrounding prose fail JSON parsing.
+
+Normal Zod parsing semantics apply: `z.object` strips unknown properties, while
+`z.strictObject` rejects them. Defaults and transforms apply locally. The prompt
+describes the schema's input shape; the return value is its parsed output. Async
+refinements and transforms are supported. Custom refinements run locally and may
+need descriptions or correction feedback to explain constraints to the model.
+Schemas whose input shape cannot be converted to JSON Schema fail before sending.
+Exceptions thrown by custom validation code propagate without correction retries.
+
+Exhaustion throws the exported `StructuredOutputError`, with `attempts`,
+`lastOutput`, and `issues`. Provider, transport and unsupported-output failures
+propagate without automatic retries. No provider-native response format is set;
+avoid conflicting session-level `responseFormat` settings.
+
+## Session behavior
+
+Each attempt is an ordinary durable turn. Corrections can invoke the session's
+tools: the SDK asks the agent not to repeat actions but cannot enforce that through
+a prompt. Model and tool calls inside a turn are additional to the retry count.
+
+The caller runs validation and retries. If the calling process exits, the SDK does
+not schedule further attempts. Invalid answers and corrective messages remain in
+history. A locally rejected answer can still belong to a successfully completed
+server turn. Streams expose raw, provisional output; the returned value is validated.
+
+Use one caller for the session during a structured send. Overlapping sends through
+the same handle are rejected while it is running; other handles and processes
+require application coordination. Optional `signal` stays alongside `output` and
+cancels the current turn and stops corrections. An asynchronous custom validator
+finishes before its result is checked for cancellation.
+
+An explicit `idempotencyKey` identifies the first turn; correction turns use distinct
+derived keys. Repeating the same operation reuses completed turns when its prompts
+and validation feedback are identical. This is not an atomic server operation or
+a cross-process retry scheduler; nondeterministic validation can conflict on replay.
+
+The loop must emit `output_emitted` with an Agentloop-origin
+`{ type: "assistant_message", message: string }` payload. Pi, Codex and the reference
+loop use this convention. The SDK selects the last such message in the exact
+completed turn and fails clearly if it is absent. It does not scrape internal model
+calls or classify refusals from arbitrary output text.

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,7 @@
     "events": "node event-history.mjs",
     "lifecycle": "node session-lifecycle.mjs",
     "http": "node raw-http.mjs",
-    "test": "node --check example-brain.mjs && node --check basic-session.mjs && node --check event-history.mjs && node --check session-lifecycle.mjs && node --check raw-http.mjs && node --test lazy-environment.test.mjs loop-environment.test.mjs"
+    "test": "node --check example-brain.mjs && node --check basic-session.mjs && node --check structured-output.mjs && node --check event-history.mjs && node --check session-lifecycle.mjs && node --check raw-http.mjs && node --test lazy-environment.test.mjs loop-environment.test.mjs"
   },
   "dependencies": {
     "@aexhq/brain": "*",

--- a/examples/structured-output.mjs
+++ b/examples/structured-output.mjs
@@ -1,0 +1,26 @@
+import { Brain, brainEnv } from "@aexhq/brain";
+import { z } from "zod";
+import { example } from "./example-brain.mjs";
+
+const apiKey = process.env.VERCEL_AI_GATEWAY_API_KEY;
+if (!apiKey) throw new Error("VERCEL_AI_GATEWAY_API_KEY is required");
+const brain = new Brain({
+  baseUrl: process.env.BRAIN_BASE_URL ?? "http://127.0.0.1:8080",
+  token: process.env.BRAIN_API_TOKEN,
+});
+const session = await brain.sessions.create({
+  model: { provider: "vercel-ai-gateway", name: process.env.BRAIN_MODEL ?? "openai/gpt-4.1-mini", apiKey },
+  agentloop: example({ env: brainEnv({ name: "brain" }) }),
+});
+try {
+  const person = await session.send("Ada is 37 years old. Extract her details.", {
+    output: {
+      type: z.object({ name: z.string(), age: z.number() }),
+      maxRetries: 2,
+    },
+  });
+  console.log(person);
+} finally {
+  await session.end();
+  await session.delete();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {
@@ -37,7 +37,7 @@
     "gen": "node scripts/gen.mjs",
     "prebuild": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "tsc -p tsconfig.json",
-    "test": "tsc -p tsconfig.json && node --test test/*.test.mjs",
+    "test": "tsc -p tsconfig.json && tsc -p test/types/tsconfig.json && node --test test/*.test.mjs",
     "prepack": "npm run build"
   },
   "devDependencies": {

--- a/packages/brain-sdk/src/client.ts
+++ b/packages/brain-sdk/src/client.ts
@@ -2,6 +2,7 @@ import { HostPump } from "./client-pump.js";
 import { BrainError } from "./errors.js";
 import { inspectAgentloop, inspectComponent, inspectEnvironment, inspectTool, isComponent } from "./extensions.js";
 import { HostToolRegistry } from "./host.js";
+import { structuredOutput } from "./structured-output.js";
 import type {
   AgentloopAdmission, CreateSessionRequest, Environment as WireEnvironment, EventPage, HostRegistration,
   SessionList, SessionSummary as WireSession, SessionTranscript, Tool as WireTool, ToolAdmission,
@@ -9,6 +10,7 @@ import type {
 import type {
   Component, CreateSessionOptions, Environment, OperationOptions, PlacedAgentloop, PlacedTool,
   SessionEvent, SessionState, SessionStreamEvent, UserInput, SendOptions,
+  Schema, SchemaOutput, StructuredSendOptions,
 } from "./types.js";
 
 export interface BrainOptions {
@@ -66,7 +68,7 @@ export class BrainClient {
     return new BrainClient({ baseUrl: this.baseUrl, token, timeoutMs: this.timeoutMs, fetch: this.transport });
   }
 
-  async request<T>(method: string, path: string, body?: unknown, idempotencyKey?: string, contentType = "application/json"): Promise<T> {
+  async request<T>(method: string, path: string, body?: unknown, idempotencyKey?: string, contentType = "application/json", signal?: AbortSignal): Promise<T> {
     const headers = new Headers({ accept: "application/json" });
     if (body !== undefined) headers.set("content-type", contentType);
     if (this.token !== undefined) headers.set("authorization", `Bearer ${this.token}`);
@@ -75,7 +77,7 @@ export class BrainClient {
       method,
       headers,
       body: body === undefined ? undefined : body instanceof Uint8Array ? new Uint8Array(body).buffer : JSON.stringify(body),
-      ...(this.timeoutMs === undefined ? {} : { signal: AbortSignal.timeout(this.timeoutMs) }),
+      signal: this.timeoutMs === undefined ? signal : signal === undefined ? AbortSignal.timeout(this.timeoutMs) : AbortSignal.any([signal, AbortSignal.timeout(this.timeoutMs)]),
     });
     if (!response.ok) {
       const error = (await response.json().catch(() => ({}))) as Partial<BrainError>;
@@ -298,6 +300,8 @@ export class Sessions {
 }
 
 export class SessionHandle {
+  private activeSends = 0;
+  private structuredSend = false;
   constructor(
     private readonly client: BrainClient,
     public state: SessionState,
@@ -305,9 +309,27 @@ export class SessionHandle {
   ) {}
   get id(): string { return this.state.id; }
 
-  async send(input: UserInput | string, operation: SendOptions = {}): Promise<SessionState> {
+  send<S extends Schema>(input: UserInput | string, operation: StructuredSendOptions<S>): Promise<SchemaOutput<S>>;
+  send(input: UserInput | string, operation?: SendOptions): Promise<SessionState>;
+  async send(input: UserInput | string, operation: SendOptions | StructuredSendOptions<Schema> = {}): Promise<unknown> {
     const normalized = typeof input === "string" ? { message: input } : input;
     if (typeof normalized?.message !== "string" || normalized.message === "") throw new TypeError("send needs a non-empty message");
+    const output = "output" in operation ? operation.output : undefined;
+    if (this.structuredSend || (output !== undefined && this.activeSends !== 0)) throw new Error("structured output requires exclusive sends on this session handle");
+    this.activeSends++;
+    this.structuredSend = output !== undefined;
+    try {
+      if (output === undefined) return await this.sendTurn(normalized, operation);
+      return await structuredOutput(normalized, { ...operation, output }, keyOf(operation),
+        (message, options) => this.sendTurn(message, options),
+        (after) => this.events(after, operation.signal), () => this.state.lastSequence);
+    } finally {
+      this.activeSends--;
+      this.structuredSend = false;
+    }
+  }
+
+  private async sendTurn(normalized: UserInput, operation: SendOptions): Promise<SessionState> {
     operation.signal?.throwIfAborted();
     const after = this.state.lastSequence;
     const pending = this.client.request<WireSession>("POST", `/v1/sessions/${encodeURIComponent(this.id)}/messages`, { input: normalized }, keyOf(operation));
@@ -346,13 +368,13 @@ export class SessionHandle {
     return this.client.request("GET", `/v1/sessions/${encodeURIComponent(this.id)}/transcript`);
   }
 
-  events(after = 0): AsyncIterable<SessionEvent> {
+  events(after = 0, signal?: AbortSignal): AsyncIterable<SessionEvent> {
     const client = this.client;
     const sessionId = this.id;
     return { async *[Symbol.asyncIterator]() {
       let cursor = after;
       for (;;) {
-        const page = await client.request<EventPage>("GET", `/v1/sessions/${encodeURIComponent(sessionId)}/events?after=${cursor}`);
+        const page = await client.request<EventPage>("GET", `/v1/sessions/${encodeURIComponent(sessionId)}/events?after=${cursor}`, undefined, undefined, "application/json", signal);
         for (const event of page.events) yield { sequence: event.sequence, recordedAt: new Date(event.recorded_at_ms), type: event.event_type, data: event.data, ...(event.origin == null ? {} : { origin: event.origin }) };
         if (page.next_cursor === cursor) return;
         cursor = page.next_cursor;

--- a/packages/brain-sdk/src/index.ts
+++ b/packages/brain-sdk/src/index.ts
@@ -22,6 +22,7 @@ export type {
 } from "./extensions.js";
 export type { HostToolCall } from "./host.js";
 export { BrainError } from "./errors.js";
+export { StructuredOutputError } from "./structured-output.js";
 export type { EventPage, ModelRequest, ModelResult, SessionTranscript, ToolResult } from "./generated/session.js";
 export type {
   AgentloopAdmission,
@@ -39,6 +40,7 @@ export type {
   ModelUsage,
   OperationOptions,
   SendOptions,
+  StructuredSendOptions,
   Media,
   UserInput,
   Outcome,

--- a/packages/brain-sdk/src/structured-output.ts
+++ b/packages/brain-sdk/src/structured-output.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import type { Schema, SchemaOutput, SendOptions, SessionEvent, SessionState, StructuredSendOptions, UserInput } from "./types.js";
+
+export class StructuredOutputError extends Error {
+  readonly name = "StructuredOutputError";
+  constructor(
+    readonly attempts: number,
+    readonly lastOutput: string,
+    readonly issues: readonly z.core.$ZodIssue[],
+  ) {
+    super(`Structured output did not match the schema after ${attempts} attempt${attempts === 1 ? "" : "s"}`);
+  }
+}
+
+export async function structuredOutput<S extends Schema>(
+  input: UserInput,
+  options: StructuredSendOptions<S>,
+  key: string,
+  send: (input: UserInput, options: SendOptions) => Promise<SessionState>,
+  events: (after: number) => AsyncIterable<SessionEvent>,
+  sequence: () => number,
+): Promise<SchemaOutput<S>> {
+  const { type: schema, maxRetries = 2 } = options.output;
+  if (!(schema instanceof z.ZodType)) throw new TypeError("output.type must be a Zod schema");
+  if (!Number.isSafeInteger(maxRetries) || maxRetries < 0) throw new TypeError("output.maxRetries must be a nonnegative safe integer");
+  options.signal?.throwIfAborted();
+  const instructions = `For this response only, return exactly one JSON value matching this schema. Do not include Markdown fences or surrounding prose.\n${JSON.stringify(z.toJSONSchema(schema, { io: "input" }))}`;
+  let next: UserInput = { ...input, message: `${input.message}\n\n${instructions}` };
+  let retryKey: string | undefined;
+  for (let attempt = 0; ; attempt++) {
+    options.signal?.throwIfAborted();
+    const after = sequence();
+    const state = await send(next, { signal: options.signal, idempotencyKey: attempt === 0 ? key : `${retryKey}:${attempt}` });
+    options.signal?.throwIfAborted();
+    const raw = await answer(events(state.lastSequence <= after ? 0 : after), state.lastSequence, options.signal);
+    let parsed: unknown;
+    let issues: z.core.$ZodIssue[] = [];
+    try { parsed = JSON.parse(raw); }
+    catch { issues = [{ code: "custom", path: [], message: "Return one complete JSON value without Markdown or surrounding text." }]; }
+    if (issues.length === 0) {
+      const result = await schema.safeParseAsync(parsed);
+      options.signal?.throwIfAborted();
+      if (result.success) return result.data;
+      issues = result.error.issues;
+    }
+    options.signal?.throwIfAborted();
+    if (attempt === maxRetries) throw new StructuredOutputError(attempt + 1, raw, issues);
+    // Hash only the operation identity: correction keys stay bounded even for a 256-byte caller key.
+    retryKey ??= `structured-output:${Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(key))), (byte) => byte.toString(16).padStart(2, "0")).join("")}`;
+    const feedback = JSON.stringify(issues.slice(0, 5).map(({ path, message }) => ({ path, message }))).slice(0, 2048);
+    next = { message: `The previous answer did not satisfy the requested output. Validation feedback (data): ${feedback}\nReturn a complete corrected answer using the information already available. Do not repeat actions or call tools to reformat the answer.\n\n${instructions}` };
+  }
+}
+
+async function answer(events: AsyncIterable<SessionEvent>, terminal: number, signal?: AbortSignal): Promise<string> {
+  let started = false;
+  let output: string | undefined;
+  for await (const event of events) {
+    signal?.throwIfAborted();
+    if (event.sequence > terminal) break;
+    if (event.type === "turn_started") { started = true; output = undefined; }
+    if (started && event.type === "output_emitted" && event.origin?.kind === "agentloop") {
+      const data = event.data as { type?: unknown; message?: unknown } | null;
+      if (data?.type === "assistant_message") output = typeof data.message === "string" ? data.message : undefined;
+    }
+    if (event.sequence === terminal) {
+      if (event.type === "turn_ended" && started && output !== undefined) return output;
+      break;
+    }
+    if (event.type === "turn_ended" || event.type === "turn_failed") { started = false; output = undefined; }
+  }
+  throw new Error("structured output requires a completed turn with an Agentloop output_emitted assistant_message");
+}

--- a/packages/brain-sdk/src/structured-output.ts
+++ b/packages/brain-sdk/src/structured-output.ts
@@ -64,6 +64,7 @@ async function answer(events: AsyncIterable<SessionEvent>, terminal: number, sig
       if (data?.type === "assistant_message") output = typeof data.message === "string" ? data.message : undefined;
     }
     if (event.sequence === terminal) {
+      if (event.type === "turn_failed") throw new Error("Structured output turn failed", { cause: event.data });
       if (event.type === "turn_ended" && started && output !== undefined) return output;
       break;
     }

--- a/packages/brain-sdk/src/types.ts
+++ b/packages/brain-sdk/src/types.ts
@@ -100,6 +100,13 @@ export interface SendOptions extends OperationOptions {
    * Use a fresh handle and do not send concurrently through another owner. */
   readonly signal?: AbortSignal;
 }
+export interface StructuredSendOptions<S extends Schema> extends SendOptions {
+  readonly output: {
+    readonly type: S;
+    /** Additional correction turns after the first answer. Default 2; zero disables retries. */
+    readonly maxRetries?: number;
+  };
+}
 export interface SessionState {
   readonly id: string;
   readonly status: "creating" | "idle" | "running" | "ending" | "ended" | "failed";

--- a/packages/brain-sdk/test/structured-output.test.mjs
+++ b/packages/brain-sdk/test/structured-output.test.mjs
@@ -148,6 +148,21 @@ test("provider and transport failures never trigger output corrections", async (
   }
 });
 
+test("a committed turn failure is preserved as the cause without correction", async () => {
+  const f = fixture(['"unused"']);
+  const events = f.session.events.bind(f.session);
+  const failure = { code: "model_failed", message: "provider unavailable", retryable: false };
+  f.session.events = after => ({ async *[Symbol.asyncIterator]() {
+    for await (const event of events(after)) yield event.type === "turn_ended" ? { ...event, type: "turn_failed", data: failure } : event;
+  } });
+  await assert.rejects(f.session.send("Extract", { output: { type: z.string() } }), error => {
+    assert.equal(error.message, "Structured output turn failed");
+    assert.deepEqual(error.cause, failure);
+    return true;
+  });
+  assert.equal(f.posts.length, 1);
+});
+
 test("cancellation before send or during async validation prevents further turns", async () => {
   const first = fixture([]);
   await assert.rejects(first.session.send("Extract", { output: { type: z.string() }, signal: AbortSignal.abort() }), { name: "AbortError" });

--- a/packages/brain-sdk/test/structured-output.test.mjs
+++ b/packages/brain-sdk/test/structured-output.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { z } from "zod";
+import { Brain, BrainError, SessionHandle, StructuredOutputError } from "../dist/index.js";
+
+function fixture(answers, { pageSize = 1000, origin = { kind: "agentloop", sequence: 2 } } = {}) {
+  const posts = [], reads = [], records = [], receipts = new Map();
+  const add = (event_type, data, attribution) => records.push({ sequence: records.length + 1, recorded_at_ms: 1, event_type, data, ...(attribution ? { origin: attribution } : {}) });
+  const client = new Brain({ baseUrl: "https://brain.example", fetch: async (url, init) => {
+    if (url.endsWith("/messages")) {
+      const input = JSON.parse(init.body).input;
+      const key = new Headers(init.headers).get("idempotency-key");
+      posts.push({ input, key });
+      if (receipts.has(key)) {
+        const previous = receipts.get(key);
+        assert.deepEqual(input, previous.input);
+        return Response.json(previous.state);
+      }
+      assert.ok(answers.length, "unexpected correction send");
+      const candidate = answers.shift();
+      if (candidate instanceof Error) throw candidate;
+      const raw = typeof candidate === "function" ? await candidate(input) : candidate;
+      add("turn_started", { input });
+      add("output_emitted", { type: "assistant_message", message: "unrelated tool output" }, { kind: "tool", sequence: 2 });
+      if (raw !== undefined) add("output_emitted", { type: "assistant_message", message: raw }, origin);
+      add("turn_ended", { result: null });
+      const state = { session_id: "s", status: "idle", last_sequence: records.length };
+      receipts.set(key, { input, state });
+      return Response.json(state);
+    }
+    assert.ok(url.includes("/events?"));
+    init.signal?.throwIfAborted();
+    const after = Number(new URL(url).searchParams.get("after"));
+    reads.push(after);
+    const events = records.filter(event => event.sequence > after).slice(0, pageSize);
+    return Response.json({ events, next_cursor: events.at(-1)?.sequence ?? after });
+  } });
+  const session = new SessionHandle(client, { id: "s", status: "idle", lastSequence: 0 });
+  return { session, client, posts, reads, records, add };
+}
+
+test("structured send returns Zod output, preserves media, and scopes the prompt to this response", async () => {
+  const f = fixture(['{"name":"Ada","age":"37","extra":true}']);
+  const type = z.object({ name: z.string().describe("Full name"), age: z.string().transform(Number) });
+  const media = [{ type: "image", url: "https://example.com/person.png" }];
+  assert.deepEqual(await f.session.send({ message: "Extract the person", media }, { output: { type } }), { name: "Ada", age: 37 });
+  assert.deepEqual(f.posts[0].input.media, media);
+  assert.match(f.posts[0].input.message, /Extract the person[\s\S]*For this response only/);
+  assert.match(f.posts[0].input.message, /Full name/);
+  assert.equal(f.session.state.status, "idle");
+});
+
+for (const rejected of [[], ["not json"], ["```json\n{}\n```", '{"age":"wrong"}']]) {
+  test(`succeeds after ${rejected.length} corrections with distinct bounded keys`, async () => {
+    const f = fixture([...rejected, '{"age":37}']);
+    const options = { output: { type: z.object({ age: z.number() }) }, idempotencyKey: "k".repeat(256) };
+    assert.deepEqual(await f.session.send("Extract", options), { age: 37 });
+    assert.equal(f.posts.length, rejected.length + 1);
+    assert.equal(f.posts[0].key, options.idempotencyKey);
+    assert.equal(new Set(f.posts.map(p => p.key)).size, f.posts.length);
+    assert.ok(f.posts.every(p => p.key.length <= 256));
+    for (const post of f.posts.slice(1)) {
+      assert.match(post.input.message, /Validation feedback/);
+      assert.match(post.input.message, /Do not repeat actions or call tools/);
+    }
+  });
+}
+
+for (const maxRetries of [undefined, 0, 1]) {
+  test(`exhaustion respects maxRetries=${maxRetries}`, async () => {
+    const count = (maxRetries ?? 2) + 1;
+    const f = fixture(Array(count).fill('{"age":"wrong"}'));
+    await assert.rejects(f.session.send("Extract", { output: { type: z.object({ age: z.number() }), maxRetries } }), error => {
+      assert.ok(error instanceof StructuredOutputError);
+      assert.equal(error.attempts, count);
+      assert.equal(error.lastOutput, '{"age":"wrong"}');
+      assert.deepEqual(error.issues[0].path, ["age"]);
+      return true;
+    });
+    assert.equal(f.posts.length, count);
+    assert.equal(f.records.at(-1).event_type, "turn_ended");
+  });
+}
+
+test("invalid options, unrepresentable schemas and empty input fail before network effects", async () => {
+  const f = fixture([]);
+  for (const maxRetries of [-1, 0.5, NaN, Infinity, Number.MAX_SAFE_INTEGER + 1, "2", null]) {
+    await assert.rejects(f.session.send("Extract", { output: { type: z.string(), maxRetries } }), TypeError);
+  }
+  await assert.rejects(f.session.send("Extract", { output: { type: {} } }), TypeError);
+  await assert.rejects(f.session.send("Extract", { output: { type: z.date() } }), /cannot be represented/);
+  await assert.rejects(f.session.send("", { output: { type: z.string() } }), TypeError);
+  assert.equal(f.posts.length, 0);
+});
+
+test("uses exact terminal boundaries across pagination and replay of older receipts", async () => {
+  const f = fixture(['"first"', '"later"'], { pageSize: 2 });
+  const output = { type: z.string() };
+  assert.equal(await f.session.send("First", { output, idempotencyKey: "first" }), "first");
+  assert.equal(await f.session.send("Later", { output }), "later");
+  assert.equal(await f.session.send("First", { output, idempotencyKey: "first" }), "first");
+  assert.ok(f.reads.includes(2), "crossed event pages");
+  assert.equal(f.records.filter(r => r.event_type === "turn_started").length, 2);
+});
+
+test("replaying the entire correction sequence preserves per-turn idempotency", async () => {
+  const f = fixture(['"wrong"', "42"]);
+  const options = { output: { type: z.number() }, idempotencyKey: "extract-once" };
+  assert.equal(await f.session.send("Extract", options), 42);
+  assert.equal(await f.session.send("Extract", options), 42);
+  assert.equal(f.records.filter(r => r.event_type === "turn_started").length, 2);
+  assert.equal(f.posts[1].key, f.posts[3].key);
+});
+
+test("normal sends are unchanged and sequential structured sends can use different schemas", async () => {
+  const f = fixture(["ordinary", "null", "[1,2]", '{"name":"Ada"}']);
+  assert.equal((await f.session.send("Chat", { idempotencyKey: "plain" })).status, "idle");
+  assert.equal(f.posts[0].input.message, "Chat");
+  assert.equal(await f.session.send("Nothing", { output: { type: z.null() } }), null);
+  assert.deepEqual(await f.session.send("Numbers", { output: { type: z.array(z.number()) } }), [1, 2]);
+  assert.deepEqual(await f.session.send("Default", { output: { type: z.object({ name: z.string(), age: z.number().default(37) }) } }), { name: "Ada", age: 37 });
+});
+
+test("async refinements correct their failures, while custom-code exceptions propagate", async () => {
+  const f = fixture(['"wrong"', '"Ada"']);
+  const type = z.string().refine(async value => value === "Ada", "Must be Ada");
+  assert.equal(await f.session.send("Name", { output: { type } }), "Ada");
+  assert.match(f.posts[1].input.message, /Must be Ada/);
+  const bug = new Error("validator bug");
+  const broken = fixture(['"Ada"']);
+  await assert.rejects(broken.session.send("Name", { output: { type: z.string().transform(() => { throw bug; }) } }), error => error === bug);
+  assert.equal(broken.posts.length, 1);
+});
+
+for (const options of [{}, { origin: { kind: "tool", sequence: 2 } }]) {
+  test(`unsupported output fails without corrections (${JSON.stringify(options)})`, async () => {
+    const f = fixture([options.origin ? '"spoofed"' : undefined], options);
+    await assert.rejects(f.session.send("Extract", { output: { type: z.string() } }), /requires a completed turn/);
+    assert.equal(f.posts.length, 1);
+  });
+}
+
+test("provider and transport failures never trigger output corrections", async () => {
+  for (const error of [new BrainError(503, "model_failed", "unavailable", false), new TypeError("fetch failed")]) {
+    const f = fixture([error]);
+    await assert.rejects(f.session.send("Extract", { output: { type: z.string() } }), e => e === error);
+    assert.equal(f.posts.length, 1);
+  }
+});
+
+test("cancellation before send or during async validation prevents further turns", async () => {
+  const first = fixture([]);
+  await assert.rejects(first.session.send("Extract", { output: { type: z.string() }, signal: AbortSignal.abort() }), { name: "AbortError" });
+  const controller = new AbortController();
+  const f = fixture(['"wrong"']);
+  const type = z.string().refine(async () => { controller.abort(); return false; });
+  await assert.rejects(f.session.send("Extract", { output: { type }, signal: controller.signal }), { name: "AbortError" });
+  assert.equal(f.posts.length, 1);
+});
+
+test("structured sends reject overlap in either direction and release ownership on failure", async () => {
+  const release = Promise.withResolvers();
+  const f = fixture([() => release.promise, "ordinary"]);
+  const pending = f.session.send("Extract", { output: { type: z.string(), maxRetries: 0 } });
+  await assert.rejects(f.session.send("Overlap"), /exclusive sends/);
+  await assert.rejects(f.session.send("Overlap", { output: { type: z.string() } }), /exclusive sends/);
+  release.resolve("not json");
+  await assert.rejects(pending, StructuredOutputError);
+  assert.equal((await f.session.send("Now chat")).status, "idle");
+  const done = Promise.withResolvers();
+  const ordinary = fixture([() => done.promise]);
+  const sending = ordinary.session.send("Chat");
+  await assert.rejects(ordinary.session.send("Extract", { output: { type: z.string() } }), /exclusive sends/);
+  done.resolve("finished");
+  await sending;
+});
+
+test("cancellation interrupts an outstanding output-history read", async () => {
+  const reading = Promise.withResolvers();
+  const controller = new AbortController();
+  const client = new Brain({ baseUrl: "https://brain.example", fetch: async (url, init) => {
+    if (url.endsWith("/messages")) return Response.json({ session_id: "s", status: "idle", last_sequence: 3 });
+    reading.resolve();
+    return new Promise((_, reject) => init.signal.addEventListener("abort", () => reject(init.signal.reason), { once: true }));
+  } });
+  const session = new SessionHandle(client, { id: "s", status: "idle", lastSequence: 0 });
+  const pending = session.send("Extract", { output: { type: z.string() }, signal: controller.signal });
+  await reading.promise;
+  controller.abort();
+  await assert.rejects(pending, { name: "AbortError" });
+});

--- a/packages/brain-sdk/test/types/structured-output.ts
+++ b/packages/brain-sdk/test/types/structured-output.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import type { SessionHandle, SessionState, StructuredSendOptions } from "../../dist/index.js";
+
+declare const session: SessionHandle;
+const schema = z.object({ age: z.string().transform(Number) });
+const options: StructuredSendOptions<typeof schema> = { output: { type: schema } };
+const structured: Promise<{ age: number }> = session.send("Extract", options);
+const ordinary: Promise<SessionState> = session.send("Chat");
+const cancellable: Promise<SessionState> = session.send("Chat", { signal: new AbortController().signal });
+// @ts-expect-error The return value is the transformed output, not the schema's input.
+const input: Promise<{ age: string }> = session.send("Extract", options);
+// @ts-expect-error Output needs a Zod type.
+session.send("Extract", { output: { type: {} } });
+// @ts-expect-error Retry counts are numeric.
+session.send("Extract", { output: { type: schema, maxRetries: "2" } });
+void [structured, ordinary, cancellable, input];

--- a/packages/brain-sdk/test/types/tsconfig.json
+++ b/packages/brain-sdk/test/types/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES2023", "module": "NodeNext", "moduleResolution": "NodeNext",
+    "strict": true, "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/tests/journeys/structured-output.test.mjs
+++ b/tests/journeys/structured-output.test.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { z } from "zod";
+import { StructuredOutputError } from "@aexhq/brain";
+import { fixture, collect, reply, deferred } from "./support.mjs";
+
+const f = fixture();
+
+test("prompt output corrects twice, replays keyed turns, and changes schemas on the same session", { timeout: 30_000 }, async t => {
+  const answers = ["not JSON", '{"age":"wrong"}', '{"age":37}', '["Ada"]'];
+  f.model = (request, response) => {
+    assert.equal(request.response_format, undefined);
+    reply(response, answers.shift());
+  };
+  const session = await f.create(t);
+  const options = { output: { type: z.object({ age: z.number() }) }, idempotencyKey: "structured-once" };
+  assert.deepEqual(await session.send("Extract Ada's age", options), { age: 37 });
+  assert.equal(f.modelRequests.length, 3);
+  assert.match(JSON.stringify(f.modelRequests[1].messages), /Validation feedback/);
+  assert.deepEqual(await session.send("Extract Ada's age", options), { age: 37 });
+  assert.equal(f.modelRequests.length, 3, "idempotent correction turns do not rerun inference");
+  assert.deepEqual(await session.send("List names", { output: { type: z.array(z.string()) } }), ["Ada"]);
+  const reopened = await f.brain.sessions.get(session.id);
+  const events = await collect(reopened.events());
+  assert.equal(events.filter(e => e.type === "turn_ended").length, 4);
+  assert.equal(events.filter(e => e.type === "output_emitted").length, 4);
+  assert.equal(answers.length, 0);
+});
+
+test("exhaustion is local while completed turns remain durable", { timeout: 30_000 }, async t => {
+  f.model = (_, response) => reply(response, "{}");
+  const session = await f.create(t);
+  await assert.rejects(session.send("Extract", { output: { type: z.object({ name: z.string() }) } }), error => {
+    assert.ok(error instanceof StructuredOutputError);
+    assert.equal(error.attempts, 3);
+    return true;
+  });
+  assert.equal(f.modelRequests.length, 3);
+  const events = await collect(session.events());
+  assert.equal(events.filter(e => e.type === "turn_ended").length, 3);
+  assert.equal(events.filter(e => e.type === "turn_failed").length, 0);
+});
+
+test("cancellation of a correction stops the sequence without another model call", { timeout: 30_000 }, async t => {
+  const correcting = deferred();
+  f.model = (_, response) => {
+    if (f.modelRequests.length === 1) reply(response, "not JSON");
+    else correcting.resolve();
+  };
+  const session = await f.create(t);
+  const controller = new AbortController();
+  const pending = session.send("Extract", { output: { type: z.string() }, signal: controller.signal }).catch(error => error);
+  await correcting.promise;
+  controller.abort();
+  assert.ok(await pending instanceof Error);
+  assert.equal(f.modelRequests.length, 2);
+  assert.ok((await collect(session.events())).some(e => e.type === "turn_failed"));
+});

--- a/tests/journeys/structured-output.test.mjs
+++ b/tests/journeys/structured-output.test.mjs
@@ -1,10 +1,24 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { z } from "zod";
-import { StructuredOutputError } from "@aexhq/brain";
+import { agentloop, StructuredOutputError } from "@aexhq/brain";
+import { loopEnvironment } from "../../examples/loop-environment.mjs";
 import { fixture, collect, reply, deferred } from "./support.mjs";
 
-const f = fixture();
+const remote = loopEnvironment({ fetch: async (url, init) => {
+  const response = await fetch(url, init);
+  const { method, input } = JSON.parse(init.body);
+  if (response.ok && method === "set_transcript" && input.at(-1)?.role === "assistant") {
+    const message = input.at(-1).content.filter(block => block.type === "text").map(block => block.text).join("");
+    const emitted = await fetch(url, { ...init, body: JSON.stringify({ method: "emit", input: {
+      event_type: "output_emitted", data: { type: "assistant_message", message },
+    } }) });
+    assert.equal(emitted.status, 200);
+  }
+  return response;
+} });
+const f = fixture({ providers: { output: remote.handle } });
+const create = t => f.create(t, { agentloop: agentloop({ implementation: { type: "reference_agentloop" } })({ env: f.provider("output") }) });
 
 test("prompt output corrects twice, replays keyed turns, and changes schemas on the same session", { timeout: 30_000 }, async t => {
   const answers = ["not JSON", '{"age":"wrong"}', '{"age":37}', '["Ada"]'];
@@ -12,7 +26,7 @@ test("prompt output corrects twice, replays keyed turns, and changes schemas on 
     assert.equal(request.response_format, undefined);
     reply(response, answers.shift());
   };
-  const session = await f.create(t);
+  const session = await create(t);
   const options = { output: { type: z.object({ age: z.number() }) }, idempotencyKey: "structured-once" };
   assert.deepEqual(await session.send("Extract Ada's age", options), { age: 37 });
   assert.equal(f.modelRequests.length, 3);
@@ -29,7 +43,7 @@ test("prompt output corrects twice, replays keyed turns, and changes schemas on 
 
 test("exhaustion is local while completed turns remain durable", { timeout: 30_000 }, async t => {
   f.model = (_, response) => reply(response, "{}");
-  const session = await f.create(t);
+  const session = await create(t);
   await assert.rejects(session.send("Extract", { output: { type: z.object({ name: z.string() }) } }), error => {
     assert.ok(error instanceof StructuredOutputError);
     assert.equal(error.attempts, 3);
@@ -47,12 +61,18 @@ test("cancellation of a correction stops the sequence without another model call
     if (f.modelRequests.length === 1) reply(response, "not JSON");
     else correcting.resolve();
   };
-  const session = await f.create(t);
+  const session = await create(t);
   const controller = new AbortController();
   const pending = session.send("Extract", { output: { type: z.string() }, signal: controller.signal }).catch(error => error);
-  await correcting.promise;
+  await Promise.race([correcting.promise, pending.then(error => { throw error; })]);
   controller.abort();
   assert.ok(await pending instanceof Error);
   assert.equal(f.modelRequests.length, 2);
   assert.ok((await collect(session.events())).some(e => e.type === "turn_failed"));
+});
+
+test("a loop without assistant output fails clearly without correction turns", { timeout: 30_000 }, async t => {
+  const session = await f.create(t);
+  await assert.rejects(session.send("Extract", { output: { type: z.string() } }), /requires a completed turn/);
+  assert.equal(f.modelRequests.length, 1);
 });


### PR DESCRIPTION
Adds optional `session.send(message, { output: { type: z.object(...), maxRetries: 2 } })` returning the inferred Zod output. The SDK augments the prompt, validates the exact completed turn's assistant output, and makes at most two corrective sends by default. Existing ordinary sends, Agentloops, provider formats and server contracts are unchanged.

Corrections use distinct idempotency keys, cancellation covers turns and history reads, and overlapping sends on the same handle fail while structured output is active. Exhaustion throws StructuredOutputError with attempts, last output and issues. Zod transformations and async refinements run locally.

Validation: npm test (39 SDK tests, type assertions, 2 example tests), npm run package-smoke, npm audit --audit-level=high, and git diff --check pass locally. All 50 real Linux SDK journeys also pass locally, including correction, replay, schema changes, exhaustion, cancellation and unsupported loops; required CI runs them before merge. Includes executable example and user documentation. Publishes SDK 0.21.0.

