### PR TITLE
tools: preserve host outcomes and known interruption causes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ with HTTP and SSE. A local deployment needs no external store. The
 The tool below is a plain function in your own process. The SDK registers your process as a host
 over SSE, so your app needs no open port.
 
+Host functions can return ordinary output or an `Outcome` directly, preserving structured errors.
+Tool deadlines yield `timeout`, explicit cancellation yields `cancelled`, and missing results after
+dispatch yield `unknown`. Each is a failed Tool result; see [Tool outcomes](docs/guides/write-a-tool.mdx#return-values-and-outcomes).
+
 Run a server:
 
 ```sh

--- a/crates/brain-server/src/environment/host.rs
+++ b/crates/brain-server/src/environment/host.rs
@@ -397,9 +397,7 @@ impl HostEnvironment {
                 () = command_sender.closed() => break Err(brain::Error::Ambiguous(
                     "the host disconnected after dispatch".into(),
                 )),
-                () = &mut deadline => break Err(brain::Error::Ambiguous(
-                    "the Tool deadline elapsed after dispatch".into(),
-                )),
+                () = &mut deadline => break Ok(Outcome::Timeout),
                 Some(event) = event_receiver.recv() => {
                     let answer = services.call("emit", serde_json::json!({"event_type": event.kind, "data": event.data})).await.and_then(|value| serde_json::from_value(value).map_err(|error| brain::Error::Executor(error.to_string()))).map_err(|error| error.to_string());
                     let _ = event.reply.send(answer);
@@ -798,6 +796,37 @@ mod tests {
             executing.await.unwrap().unwrap(),
             EnvironmentReceipt::Result { output: value } if value == serde_json::json!({"ok": true})
         ));
+    }
+
+    #[tokio::test]
+    async fn an_unanswered_host_command_returns_a_timeout_receipt() {
+        let hosts = test_hosts();
+        let registration = hosts.register().unwrap();
+        let mut connection = hosts
+            .connect(&registration.host_id, &registration.token)
+            .unwrap();
+        let executing = tokio::spawn({
+            let hosts = hosts.clone();
+            let entry = entry(registration.host_id);
+            async move {
+                let mut invocation = invoke();
+                if let EnvironmentRequest::Execute { deadline_ms, .. } = &mut invocation.request {
+                    *deadline_ms = 20;
+                }
+                hosts
+                    .execute(
+                        &entry,
+                        &invocation,
+                        Some(Arc::new(brain_sessions::SessionServices::Tool(Arc::new(
+                            NoEvents,
+                        )))),
+                    )
+                    .await
+            }
+        });
+        connection.commands.recv().await.unwrap();
+        assert!(matches!(executing.await.unwrap().unwrap(),
+            EnvironmentReceipt::Failure { code, .. } if code == "timeout"));
     }
 
     #[tokio::test]

--- a/crates/brain-sessions/src/execution.rs
+++ b/crates/brain-sessions/src/execution.rs
@@ -131,7 +131,7 @@ impl ToolExecutor for SessionToolExecutor {
                     details,
                 },
             }),
-            EnvironmentReceipt::Unknown { message } => Err(brain::Error::Ambiguous(message)),
+            EnvironmentReceipt::Unknown { message } => Ok(Outcome::Unknown { message }),
             _ => Err(brain::Error::Ambiguous(
                 "Environment returned a nonterminal Tool receipt".into(),
             )),

--- a/crates/brain-sessions/src/execution_tests.rs
+++ b/crates/brain-sessions/src/execution_tests.rs
@@ -51,6 +51,21 @@ async fn environment_errors_reach_tools_without_losing_information() {
 }
 
 #[tokio::test]
+async fn an_explicit_unknown_receipt_is_a_tool_outcome_not_a_transport_failure() {
+    let executor = SessionToolExecutor::new(Arc::new(EnvironmentRegistry::new(Arc::new(Adapter(
+        EnvironmentReceipt::Unknown {
+            message: "result lost after dispatch".into(),
+        },
+    )))));
+    assert_eq!(
+        executor.execute(dispatch(), Arc::new(Leaf)).await.unwrap(),
+        Outcome::Unknown {
+            message: "result lost after dispatch".into()
+        }
+    );
+}
+
+#[tokio::test]
 async fn nonterminal_execute_receipts_leave_the_effect_unknown() {
     for receipt in [
         EnvironmentReceipt::Accepted,

--- a/crates/brain/src/session/actor.rs
+++ b/crates/brain/src/session/actor.rs
@@ -686,10 +686,17 @@ impl TurnServices for TurnHost {
                     // same way.
                     let output_schema = dispatch.tool.output_schema.clone();
                     let call = async {
-                        let validator = jsonschema::validator_for(&dispatch.tool.input_schema).map_err(|e| Error::InvalidState(e.to_string()))?;
+                        let validator = jsonschema::validator_for(&dispatch.tool.input_schema)
+                            .map_err(|e| Error::InvalidState(e.to_string()))?;
                         if let Err(error) = validator.validate(&dispatch.invocation.input) {
-                            return Ok(Outcome::Error { error: brain_protocol::OutcomeError { retryable: false,
-code: "invalid_input".into(), message: error.to_string(), details: None } });
+                            return Ok(Outcome::Error {
+                                error: brain_protocol::OutcomeError {
+                                    retryable: false,
+                                    code: "invalid_input".into(),
+                                    message: error.to_string(),
+                                    details: None,
+                                },
+                            });
                         }
                         let mut services = self.clone();
                         services.origin = brain_protocol::EventOrigin::Tool { sequence };
@@ -703,41 +710,57 @@ code: "invalid_input".into(), message: error.to_string(), details: None } });
                     let result = tokio::select! {
                         outcome = tokio::time::timeout(deadline, call) => match outcome {
                             Ok(result) => result.map(|outcome| (outcome, false)),
-                            Err(_) => Ok((Outcome::Unknown {
-                                message: "Tool deadline elapsed after the call was sent".into(),
-                            }, true)),
+                            Err(_) => Ok((Outcome::Timeout, true)),
                         },
-                        () = cancelled => Ok((Outcome::Unknown {
-                            message: "Tool cancellation was requested after the call was sent".into(),
-                        }, true)),
+                        () = cancelled => Ok((Outcome::Cancelled, true)),
                     };
                     let dropped = matches!(&result, Ok((_, true)));
                     let unreachable = matches!(&result, Err(Error::Ambiguous(_)));
                     let result = result.and_then(|(outcome, dropped)| {
                         if let (Outcome::Ok { value }, Some(schema)) = (&outcome, &output_schema) {
-                            let validator = jsonschema::validator_for(schema).map_err(|e| Error::Executor(e.to_string()))?;
+                            let validator = jsonschema::validator_for(schema)
+                                .map_err(|e| Error::Executor(e.to_string()))?;
                             if let Err(error) = validator.validate(value) {
-                                return Ok((Outcome::Error { error: brain_protocol::OutcomeError { retryable: false,
-code: "invalid_output".into(), message: error.to_string(), details: None } }, dropped));
+                                return Ok((
+                                    Outcome::Error {
+                                        error: brain_protocol::OutcomeError {
+                                            retryable: false,
+                                            code: "invalid_output".into(),
+                                            message: error.to_string(),
+                                            details: None,
+                                        },
+                                    },
+                                    dropped,
+                                ));
                             }
                         }
                         Ok((outcome, dropped))
                     });
                     let result = match result {
                         Ok((outcome, _)) => ToolResult::from_outcome(call_id, outcome),
-                        Err(Error::Ambiguous(message)) => ToolResult::from_outcome(call_id, Outcome::Unknown { message }),
+                        Err(Error::Ambiguous(message)) => {
+                            ToolResult::from_outcome(call_id, Outcome::Unknown { message })
+                        }
                         Err(error) => ToolResult {
                             call_id,
-                            output: serde_json::to_value(Failure::new(codes::failure::TOOL_ERROR, error.to_string())).map_err(json_error)?,
+                            output: serde_json::to_value(Failure::new(
+                                codes::failure::TOOL_ERROR,
+                                error.to_string(),
+                            ))
+                            .map_err(json_error)?,
                             is_error: true,
                         },
                     };
                     let mut cursor = self.cursor.lock().await;
-                    let mut records = vec![AppendRecord::new(codes::event::TOOL_CALL_ENDED,
-                        serde_json::json!({"sequence": sequence, "result": result}))];
+                    let mut records = vec![AppendRecord::new(
+                        codes::event::TOOL_CALL_ENDED,
+                        serde_json::json!({"sequence": sequence, "result": result}),
+                    )];
                     if unreachable {
-                        records.push(AppendRecord::new(codes::event::ENVIRONMENT_UNREACHABLE,
-                            serde_json::json!({"environment": environment, "sequence": sequence})));
+                        records.push(AppendRecord::new(
+                            codes::event::ENVIRONMENT_UNREACHABLE,
+                            serde_json::json!({"environment": environment, "sequence": sequence}),
+                        ));
                     }
                     self.append(&mut cursor, records).await?;
                     Ok::<_, Error>((index, result, dropped))

--- a/crates/brain/tests/session.rs
+++ b/crates/brain/tests/session.rs
@@ -675,6 +675,12 @@ async fn invoke_outcomes_map_onto_tool_results() {
         (Outcome::Timeout, Some("timeout")),
         (Outcome::Cancelled, Some("cancelled")),
         (
+            Outcome::Unknown {
+                message: "result lost".into(),
+            },
+            Some("unknown"),
+        ),
+        (
             Outcome::Ok {
                 value: serde_json::json!({"content": "done"}),
             },
@@ -726,7 +732,7 @@ async fn invoke_outcomes_map_onto_tool_results() {
 }
 
 #[tokio::test]
-async fn an_overdue_invoke_is_cancelled_and_recorded_as_unknown() {
+async fn an_overdue_invoke_is_cancelled_and_recorded_as_timeout() {
     let data_dir = temporary_directory("tool-timeout");
     let tools = Arc::new(OutcomeTools {
         outcome: Outcome::Ok {
@@ -759,7 +765,8 @@ async fn an_overdue_invoke_is_cancelled_and_recorded_as_unknown() {
         .unwrap();
     assert!(started.elapsed() < Duration::from_secs(10));
     let results = seen.lock().unwrap().clone();
-    assert_eq!(results[0].output["code"], "unknown");
+    assert!(results[0].is_error);
+    assert_eq!(results[0].output["code"], "timeout");
     assert_eq!(
         tools.cancelled.lock().unwrap().len(),
         1,
@@ -813,7 +820,7 @@ async fn a_tool_in_a_host_env_uses_the_configured_executor() {
 }
 
 #[tokio::test]
-async fn an_unanswered_host_call_becomes_unknown_and_journals_the_cancellation() {
+async fn an_unanswered_host_call_times_out_and_journals_the_cancellation() {
     let data_dir = temporary_directory("host-timeout");
     let seen = Arc::new(Mutex::new(Vec::new()));
     let loop_executor = {
@@ -847,7 +854,8 @@ async fn an_unanswered_host_call_becomes_unknown_and_journals_the_cancellation()
         .await
         .unwrap();
     let results = seen.lock().unwrap().clone();
-    assert_eq!(results[0].output["code"], "unknown");
+    assert!(results[0].is_error);
+    assert_eq!(results[0].output["code"], "timeout");
     let kinds = runtime.kinds(handle.id());
     assert!(kinds.iter().any(|kind| kind == "tool_cancel_started"));
     assert_eq!(kinds.last().unwrap(), "turn_ended");

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -77,8 +77,11 @@ bound; see [Configuration](/docs/reference/configuration) for the rest:
 The wall deadline initiates cancellation. Brain records outstanding effect outcomes and waits for
 bounded executor cancellation before closing the turn; this cleanup can extend the response time.
 
-Cancellation requests stop local waiting and are forwarded to active executors. A remote effect
-that may have continued is reported as unknown, not as a successful cancellation.
+Cancellation requests stop local waiting and are forwarded to active executors. Outstanding Tool
+calls return `cancelled`; their own invocation deadlines return `timeout`. Neither promises that
+external effects were rolled back. `unknown` means dispatch may have happened but no reliable
+terminal result is available, such as a lost connection or an unfinished effect recovered after
+restart. These Tool results all have `is_error: true` and are never replayed automatically.
 
 ## Suspension and recovery
 

--- a/docs/concepts/tool.mdx
+++ b/docs/concepts/tool.mdx
@@ -85,6 +85,12 @@ Brain validates canonical input and output schemas for every placement. Brain re
 `ok`, `error`, `timeout`, `cancelled`, or `unknown` before the Agentloop sees the result, and never
 automatically retries a Tool call.
 
+The invocation deadline produces `timeout`, explicit cancellation produces `cancelled`, and a known
+failure produces `error` with its structured details. `unknown` is reserved for a possibly dispatched
+operation whose result cannot be established. All four are failed Tool results. Timeout and
+cancellation describe the stop cause and do not imply rollback. A host function may return an
+Outcome directly; see [Write a Tool](/brain/docs/guides/write-a-tool#return-values-and-outcomes).
+
 
 ## Placement and model presentation
 

--- a/docs/guides/write-a-tool.mdx
+++ b/docs/guides/write-a-tool.mdx
@@ -45,6 +45,19 @@ journal sequence of the call, the absolute deadline, the Tool, and the input. Th
 input, calls the registered function, validates configured output, and posts one outcome to the
 host result endpoint.
 
+### Return values and outcomes
+
+Return ordinary output for success, or return an `Outcome` directly. An error outcome preserves
+`error.code`, `error.message`, `error.retryable` and `error.details`. See the executable
+[Tool outcomes example](https://github.com/aexhq/brain/blob/main/examples/tool-outcomes.mjs).
+Thrown exceptions become `tool_error`.
+
+The top-level `status` values `ok`, `error`, `timeout`, `cancelled` and `unknown` are reserved for
+outcome envelopes. A malformed envelope becomes `invalid_output`. Successful-output validation
+applies to ordinary output or an explicit `ok.value`; non-success outcomes bypass it. If business
+data itself uses a reserved status, return it as the `value` of an explicit `ok` outcome. The SDK
+does not inspect that value for another outcome. Other status values remain ordinary data.
+
 ### Context
 
 The second `run` argument contains:
@@ -66,9 +79,13 @@ run: async (input, ctx) => {
 }
 ```
 
-Brain sends each invocation once and does not retry after disconnect. If deadline or cancellation
-wins after dispatch, the host returns an unknown outcome because the function may still finish.
-The SDK cancels local in-flight work and reconnects the same registered host for future commands;
+Brain sends each invocation once. Its deadline returns `timeout`; explicit SDK cancellation returns
+`cancelled`. Both are failed Tool results and describe why the caller stopped waiting, without
+promising rollback. The first terminal cause is retained even if the function later finishes.
+Connection loss after dispatch, without a reliable result, returns `unknown`. Known validation,
+execution and protocol failures return `error`.
+
+The SDK aborts local in-flight work and reconnects the same registered host for future commands;
 it never replays the disconnected command. Cooperative functions should observe `ctx.signal` and
 stop promptly.
 

--- a/docs/guides/write-an-environment.mdx
+++ b/docs/guides/write-an-environment.mdx
@@ -52,6 +52,12 @@ Execute requires a terminal `result`, `failure`, or `unknown` receipt. Returning
 and optional JSON `details` reach Tool results unchanged. Retryability is advisory; Brain does
 not retry or restore failed resources automatically.
 
+For Tool invocations, return a failure with code `timeout` when its deadline expires, or `cancelled`
+for explicit cancellation. Keep the first stop cause if cleanup also fails, including cleanup
+evidence in `details`. These codes do not promise rollback. Use `unknown` only when dispatch may
+have happened but no reliable result is available. An explicit unknown receipt does not itself
+mark the Environment unreachable; a transport failure still does.
+
 ## Invocation services
 
 An execution may receive `callback: { url, token, methods }`. POST `{ method, input }` to that

--- a/examples/tool-outcomes.mjs
+++ b/examples/tool-outcomes.mjs
@@ -1,0 +1,14 @@
+import { tool } from "@aexhq/brain";
+import { z } from "zod";
+
+const records = new Map([["1", { name: "Ada" }]]);
+export const lookupRecord = tool({
+  name: "lookup_record",
+  description: "Look up a record by id.",
+  input: z.object({ id: z.string() }),
+  output: z.object({ name: z.string() }),
+  run: ({ id }) => records.get(id) ?? {
+    status: "error",
+    error: { code: "not_found", message: "Record not found", retryable: false, details: { id } },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/packages/brain-sdk/README.md
+++ b/packages/brain-sdk/README.md
@@ -77,6 +77,16 @@ terminal outcome. `ctx.emit(kind, data)` appends an extension event to the sessi
 journal before its promise resolves. Save `await brain.credentials()` and pass it back as
 `credentials` to resume the host after a restart.
 
+Host functions may return ordinary successful output or an `Outcome` directly. The top-level
+statuses `ok`, `error`, `timeout`, `cancelled` and `unknown` declare outcomes; malformed envelopes
+fail as `invalid_output`. Only successful values pass through the output schema. Structured errors
+retain code, message, retryable and details. Use an explicit `ok.value` for business data that uses a
+reserved status. See [the tested example](../../examples/tool-outcomes.mjs).
+
+Tool deadlines produce `timeout`, explicit cancellation produces `cancelled`, and known failures
+produce `error`. `unknown` means an operation may have been dispatched but its result is unavailable.
+All non-success outcomes become failed Tool results. Cancellation and timeout do not promise rollback.
+
 The SDK admits Component bytes by content, preserves explicit placement, and supplies deterministic
 idempotency keys for admission. A caller may supply an `idempotencyKey` for other mutating
 requests. Repeating session creation with the same key keeps the existing host handlers, including

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/packages/brain-sdk/src/client-pump.ts
+++ b/packages/brain-sdk/src/client-pump.ts
@@ -77,7 +77,7 @@ export class HostPump {
         } catch (error) {
           if (!opened) throw error;
         }
-        this.cancelInFlight();
+        this.cancelInFlight("disconnect");
         if (!opened) throw new Error("host command stream closed before opening");
         if (!this.controller.signal.aborted) await new Promise((resolve) => setTimeout(resolve, 100));
       }
@@ -87,10 +87,12 @@ export class HostPump {
     }
   }
 
-  private cancelInFlight(): void {
+  private cancelInFlight(reason: "cancel" | "disconnect" = "cancel"): void {
     for (const [key, sequence] of this.inFlight) {
       const separator = key.lastIndexOf(":");
-      this.sessions.get(key.slice(0, separator))?.cancel(sequence);
+      const registry = this.sessions.get(key.slice(0, separator));
+      if (reason === "disconnect") registry?.disconnect(sequence);
+      else registry?.cancel(sequence);
     }
     this.inFlight.clear();
   }

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import type { HostToolCall, HostToolContract } from "./host.js";
 import type {
-  Component, Environment, PlacedAgentloop, PlacedTool, Schema, SchemaInput, SchemaOutput,
+  Component, Environment, Outcome, PlacedAgentloop, PlacedTool, Schema, SchemaInput, SchemaOutput,
   ToolDefinition,
 } from "./types.js";
 
@@ -169,6 +169,10 @@ export interface ToolRunContext<Options> extends HostToolCall {
   emit(kind: string, data: unknown): Promise<number>;
 }
 
+type ToolReturn<OutputSchema extends Schema | undefined> =
+  | (OutputSchema extends Schema ? SchemaInput<OutputSchema> : unknown)
+  | Outcome<OutputSchema extends Schema ? SchemaInput<OutputSchema> : unknown>;
+
 /** One Tool: what the model is told and either a
  * function this process runs or an implementation its Environment interprets. Where it
  * runs is decided at placement, `{ env }`. */
@@ -181,7 +185,7 @@ export interface ToolContract<OptionsSchema extends Schema | undefined, InputSch
   readonly run?: (
     input: SchemaOutput<InputSchema>,
     context: ToolRunContext<Options<OptionsSchema>>,
-  ) => (OutputSchema extends Schema ? SchemaInput<OutputSchema> : unknown) | Promise<OutputSchema extends Schema ? SchemaInput<OutputSchema> : unknown>;
+  ) => ToolReturn<OutputSchema> | Promise<ToolReturn<OutputSchema>>;
   readonly implementation?: Component | Readonly<Record<string, unknown>> | ((options: Options<OptionsSchema>) => unknown);
 }
 

--- a/packages/brain-sdk/src/host.ts
+++ b/packages/brain-sdk/src/host.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { Outcome, Schema } from "./types.js";
 
 /** The contract of one Tool this process holds: what the model sees, declared where
@@ -21,7 +22,7 @@ export interface HostToolCall {
   emit(kind: string, data: unknown): Promise<number>;
 }
 
-export type HostToolHandler<Input, Output> = (input: Input, call: HostToolCall) => Output | Promise<Output>;
+export type HostToolHandler<Input, Output> = (input: Input, call: HostToolCall) => Output | Outcome<Output> | Promise<Output | Outcome<Output>>;
 
 /** One invocation as the pump hands it to the registry. `deadline_ms` is the
  * remaining budget, not an epoch. */
@@ -47,12 +48,14 @@ interface RegisteredHostTool {
   readonly handler: HostToolHandler<unknown, unknown>;
 }
 
+type Interruption = Extract<Outcome, { status: "timeout" | "cancelled" | "unknown" }>;
+
 /** Shared execution semantics for the Tools this process holds, whoever answers the
  * session's feed: schema-checked input and output, a clamped deadline race, best-effort
  * cancellation, exactly one Outcome. Internal to the SDK's pump. */
 export class HostToolRegistry {
   private readonly tools = new Map<string, RegisteredHostTool>();
-  private readonly active = new Map<number, { readonly controller: AbortController; cancelled: boolean }>();
+  private readonly active = new Map<number, { readonly controller: AbortController; outcome?: Interruption }>();
 
   register(environment: string, contract: HostToolContract, handler: HostToolHandler<unknown, unknown>): void {
     if (typeof contract?.name !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(contract.name)) throw new TypeError("host tool name must be an identifier");
@@ -64,10 +67,18 @@ export class HostToolRegistry {
   }
 
   cancel(sequence: number): void {
+    this.interrupt(sequence, { status: "cancelled" });
+  }
+
+  disconnect(sequence: number): void {
+    this.interrupt(sequence, { status: "unknown", message: "host connection was lost after dispatch" });
+  }
+
+  private interrupt(sequence: number, outcome: Interruption): void {
     const call = this.active.get(sequence);
-    if (call === undefined) return;
-    call.cancelled = true;
-    call.controller.abort(new Error("call cancelled"));
+    if (call === undefined || call.outcome !== undefined) return;
+    call.outcome = outcome;
+    call.controller.abort(new Error(outcome.status === "unknown" ? outcome.message : "host Tool " + outcome.status));
   }
 
   async run(frame: InvokeFrame): Promise<Outcome> {
@@ -79,10 +90,10 @@ export class HostToolRegistry {
     } catch (error) {
       return errorOutcome("invalid_input", String(error instanceof Error ? error.message : error));
     }
-    const call = { controller: new AbortController(), cancelled: false };
+    const call: { controller: AbortController; outcome?: Interruption } = { controller: new AbortController() };
     this.active.set(frame.sequence, call);
     const deadlineMs = frame.deadline_ms > MAX_DEADLINE_MS ? MAX_DEADLINE_MS : frame.deadline_ms;
-    const timer = setTimeout(() => call.controller.abort(new Error("call deadline passed")), deadlineMs);
+    const timer = setTimeout(() => this.interrupt(frame.sequence, { status: "timeout" }), deadlineMs);
     const interrupted = new Promise<typeof interruption>((resolve) => call.controller.signal.addEventListener("abort", () => resolve(interruption), { once: true }));
     try {
       const value = await Promise.race([
@@ -94,15 +105,19 @@ export class HostToolRegistry {
         })),
         interrupted,
       ]);
-      if (value === interruption) return { status: "unknown", message: call.cancelled ? "host Tool was cancelled after dispatch" : "host Tool exceeded its deadline after dispatch" };
-      if (registered.contract.output === undefined) return { status: "ok", value: value ?? null };
+      if (call.outcome !== undefined) return call.outcome;
       try {
-        return { status: "ok", value: registered.contract.output.parse(value) ?? null };
+        const status = typeof value === "object" && value !== null && "status" in value ? value.status : undefined;
+        const outcome: Outcome = typeof status === "string" && ["ok", "error", "timeout", "cancelled", "unknown"].includes(status)
+          ? outcomeSchema.parse(value)
+          : { status: "ok", value: value ?? null };
+        if (outcome.status !== "ok" || registered.contract.output === undefined) return outcome;
+        return { status: "ok", value: registered.contract.output.parse(outcome.value) ?? null };
       } catch (error) {
         return errorOutcome("invalid_output", String(error instanceof Error ? error.message : error));
       }
     } catch (error) {
-      if (call.controller.signal.aborted) return { status: "unknown", message: call.cancelled ? "host Tool was cancelled after dispatch" : "host Tool exceeded its deadline after dispatch" };
+      if (call.outcome !== undefined) return call.outcome;
       return errorOutcome("tool_error", String(error instanceof Error ? error.message : error));
     } finally {
       clearTimeout(timer);
@@ -112,3 +127,16 @@ export class HostToolRegistry {
 }
 
 const interruption = Symbol("call interrupted");
+
+const outcomeSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("ok"), value: z.json() }),
+  z.object({ status: z.literal("error"), error: z.strictObject({
+    code: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u),
+    message: z.string().max(4096),
+    retryable: z.boolean().optional(),
+    details: z.json().optional(),
+  }) }),
+  z.object({ status: z.literal("timeout") }),
+  z.object({ status: z.literal("cancelled") }),
+  z.object({ status: z.literal("unknown"), message: z.string() }),
+]);

--- a/packages/brain-sdk/src/types.ts
+++ b/packages/brain-sdk/src/types.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import type { EventOrigin } from "./generated/session.js";
+import type { EventOrigin, Outcome as WireOutcome } from "./generated/session.js";
 
 declare const componentBrand: unique symbol;
 declare const agentloopBrand: unique symbol;
@@ -31,10 +31,7 @@ export interface ToolDefinition {
 
 export type Outcome<Value = unknown> =
   | { readonly status: "ok"; readonly value: Value }
-  | { readonly status: "error"; readonly error: { readonly code: string; readonly message: string; readonly details?: unknown } }
-  | { readonly status: "timeout" }
-  | { readonly status: "cancelled" }
-  | { readonly status: "unknown"; readonly message: string };
+  | Exclude<WireOutcome, { status: "ok" }>;
 
 export type { KnownProviderId } from "./generated/providers.js";
 import type { KnownProviderId } from "./generated/providers.js";

--- a/packages/brain-sdk/test/client-tools.test.mjs
+++ b/packages/brain-sdk/test/client-tools.test.mjs
@@ -182,6 +182,34 @@ test("a host reconnects without replaying old commands", async () => {
   await pump.closed;
 });
 
+test("losing the command stream reports an in-flight call as unknown without replay", async () => {
+  let calls = 0;
+  let finish;
+  const finished = new Promise(resolve => { finish = resolve; });
+  const pump = new HostPump({
+    stream: async function* (_signal, onOpen) {
+      onOpen();
+      yield { type: "command", data: {
+        session_id: sessionId, environment: "app", sequence: 9,
+        deadline_at_ms: Date.now() + 5_000,
+        operation: { type: "invoke_tool", name: "lookup", input: {} },
+      } };
+    },
+    result: async result => { finish(result); pump.stop(); },
+    emit: async () => ({ sequence: 10 }),
+  });
+  const registry = new HostToolRegistry();
+  registry.register("app", { name: "lookup", description: "Lookup.", input: z.object({}) }, () => {
+    calls += 1;
+    return new Promise(() => {});
+  });
+  pump.register(sessionId, registry);
+  await pump.start();
+  assert.equal((await finished).outcome.status, "unknown");
+  await pump.closed;
+  assert.equal(calls, 1);
+});
+
 test("a new session reconnects the durable host after its previous stream stopped", async () => {
   let hosts = 0;
   let sessions = 0;

--- a/packages/brain-sdk/test/host-outcomes.test.mjs
+++ b/packages/brain-sdk/test/host-outcomes.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { z } from "zod";
+import { HostToolRegistry } from "../dist/host.js";
+
+const frame = { environment: "app", sequence: 1, name: "test", arguments: {}, deadline_ms: 5_000, emit: async () => 2 };
+function registry(handler, output) {
+  const tools = new HostToolRegistry();
+  tools.register("app", { name: "test", description: "Test outcomes.", input: z.object({}), output }, handler);
+  return tools;
+}
+
+test("ordinary values and successful Outcomes share output parsing", async () => {
+  const output = z.object({ count: z.string().transform(Number) });
+  for (const value of [{ count: "3" }, { status: "ok", value: { count: "3" } }]) {
+    assert.deepEqual(await registry(() => value, output).run(frame), { status: "ok", value: { count: 3 } });
+  }
+  assert.deepEqual(await registry(() => undefined).run(frame), { status: "ok", value: null });
+  assert.deepEqual(await registry(() => ({ status: "pending" })).run(frame), { status: "ok", value: { status: "pending" } });
+  assert.deepEqual(await registry(() => ({ status: "ok", value: { status: "unknown" } })).run(frame), { status: "ok", value: { status: "unknown" } });
+});
+
+test("non-success Outcomes preserve structured errors and bypass the success schema", async () => {
+  for (const outcome of [
+    { status: "error", error: { code: "rate_limited", message: "Try later", retryable: true, details: { retry_after_ms: 1000 } } },
+    { status: "timeout" },
+    { status: "cancelled" },
+    { status: "unknown", message: "Connection closed after the mutation" },
+  ]) {
+    assert.deepEqual(await registry(() => outcome, z.string()).run(frame), outcome);
+  }
+});
+
+test("malformed reserved Outcomes fail output validation instead of becoming successful data", async () => {
+  for (const value of [
+    { status: "ok" }, { status: "unknown" }, { status: "error", error: "denied" },
+    { status: "error", error: { code: "bad code", message: "denied" } },
+    { status: "error", error: { code: "denied", message: "denied", retryable: "yes" } },
+    { status: "error", error: { code: "denied", message: "denied", details: { value: 1n } } },
+  ]) {
+    const outcome = await registry(() => value).run(frame);
+    assert.equal(outcome.status, "error");
+    assert.equal(outcome.error.code, "invalid_output");
+  }
+  assert.equal((await registry(() => ({ status: "ok", value: 3 }), z.string()).run(frame)).error.code, "invalid_output");
+  assert.equal((await registry(() => { throw new Error("known exception"); }).run(frame)).error.code, "tool_error");
+});
+
+test("deadline, explicit cancellation and disconnect retain the first cause despite late rejection", async () => {
+  for (const cause of ["timeout", "cancelled", "unknown"]) {
+    let signal;
+    let reject;
+    const tools = registry((_, call) => {
+      signal = call.signal;
+      return new Promise((_, fail) => { reject = fail; });
+    });
+    const running = tools.run({ ...frame, deadline_ms: cause === "timeout" ? 5 : 5_000 });
+    if (cause === "cancelled") { tools.cancel(1); tools.disconnect(1); }
+    if (cause === "unknown") { tools.disconnect(1); tools.cancel(1); }
+    const outcome = await running;
+    assert.equal(outcome.status, cause);
+    assert.equal(signal.aborted, true);
+    reject(new Error("late cleanup failure"));
+    tools.cancel(1);
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(outcome.status, cause);
+  }
+});

--- a/packages/brain-sdk/test/types/tool-outcomes.ts
+++ b/packages/brain-sdk/test/types/tool-outcomes.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+import { tool, type Outcome } from "../../dist/index.js";
+
+const failure: Outcome<number> = {
+  status: "error", error: { code: "denied", message: "Denied", retryable: false, details: { scope: "write" } },
+};
+tool({ name: "raw", description: "Raw", input: z.object({}), output: z.number(), run: () => 1 });
+tool({ name: "known", description: "Known", input: z.object({}), output: z.number(), run: () => failure });
+tool({ name: "unknown", description: "Unknown", input: z.object({}), output: z.number(), run: async () => ({ status: "unknown", message: "Connection lost" }) });
+tool({ name: "success", description: "Success", input: z.object({}), output: z.string().transform(Number), run: () => ({ status: "ok", value: "1" }) });
+// @ts-expect-error A successful Outcome must match the output schema's input.
+tool({ name: "wrong", description: "Wrong", input: z.object({}), output: z.number(), run: () => ({ status: "ok", value: "1" }) });

--- a/references/adrs/2026-09-05-05-interruption.md
+++ b/references/adrs/2026-09-05-05-interruption.md
@@ -4,6 +4,9 @@
 - Status: Accepted
 - Compiled: 2026-09-05
 
+Tool stop causes clarified by [ADR-047](2026-09-12-01-tool-outcomes.md): invocation deadlines and
+explicit cancellation have known terminal causes; missing results after dispatch remain unknown.
+
 Amended by: [ADR-040: Identify records by session and sequence, and everything inside a session by name](2026-09-05-09-session-names.md) and [ADR-041: Run every Tool in an Environment that implements one protocol, including Brain's own](2026-09-05-10-one-execution-model.md): model credentials are sealed under the session id rather than a binding identity, and host token hashes belong to the host env.
 
 ## Context

--- a/references/adrs/2026-09-12-01-tool-outcomes.md
+++ b/references/adrs/2026-09-12-01-tool-outcomes.md
@@ -1,0 +1,40 @@
+# ADR-047: Preserve known Tool stop causes and accept host outcomes directly
+
+- Decision date: 2026-09-12
+- Status: Accepted
+
+## Context
+
+Host functions could only return successful values or throw an unstructured exception. Returning
+an existing Outcome was wrapped as success, so adapters could not preserve structured failures or
+report a lost remote result. Several deadline and cancellation paths also returned unknown despite
+knowing why the invocation stopped.
+
+## Decision
+
+Tool invocation deadlines produce `timeout`, explicit cancellation produces `cancelled`, and known
+failures produce `error`. Unknown is the last resort for a possibly dispatched effect with no reliable
+terminal result. A caught transport exception does not prove whether the remote effect completed.
+Timeout and cancellation describe the caller's stop cause and do not promise rollback. Preserve the
+first terminal cause and existing bounded cleanup. Every non-success outcome is a failed Tool result.
+
+Host functions return ordinary output or an existing Outcome directly. Reserve the top-level status
+discriminators `ok`, `error`, `timeout`, `cancelled` and `unknown`; validate their envelope before
+posting. Only successful values undergo output-schema validation. Preserve structured error fields.
+An explicit success envelope can carry business data that uses a reserved status; do not recursively
+interpret its value. Derive non-success SDK types from the generated protocol types.
+
+An explicit Environment unknown receipt is an Outcome, not evidence that the Environment is
+unreachable. Actual transport ambiguity retains the unreachable journal event. Environment timeout
+and cancellation use existing failure receipt codes. No wire shape or transcript status is added.
+
+## Consequences
+
+Host adapters need no result helper, symbol brand or separate authoring mode. Applications returning
+business data with a reserved status must put it in an explicit success value. Ordinary thrown
+exceptions remain `tool_error`; adapters return structured Outcomes when they have more information.
+
+The [send-once decision](2026-09-05-04-send-once.md) still applies. This clarifies Tool stop causes
+without changing [recovery of uncertain effects](2026-09-05-05-interruption.md), model-call outcomes,
+or whole-turn results. User-facing behavior and examples live in
+[Write a Tool](../../docs/guides/write-a-tool.mdx).

--- a/references/adrs/README.md
+++ b/references/adrs/README.md
@@ -43,6 +43,7 @@ remain in [the contracts](../../contracts), [user docs](../../docs), and
 - [ADR-044: Separate session management from the built-in execution Environment](2026-09-06-03-sessions-and-brain-env.md)
 
 - [ADR-046: Keep dependency preparation in Environments and give Agentloop KV one API](2026-09-09-01-minimal-extension-contract.md)
+- [ADR-047: Preserve known Tool stop causes and accept host outcomes directly](2026-09-12-01-tool-outcomes.md)
 
 ## Chronological index
 
@@ -94,6 +95,7 @@ remain in [the contracts](../../contracts), [user docs](../../docs), and
 | 2026-09-06 | [ADR-044: Separate session management from the built-in execution Environment](2026-09-06-03-sessions-and-brain-env.md) | Accepted |
 | 2026-09-07 | [ADR-045: Resolve protocol gaps before stable v1](2026-09-07-01-protocol-freeze.md) | Accepted |
 | 2026-09-09 | [ADR-046: Keep dependency preparation in Environments and give Agentloop KV one API](2026-09-09-01-minimal-extension-contract.md) | Accepted |
+| 2026-09-12 | [ADR-047: Preserve known Tool stop causes and accept host outcomes directly](2026-09-12-01-tool-outcomes.md) | Accepted |
 
 ## Important reversals
 

--- a/tests/journeys/host.test.mjs
+++ b/tests/journeys/host.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 import { z } from "zod";
 import { hostEnv, tool, inspectTool } from "@aexhq/brain";
 import { fixture, collect, callTools, reply, deferred, failure } from "./support.mjs";
+import { lookupRecord } from "../../examples/tool-outcomes.mjs";
 
 const f = fixture();
 
@@ -34,6 +35,38 @@ test("cancelling a parent reaches an owned child turn through the host Tool sign
 const app = hostEnv({ name: "app" });
 const dispatch = (name, input) => (request, response) => request.messages.at(-1).role === "tool"
   ? reply(response) : callTools(response, [{ name, input }]);
+
+test("the Tool outcome example returns structured failure despite its successful output schema", { timeout: 30_000 }, async t => {
+  const session = await f.create(t, { tools: [lookupRecord({ env: app })] });
+  f.model = dispatch("lookup_record", { id: "missing" });
+  await session.send("find the missing record");
+  const events = await collect(session.events());
+  const result = events.find(event => event.type === "tool_call_ended").data.result;
+  assert.equal(result.is_error, true);
+  assert.deepEqual(result.output, { code: "not_found", message: "Record not found", retryable: false, details: { id: "missing" } });
+  assert.deepEqual(JSON.parse(f.modelRequests.at(-1).messages.at(-1).content), result.output);
+  f.model = dispatch("lookup_record", { id: "1" });
+  await session.send("find Ada");
+  assert.match(f.modelRequests.at(-1).messages.at(-1).content, /Ada/u);
+});
+
+for (const outcome of [{ status: "timeout" }, { status: "cancelled" }, { status: "unknown", message: "Remote result lost" }]) {
+  test(`a direct host ${outcome.status} reaches the journal and model as one failed result`, { timeout: 30_000 }, async t => {
+    let calls = 0;
+    const remote = tool({ name: "remote", description: "Read a remote result", input: z.object({}), output: z.string(), run: () => { calls++; return outcome; } });
+    const session = await f.create(t, { tools: [remote({ env: app })] });
+    f.model = dispatch("remote", {});
+    await session.send("read once");
+    const events = await collect(session.events());
+    const ended = events.filter(event => event.type === "tool_call_ended");
+    assert.equal(ended.length, 1);
+    assert.equal(ended[0].data.result.is_error, true);
+    assert.equal(ended[0].data.result.output.code, outcome.status);
+    assert.equal(events.some(event => event.type === "environment_unreachable"), false);
+    assert.equal(calls, 1);
+    assert.match(f.modelRequests.at(-1).messages.at(-1).content, new RegExp(outcome.status));
+  });
+}
 
 test("graceful shutdown lets a host Tool finish and saves the completed turn", { timeout: 30_000 }, async (t) => {
   const entered = deferred();
@@ -155,7 +188,11 @@ test("cancellation reaches the tool's signal and does not execute the tool twice
   await cancelled.promise;
   await pending;
   assert.equal(calls, 1);
-  assert.ok((await collect(session.events())).some(({ type }) => type === "turn_failed"));
+  const events = await collect(session.events());
+  assert.ok(events.some(({ type }) => type === "turn_failed"));
+  const result = events.find(event => event.type === "tool_call_ended").data.result;
+  assert.equal(result.is_error, true);
+  assert.equal(result.output.code, "cancelled");
 });
 
 test("one host serves tools for two sessions concurrently", { timeout: 30_000 }, async (t) => {

--- a/tests/journeys/host.test.mjs
+++ b/tests/journeys/host.test.mjs
@@ -44,7 +44,7 @@ test("the Tool outcome example returns structured failure despite its successful
   const result = events.find(event => event.type === "tool_call_ended").data.result;
   assert.equal(result.is_error, true);
   assert.deepEqual(result.output, { code: "not_found", message: "Record not found", retryable: false, details: { id: "missing" } });
-  assert.deepEqual(JSON.parse(f.modelRequests.at(-1).messages.at(-1).content), result.output);
+  assert.equal(f.modelRequests.at(-1).messages.at(-1).content, `ERROR: ${JSON.stringify(result.output)}`);
   f.model = dispatch("lookup_record", { id: "1" });
   await session.send("find Ada");
   assert.match(f.modelRequests.at(-1).messages.at(-1).content, /Ada/u);


### PR DESCRIPTION
Host Tools can now return existing Outcome envelopes directly, preserving structured errors and unknown results instead of wrapping them as success. Tool deadlines report timeout, explicit cancellation reports cancelled, and connection loss after dispatch remains unknown. An explicit unknown Environment receipt no longer marks the Environment unreachable.

Reserved top-level outcome statuses are validated; only successful values pass through the output schema. SDK types reuse generated non-success variants, including retryable. The SDK is versioned 0.22.0, with updated authoring docs, a tested example and ADR-047.

Validation: SDK runtime/type tests and packed consumer smoke pass; focused Rust session, host and Environment tests pass; contract regeneration has no diff. Full Linux checks and all existing CI gates are required before release. Added public SDK journeys cover terminal outcomes, structured details and cancellation without replay.
