### PR TITLE
sdk: own client transport lifetime and accept defaulted tool inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,17 +118,21 @@ const lookupOrder = tool({
 });
 
 const brain = new Brain({ baseUrl: "http://127.0.0.1:8080", token: "quickstart" });
-const session = await brain.sessions.create({
-  model: { provider: "openai", name: "gpt-5-mini", apiKey: process.env.OPENAI_API_KEY },
-  agentloop: pi({ env: brainEnv({ name: "brain" }) }),
-  tools: [lookupOrder({ env: hostEnv({ name: "app" }) })],
-});
+try {
+  const session = await brain.sessions.create({
+    model: { provider: "openai", name: "gpt-5-mini", apiKey: process.env.OPENAI_API_KEY },
+    agentloop: pi({ env: brainEnv({ name: "brain" }) }),
+    tools: [lookupOrder({ env: hostEnv({ name: "app" }) })],
+  });
 
-await session.send("Where is order A-1001?");
-for await (const event of session.events()) console.log(event.sequence, event.type);
+  await session.send("Where is order A-1001?");
+  for await (const event of session.events()) console.log(event.sequence, event.type);
 
-await session.end();
-await session.delete();
+  await session.end();
+  await session.delete();
+} finally {
+  await brain.close();
+}
 ```
 
 ## Performance

--- a/docs/concepts/sessions.mdx
+++ b/docs/concepts/sessions.mdx
@@ -154,13 +154,23 @@ exposes the payload as `event.data` and provenance as `event.origin` on both pag
 
 ## Lifecycle
 
-`cancel` requests cancellation of work in flight. `end` refuses new messages and detaches the
+`session.interrupt()` requests cancellation of work in flight and keeps the session available
+for another turn. The HTTP operation remains `POST /v1/sessions/{id}/cancel`.
+`end` refuses new messages and detaches the
 session's Environments while preserving history. `delete` removes the session directory, tears
-down its Environments, and forgets its credentials.
+down its Environments, and forgets its credentials; the session must first be ended or failed.
+
+`await brain.close()` releases the client's connections and local handlers. It is idempotent,
+rejects subsequent client operations, and does not interrupt, end or delete stored sessions.
+The client retains its shared host connection until close, including after failed creation or
+ending its last session. Put creation inside `try` and close the client in `finally`, as in the
+[lifecycle example](https://github.com/aexhq/brain/blob/main/examples/session-lifecycle.mjs).
+Handlers should observe their cancellation signal; close does not wait for application code
+that ignores it. A client created by `withToken` has its own lifetime.
 
 `end` waits for active work. SIGTERM/server shutdown stops admitting work and drains admitted
 operations while their callbacks remain available, then closes subscriptions and workers. Deadlines,
-`cancel`, and forced process termination can still interrupt a turn and expose partial progress.
+`interrupt`, and forced process termination can still interrupt a turn and expose partial progress.
 
 An owning host Tool can pass its signal to `child.send(input, { signal: context.signal })`.
 Use a fresh handle for an exclusively owned child; do not concurrently send through other owners.

--- a/docs/guides/write-a-tool.mdx
+++ b/docs/guides/write-a-tool.mdx
@@ -34,11 +34,18 @@ The function stays in this process and may close over application state; the hos
 nothing around it, so the application owns its isolation and ambient authority. The factory parses
 and freezes options. With no options schema, place it as `lookup({ env: app })`.
 
+Tool input JSON Schema describes what Zod accepts before parsing (`io: "input"`): defaulted
+arguments are optional, and the handler receives their parsed defaults and transforms.
+An ordinary `z.object` accepts and strips extra properties; `z.strictObject` rejects them.
+Output schemas describe parsed output. Unrepresentable schemas fail when declaring the Tool.
+
 ### The host
 
 The first session with a Tool in `hostEnv` makes the SDK register this process as a host. It
 authenticates with a scoped host token and keeps `GET /v1/hosts/{host_id}/commands` open as SSE.
-Several sessions and Tools in the same `Brain` client share that connection.
+Several sessions and Tools in the same `Brain` client share that connection until
+`await brain.close()`. Ending or deleting a session releases its handlers. Put session creation
+inside `try` and close the client in `finally`, including when creation fails.
 
 Brain commits the Tool intent before publishing a command. The command names the session, the
 journal sequence of the call, the absolute deadline, the Tool, and the input. The SDK validates
@@ -92,7 +99,9 @@ stop promptly.
 
 ### Reattaching after restart
 
-Save `await brain.credentials()` in application credential storage. After restarting the
+Save `await brain.credentials()` in application credential storage. This registers the host if
+needed and returns `{ hostId, token }`, the identity for host commands rather than a provider or
+Aex API key. Close the old client before replacing its connection. After restarting the
 application, pass those credentials as `credentials` to `new Brain(...)`, then call
 `brain.sessions.get(sessionId, { tools: [lookup({ env: app })] })` with the session's `run` Tools.
 The supplied Tools must be exactly those the session placed in this host. Without `tools`, `get`

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -55,27 +55,30 @@ const brain = new Brain({
   baseUrl: "http://127.0.0.1:8080",
   token: "quickstart",
 });
-const session = await brain.sessions.create({
-  model: {
-    provider: "openai",
-    name: "gpt-5-mini",
-    apiKey: process.env.OPENAI_API_KEY,
-  },
-  agentloop: pi({ env: brainEnv({ name: "brain" }) }),
-  tools: [lookupOrder({ env: hostEnv({ name: "app" }) })],
-});
+try {
+  const session = await brain.sessions.create({
+    model: {
+      provider: "openai",
+      name: "gpt-5-mini",
+      apiKey: process.env.OPENAI_API_KEY,
+    },
+    agentloop: pi({ env: brainEnv({ name: "brain" }) }),
+    tools: [lookupOrder({ env: hostEnv({ name: "app" }) })],
+  });
 
-await session.send("Where is order A-1001?");
-for await (const event of session.events()) {
-  console.log(event.sequence, event.type, event.data);
+  await session.send("Where is order A-1001?");
+  for await (const event of session.events()) {
+    console.log(event.sequence, event.type, event.data);
+  }
+
+  await session.end();
+  await session.delete();
+} finally {
+  await brain.close();
 }
-
-await session.end();
-await session.delete();
-process.exit(0);
 ```
 
-The SDK registers this process as a host and keeps its command connection open. Brain commits
+The SDK registers this process as a host and keeps its command connection open until `brain.close()`. Brain commits
 `tool_call_started` before sending the command. `ctx.emit` appends an extension event to the same
 journal before its promise resolves, and the Tool result is committed before the Agentloop receives
 it. Brain sends each effect once; it does not retry a Tool when the outcome is uncertain.

--- a/examples/basic-session.mjs
+++ b/examples/basic-session.mjs
@@ -11,23 +11,27 @@ const brain = new Brain({
   ...(process.env.BRAIN_API_TOKEN ? { token: process.env.BRAIN_API_TOKEN } : {}),
 });
 
-const session = await brain.sessions.create({
-  model: {
-    provider: "vercel-ai-gateway",
-    name: process.env.BRAIN_MODEL ?? "openai/gpt-5-mini",
-    apiKey,
-  },
-  agentloop: example({ env: brainEnv({ name: "brain" }) }),
-  system: "Answer briefly and directly.",
-});
-
 try {
-  await session.send("Explain what an ephemeral execution runtime does in one sentence.");
+  const session = await brain.sessions.create({
+    model: {
+      provider: "vercel-ai-gateway",
+      name: process.env.BRAIN_MODEL ?? "openai/gpt-5-mini",
+      apiKey,
+    },
+    agentloop: example({ env: brainEnv({ name: "brain" }) }),
+    system: "Answer briefly and directly.",
+  });
 
-  for await (const event of session.events()) {
-    console.log(event.sequence, event.type, inspect(event.data, { depth: null }));
+  try {
+    await session.send("Explain what an ephemeral execution runtime does in one sentence.");
+
+    for await (const event of session.events()) {
+      console.log(event.sequence, event.type, inspect(event.data, { depth: null }));
+    }
+  } finally {
+    await session.end();
+    await session.delete();
   }
 } finally {
-  await session.end();
-  await session.delete();
+  await brain.close();
 }

--- a/examples/event-history.mjs
+++ b/examples/event-history.mjs
@@ -9,31 +9,35 @@ const brain = new Brain({
   ...(process.env.BRAIN_API_TOKEN ? { token: process.env.BRAIN_API_TOKEN } : {}),
 });
 
-const session = await brain.sessions.create({
-  model: {
-    provider: "vercel-ai-gateway",
-    name: process.env.BRAIN_MODEL ?? "openai/gpt-5-mini",
-    apiKey,
-  },
-  agentloop: example({ env: brainEnv({ name: "brain" }) }),
-});
-
 try {
-  await session.send("Reply with FIRST.");
-  await session.send("Reply with SECOND.");
+  const session = await brain.sessions.create({
+    model: {
+      provider: "vercel-ai-gateway",
+      name: process.env.BRAIN_MODEL ?? "openai/gpt-5-mini",
+      apiKey,
+    },
+    agentloop: example({ env: brainEnv({ name: "brain" }) }),
+  });
 
-  const complete = [];
-  for await (const event of session.events()) complete.push(event);
-  const firstTurn = complete.find((event) => event.type === "turn_ended");
-  if (!firstTurn) throw new Error("the first turn did not finish");
+  try {
+    await session.send("Reply with FIRST.");
+    await session.send("Reply with SECOND.");
 
-  console.log(`Public Events through sequence ${complete.at(-1)?.sequence ?? 0}`);
-  console.log(`Events after the first turn (${firstTurn.sequence}):`);
+    const complete = [];
+    for await (const event of session.events()) complete.push(event);
+    const firstTurn = complete.find((event) => event.type === "turn_ended");
+    if (!firstTurn) throw new Error("the first turn did not finish");
 
-  for await (const event of session.events(firstTurn.sequence)) {
-    console.log(event.sequence, event.type);
+    console.log(`Public Events through sequence ${complete.at(-1)?.sequence ?? 0}`);
+    console.log(`Events after the first turn (${firstTurn.sequence}):`);
+
+    for await (const event of session.events(firstTurn.sequence)) {
+      console.log(event.sequence, event.type);
+    }
+  } finally {
+    await session.end();
+    await session.delete();
   }
 } finally {
-  await session.end();
-  await session.delete();
+  await brain.close();
 }

--- a/examples/session-lifecycle.mjs
+++ b/examples/session-lifecycle.mjs
@@ -9,23 +9,27 @@ const brain = new Brain({
   ...(process.env.BRAIN_API_TOKEN ? { token: process.env.BRAIN_API_TOKEN } : {}),
 });
 
-const created = await brain.sessions.create({
-  model: {
-    provider: "vercel-ai-gateway",
-    name: process.env.BRAIN_MODEL ?? "openai/gpt-5-mini",
-    apiKey,
-  },
-  agentloop: example({ env: brainEnv({ name: "brain" }) }),
-});
+try {
+  const created = await brain.sessions.create({
+    model: {
+      provider: "vercel-ai-gateway",
+      name: process.env.BRAIN_MODEL ?? "openai/gpt-5-mini",
+      apiKey,
+    },
+    agentloop: example({ env: brainEnv({ name: "brain" }) }),
+  });
 
-console.log("created", created.state);
-console.log("listed", (await brain.sessions.list()).map(({ id, status }) => ({ id, status })));
+  console.log("created", created.state);
+  console.log("listed", (await brain.sessions.list()).map(({ id, status }) => ({ id, status })));
 
-const session = await brain.sessions.get(created.id);
-console.log("reopened", session.state);
+  const session = await brain.sessions.get(created.id);
+  console.log("reopened", session.state);
 
-await session.cancel();
-console.log("ended", await session.end());
-await session.delete();
+  await session.interrupt();
+  console.log("ended", await session.end());
+  await session.delete();
 
-console.log("remaining", await brain.sessions.list());
+  console.log("remaining", await brain.sessions.list());
+} finally {
+  await brain.close();
+}

--- a/examples/structured-output.mjs
+++ b/examples/structured-output.mjs
@@ -8,19 +8,23 @@ const brain = new Brain({
   baseUrl: process.env.BRAIN_BASE_URL ?? "http://127.0.0.1:8080",
   token: process.env.BRAIN_API_TOKEN,
 });
-const session = await brain.sessions.create({
-  model: { provider: "vercel-ai-gateway", name: process.env.BRAIN_MODEL ?? "openai/gpt-4.1-mini", apiKey },
-  agentloop: example({ env: brainEnv({ name: "brain" }) }),
-});
 try {
-  const person = await session.send("Ada is 37 years old. Extract her details.", {
-    output: {
-      type: z.object({ name: z.string(), age: z.number() }),
-      maxRetries: 2,
-    },
+  const session = await brain.sessions.create({
+    model: { provider: "vercel-ai-gateway", name: process.env.BRAIN_MODEL ?? "openai/gpt-4.1-mini", apiKey },
+    agentloop: example({ env: brainEnv({ name: "brain" }) }),
   });
-  console.log(person);
+  try {
+    const person = await session.send("Ada is 37 years old. Extract her details.", {
+      output: {
+        type: z.object({ name: z.string(), age: z.number() }),
+        maxRetries: 2,
+      },
+    });
+    console.log(person);
+  } finally {
+    await session.end();
+    await session.delete();
+  }
 } finally {
-  await session.end();
-  await session.delete();
+  await brain.close();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/packages/brain-sdk/README.md
+++ b/packages/brain-sdk/README.md
@@ -18,18 +18,22 @@ const lookup = tool({
 });
 
 const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });
-const session = await brain.sessions.create({
-  model: {
-    provider: "vercel-ai-gateway",
-    name: "openai/gpt-5-mini",
-    apiKey: process.env.VERCEL_AI_GATEWAY_API_KEY!,
-  },
-  agentloop: pi({ env: brainEnv({ name: "brain" }) }),
-  tools: [lookup({ env: hostEnv({ name: "app" }) })],
-});
+try {
+  const session = await brain.sessions.create({
+    model: {
+      provider: "vercel-ai-gateway",
+      name: "openai/gpt-5-mini",
+      apiKey: process.env.VERCEL_AI_GATEWAY_API_KEY!,
+    },
+    agentloop: pi({ env: brainEnv({ name: "brain" }) }),
+    tools: [lookup({ env: hostEnv({ name: "app" }) })],
+  });
 
-await session.send("Look up item 42.");
-for await (const event of session.events()) console.log(event);
+  await session.send("Look up item 42.");
+  for await (const event of session.events()) console.log(event);
+} finally {
+  await brain.close();
+}
 ```
 
 Every Tool and Agentloop is placed in a named Environment with `{ env, ...options }`. Three kinds
@@ -77,6 +81,18 @@ terminal outcome. `ctx.emit(kind, data)` appends an extension event to the sessi
 journal before its promise resolves. Save `await brain.credentials()` and pass it back as
 `credentials` to resume the host after a restart.
 
+The host connection belongs to the client and stays open until `await brain.close()`, including
+after failed creation or ending the last session. Put creation inside `try` and close in `finally`.
+Close is idempotent, aborts client I/O and local handlers, and rejects subsequent operations.
+It leaves stored sessions available. Use `session.interrupt()` to stop the current turn,
+`session.end()` to finish a session while keeping history, and `session.delete()` to remove an
+ended or failed session. See the [lifecycle example](../../examples/session-lifecycle.mjs).
+Clients returned by `withToken` have independent lifetimes.
+
+Tool input schemas use Zod's input semantics: defaulted arguments are optional, and handlers
+receive parsed defaults and transforms. Ordinary objects strip extra properties; strict objects
+reject them. Output schemas continue to describe parsed output.
+
 Host functions may return ordinary successful output or an `Outcome` directly. The top-level
 statuses `ok`, `error`, `timeout`, `cancelled` and `unknown` declare outcomes; malformed envelopes
 fail as `invalid_output`. Only successful values pass through the output schema. Structured errors
@@ -117,7 +133,14 @@ at `@aexhq/brain/contracts/agentloop.wit` and `@aexhq/brain/contracts/tool.wit`.
 history during an activation, and `emit` appends extension Events. Model, Tool, and Environment
 failures are never retried by Brain.
 
-## Upgrading to 0.20
+## Upgrading to 0.24
+
+Replace SDK `session.cancel()` with `session.interrupt()` and close each client when finished.
+The HTTP cancellation route and stored session format are unchanged. Host streams now remain
+open for the client lifetime. `register()` and `credentials()` retain their existing roles;
+saved host credentials are separate from provider and API credentials.
+
+## Upgrading from 0.19
 
 Upgrade the server and SDK together and rebuild Agentloop Components against the packaged WIT.
 Replace `set_kv` with `kv_put`; bindings expose `kv.read/put/delete`. Remove `needs` from

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/packages/brain-sdk/src/client-pump.ts
+++ b/packages/brain-sdk/src/client-pump.ts
@@ -25,12 +25,13 @@ export class HostPump {
   }
 
   register(sessionId: string, registry: HostToolRegistry): void {
+    this.controller.signal.throwIfAborted();
     // Replayed creation must retain the registry that owns any in-flight calls.
     if (this.sessions.has(sessionId)) return;
     this.sessions.set(sessionId, registry);
   }
 
-  unregister(sessionId: string): boolean {
+  unregister(sessionId: string): void {
     const registry = this.sessions.get(sessionId);
     if (registry !== undefined) {
       for (const [key, sequence] of this.inFlight) {
@@ -38,8 +39,6 @@ export class HostPump {
       }
       this.sessions.delete(sessionId);
     }
-    if (this.sessions.size === 0) this.stop();
-    return this.sessions.size === 0;
   }
 
   start(): Promise<void> {
@@ -61,6 +60,7 @@ export class HostPump {
   stop(): void {
     this.controller.abort();
     this.cancelInFlight();
+    this.sessions.clear();
   }
 
   private async run(onOpen: () => void): Promise<void> {

--- a/packages/brain-sdk/src/client.ts
+++ b/packages/brain-sdk/src/client.ts
@@ -39,8 +39,13 @@ export class BrainClient {
   private readonly transport: typeof globalThis.fetch;
   private readonly agentloops = new WeakMap<object, Promise<string>>();
   private readonly tools = new WeakMap<object, Promise<string>>();
+  private readonly controller = new AbortController();
+  private readonly requests = new Set<Promise<unknown>>();
+  private readonly readers = new Set<ReadableStreamDefaultReader<Uint8Array>>();
+  private closing?: Promise<void>;
   private registration?: HostRegistration;
   private host?: Promise<Host>;
+  private hostClient?: BrainClient;
 
   constructor(options: BrainOptions) {
     let end = options.baseUrl.length;
@@ -65,7 +70,35 @@ export class BrainClient {
   }
 
   withToken(token: string): BrainClient {
+    this.controller.signal.throwIfAborted();
     return new BrainClient({ baseUrl: this.baseUrl, token, timeoutMs: this.timeoutMs, fetch: this.transport });
+  }
+
+  /** Release this client's I/O and local handlers without ending its stored sessions. */
+  close(): Promise<void> {
+    if (this.closing !== undefined) return this.closing;
+    const opening = this.host;
+    const hostClient = this.hostClient;
+    this.closing = Promise.resolve().then(async () => {
+      const readers = [...this.readers].map((reader) => reader.cancel().catch(() => {}));
+      const host = await opening?.catch(() => undefined);
+      host?.pump.stop();
+      await Promise.allSettled([...readers, ...this.requests, hostClient?.close(), host?.pump.closed]);
+      this.readers.clear();
+    });
+    this.controller.abort(new DOMException("Brain client is closed", "AbortError"));
+    void hostClient?.close();
+    return this.closing;
+  }
+
+  private async io<T>(operation: (signal: AbortSignal) => Promise<T>, signal?: AbortSignal): Promise<T> {
+    this.controller.signal.throwIfAborted();
+    const combined = signal === undefined ? this.controller.signal : AbortSignal.any([this.controller.signal, signal]);
+    combined.throwIfAborted();
+    const pending = operation(combined);
+    this.requests.add(pending);
+    try { return await pending; }
+    finally { this.requests.delete(pending); }
   }
 
   async models(provider?: string): Promise<import("./generated/session.js").ModelList> {
@@ -78,17 +111,22 @@ export class BrainClient {
     if (body !== undefined) headers.set("content-type", contentType);
     if (this.token !== undefined) headers.set("authorization", `Bearer ${this.token}`);
     if (idempotencyKey !== undefined) headers.set("idempotency-key", idempotencyKey);
-    const response = await this.transport(`${this.baseUrl}${path}`, {
-      method,
-      headers,
-      body: body === undefined ? undefined : body instanceof Uint8Array ? new Uint8Array(body).buffer : JSON.stringify(body),
-      signal: this.timeoutMs === undefined ? signal : signal === undefined ? AbortSignal.timeout(this.timeoutMs) : AbortSignal.any([signal, AbortSignal.timeout(this.timeoutMs)]),
-    });
-    if (!response.ok) {
-      const error = (await response.json().catch(() => ({}))) as Partial<BrainError>;
-      throw new BrainError(response.status, error.code ?? "http_error", error.message ?? response.statusText, error.retryable ?? false, error.details);
-    }
-    return (response.status === 204 ? undefined : await response.json()) as T;
+    return this.io(async (signal) => {
+      const response = await this.transport(`${this.baseUrl}${path}`, {
+        method,
+        headers,
+        body: body === undefined ? undefined : body instanceof Uint8Array ? new Uint8Array(body).buffer : JSON.stringify(body),
+        signal,
+      });
+      if (!response.ok) {
+        const error = (await response.json().catch(() => ({}))) as Partial<BrainError>;
+        signal.throwIfAborted();
+        throw new BrainError(response.status, error.code ?? "http_error", error.message ?? response.statusText, error.retryable ?? false, error.details);
+      }
+      const value = response.status === 204 ? undefined : await response.json();
+      signal.throwIfAborted();
+      return value as T;
+    }, this.timeoutMs === undefined ? signal : signal === undefined ? AbortSignal.timeout(this.timeoutMs) : AbortSignal.any([signal, AbortSignal.timeout(this.timeoutMs)]));
   }
 
   async *stream(sessionId: string, after = 0, signal?: AbortSignal): AsyncGenerator<SessionStreamEvent> {
@@ -102,13 +140,20 @@ export class BrainClient {
   async *streamPath(path: string, signal?: AbortSignal, onOpen?: () => void): AsyncGenerator<SessionStreamEvent> {
     const headers = new Headers({ accept: "text/event-stream" });
     if (this.token !== undefined) headers.set("authorization", `Bearer ${this.token}`);
-    const response = await this.transport(`${this.baseUrl}${path}`, { headers, signal });
+    const response = await this.io((signal) => this.transport(`${this.baseUrl}${path}`, { headers, signal }), signal);
+    if (this.controller.signal.aborted) {
+      await response.body?.cancel().catch(() => {});
+      this.controller.signal.throwIfAborted();
+    }
     if (!response.ok || response.body === null) {
       const error = (await response.json().catch(() => ({}))) as Partial<BrainError>;
+      this.controller.signal.throwIfAborted();
+      signal?.throwIfAborted();
       throw new BrainError(response.status, error.code ?? "http_error", error.message ?? response.statusText, error.retryable ?? false, error.details);
     }
     onOpen?.();
     const reader = response.body.getReader();
+    this.readers.add(reader);
     const decoder = new TextDecoder();
     let buffer = "";
     try {
@@ -133,11 +178,14 @@ export class BrainClient {
           const text = data.join("\n");
           let payload: unknown = text;
           try { payload = JSON.parse(text); } catch { /* keep non-JSON payloads */ }
+          this.controller.signal.throwIfAborted();
+          signal?.throwIfAborted();
           yield { ...(id === undefined || id === "" ? {} : { sequence: Number(id) }), type, data: payload };
         }
       }
     } finally {
       await reader.cancel().catch(() => {});
+      this.readers.delete(reader);
     }
   }
 
@@ -155,31 +203,34 @@ export class BrainClient {
     return this.admitComponent(value, this.tools, "/v1/tools", "Tool");
   }
 
-  /** Registers this process as a host, or resumes the registration the client was
-   * given, and keeps its command stream open for as long as a session is placed here. */
+  /** Registers this process as a host, or resumes its registration, until client close. */
   async register(): Promise<Host> {
+    this.controller.signal.throwIfAborted();
     if (this.host !== undefined) return this.host;
     const opening = (async () => {
       const registration = this.registration ?? await this.request<HostRegistration>("POST", "/v1/hosts");
       this.registration = registration;
       const hostClient = this.withToken(registration.token);
+      this.hostClient = hostClient;
       const pump = new HostPump({
         stream: (signal, onOpen) => hostClient.streamPath(`/v1/hosts/${encodeURIComponent(registration.host_id)}/commands`, signal, onOpen),
         result: (value) => hostClient.request("POST", `/v1/hosts/${encodeURIComponent(registration.host_id)}/results`, value),
         emit: (value) => hostClient.request<{ sequence: number }>("POST", `/v1/hosts/${encodeURIComponent(registration.host_id)}/events`, value),
       });
-      await pump.start();
-      void pump.closed.then(() => {
+      const stop = () => pump.stop();
+      this.controller.signal.addEventListener("abort", stop, { once: true });
+      void pump.closed.then(async () => {
+        this.controller.signal.removeEventListener("abort", stop);
+        await hostClient.close();
+        if (this.hostClient === hostClient) this.hostClient = undefined;
         if (this.host === opening) this.host = undefined;
       });
+      await pump.start();
+      this.controller.signal.throwIfAborted();
       return {
         hostId: registration.host_id,
         pump,
-        unregister: (sessionId: string) => {
-          if (pump.unregister(sessionId) && this.host === opening) {
-            this.host = undefined;
-          }
-        },
+        unregister: (sessionId: string) => pump.unregister(sessionId),
       };
     })();
     this.host = opening;
@@ -195,6 +246,7 @@ export class BrainClient {
   }
 
   private async admitComponent(value: Component, cache: WeakMap<object, Promise<string>>, path: string, subject: string): Promise<string> {
+    this.controller.signal.throwIfAborted();
     const source = inspectComponent(value);
     const cached = cache.get(value);
     if (cached !== undefined) return cached;
@@ -202,8 +254,12 @@ export class BrainClient {
       const bytes = source.artifact instanceof Uint8Array
         ? source.artifact
         : source.artifact.protocol === "file:"
-          ? new Uint8Array(await (await import("node:fs/promises")).readFile(source.artifact))
-          : new Uint8Array(await (await this.transport(source.artifact)).arrayBuffer());
+          ? await this.io(async (signal) => new Uint8Array(await (await import("node:fs/promises")).readFile(source.artifact as URL, { signal })))
+          : await this.io(async (signal) => {
+              const response = await this.transport(source.artifact as URL, { signal });
+              if (!response.ok) throw new BrainError(response.status, "http_error", response.statusText, false);
+              return new Uint8Array(await response.arrayBuffer());
+            });
       if (bytes.byteLength === 0) throw new TypeError(`${subject} Component cannot be empty`);
       const idempotencyKey = `${subject.toLowerCase()}-${await sha256(bytes)}`;
       const result = await this.request<AgentloopAdmission | ToolAdmission>("POST", path, bytes, idempotencyKey, "application/octet-stream");
@@ -235,8 +291,6 @@ export class Sessions {
     const implementation = isComponent(loop.implementation)
       ? { type: "brain_component", entrypoint: "turn", id: await this.client.admitAgentloop(loop.implementation) }
       : structuredClone(loop.implementation);
-    const hosted = [...environments.keys()].some((environment) => inspectEnvironment(environment).driver.driver === "host");
-    const host = hosted ? await this.client.register() : undefined;
     const implementations = new Map<PlacedTool, unknown>();
     for (const [placed, tool] of tools) {
       if (tool.implementation === undefined) {
@@ -253,15 +307,16 @@ export class Sessions {
             configuration: structuredClone(tool.configuration),
           });
     }
-    const request = compileSession(options, implementation, environments, implementations, host?.hostId);
-    const session = await this.client.request<WireSession>("POST", "/v1/sessions", request, key);
-    if (host !== undefined) {
-      const registry = new HostToolRegistry();
-      for (const [, tool] of tools) {
-        if (tool.handler !== undefined && tool.contract !== undefined) registry.register(inspectEnvironment(tool.environment).name, tool.contract, tool.handler);
-      }
-      host.pump.register(session.session_id, registry);
+    const compiledTools = compileTools(options.tools ?? [], implementations);
+    const registry = new HostToolRegistry();
+    for (const [, tool] of tools) {
+      if (tool.handler !== undefined && tool.contract !== undefined) registry.register(inspectEnvironment(tool.environment).name, tool.contract, tool.handler);
     }
+    const hosted = [...environments.keys()].some((environment) => inspectEnvironment(environment).driver.driver === "host");
+    const host = hosted ? await this.client.register() : undefined;
+    const request = compileSession(options, implementation, environments, compiledTools, host?.hostId);
+    const session = await this.client.request<WireSession>("POST", "/v1/sessions", request, key);
+    host?.pump.register(session.session_id, registry);
     return new SessionHandle(
       this.client,
       toSessionState(session),
@@ -353,7 +408,7 @@ export class SessionHandle {
       for await (const event of this.client.stream(this.id, after, watching.signal)) {
         if (event.type === "turn_started") {
           if (completed) break;
-          cancelling = this.cancel();
+          cancelling = this.interrupt();
           await cancelling;
           break;
         }
@@ -391,7 +446,7 @@ export class SessionHandle {
     return this.client.stream(this.id, after, signal);
   }
 
-  async cancel(operation: OperationOptions = {}): Promise<void> {
+  async interrupt(operation: OperationOptions = {}): Promise<void> {
     await this.client.request("POST", `/v1/sessions/${encodeURIComponent(this.id)}/cancel`, undefined, keyOf(operation));
   }
 
@@ -432,7 +487,7 @@ function compileSession(
   options: CreateSessionOptions,
   agentloopImplementation: unknown,
   environments: ReadonlySet<Environment>,
-  implementations: ReadonlyMap<PlacedTool, unknown>,
+  tools: WireTool[],
   hostId?: string,
 ): CreateSessionRequest {
   const entries: WireEnvironment[] = [...environments].map((environment) => {
@@ -453,8 +508,26 @@ function compileSession(
         };
     }
   });
+  const loop = inspectAgentloop(options.agentloop);
+  return {
+    agentloop: {
+      implementation: structuredClone(agentloopImplementation),
+      configuration: structuredClone(loop.configuration),
+      environment: inspectEnvironment(loop.environment).name,
+    },
+    model: { provider: options.model.provider, name: options.model.name, api_key: options.model.apiKey },
+    system: options.system ?? "",
+    ...(options.responseFormat === undefined ? {} : { response_format: structuredClone(options.responseFormat) as CreateSessionRequest["response_format"] }),
+    tools,
+    environments: entries,
+    ...(options.transcript === undefined ? {} : { transcript: structuredClone(options.transcript) as CreateSessionRequest["transcript"] }),
+    ...(options.idleTtlMs === undefined ? {} : { idle_ttl_ms: options.idleTtlMs }),
+  };
+}
+
+function compileTools(selectedTools: readonly PlacedTool[], implementations: ReadonlyMap<PlacedTool, unknown>): WireTool[] {
   const tools = new Map<string, WireTool>();
-  for (const selected of options.tools ?? []) {
+  for (const selected of selectedTools) {
     const tool = inspectTool(selected);
     const definition = {
       name: tool.definition.name, description: tool.definition.description,
@@ -472,21 +545,7 @@ function compileSession(
     entry.placements[environment] = { implementation: structuredClone(implementations.get(selected)) };
     tools.set(definition.name, entry);
   }
-  const loop = inspectAgentloop(options.agentloop);
-  return {
-    agentloop: {
-      implementation: structuredClone(agentloopImplementation),
-      configuration: structuredClone(loop.configuration),
-      environment: inspectEnvironment(loop.environment).name,
-    },
-    model: { provider: options.model.provider, name: options.model.name, api_key: options.model.apiKey },
-    system: options.system ?? "",
-    ...(options.responseFormat === undefined ? {} : { response_format: structuredClone(options.responseFormat) as CreateSessionRequest["response_format"] }),
-    tools: [...tools.values()],
-    environments: entries,
-    ...(options.transcript === undefined ? {} : { transcript: structuredClone(options.transcript) as CreateSessionRequest["transcript"] }),
-    ...(options.idleTtlMs === undefined ? {} : { idle_ttl_ms: options.idleTtlMs }),
-  };
+  return [...tools.values()];
 }
 
 function validateSessionOptions(options: CreateSessionOptions): void {

--- a/packages/brain-sdk/src/extensions.ts
+++ b/packages/brain-sdk/src/extensions.ts
@@ -296,7 +296,7 @@ function toolDefinition(contract: { readonly name: string; readonly description:
   return Object.freeze({
     name: contract.name,
     description: contract.description,
-    inputSchema: z.toJSONSchema(contract.input) as Readonly<Record<string, unknown>>,
+    inputSchema: z.toJSONSchema(contract.input, { io: "input" }) as Readonly<Record<string, unknown>>,
     ...(contract.output === undefined ? {} : { outputSchema: z.toJSONSchema(contract.output) as Readonly<Record<string, unknown>> }),
   });
 }

--- a/packages/brain-sdk/test/client-close.test.mjs
+++ b/packages/brain-sdk/test/client-close.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { z } from "zod";
+import { Brain, agentloop, brainEnv, component, hostEnv, tool } from "../dist/index.js";
+
+const registration = { host_id: "host_lifecycle", token: "fixture-host-token" };
+const state = (id, status = "idle") => ({ session_id: id, status, last_sequence: 1 });
+const aborted = { name: "AbortError" };
+const untilAbort = (signal) => new Promise((_, reject) => {
+  if (signal.aborted) reject(signal.reason);
+  else signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+});
+
+function fixture(t, { route, run = () => "done" } = {}) {
+  const requests = [];
+  const connections = [];
+  const result = Promise.withResolvers();
+  let sessions = 0;
+  const client = new Brain({ baseUrl: "https://brain.example", fetch: async (input, init) => {
+    const request = new Request(input, init);
+    const path = new URL(request.url).pathname;
+    requests.push({ path, method: request.method, signal: request.signal });
+    const response = await route?.(path, request);
+    if (response !== undefined) return response;
+    if (path === "/v1/agentloops") return Response.json({ id: "a".repeat(64), status: "admitted" });
+    if (path === "/v1/hosts") return Response.json(registration);
+    if (path.endsWith("/commands")) {
+      const connection = { signal: request.signal, cancelled: false };
+      connections.push(connection);
+      return new Response(new ReadableStream({
+        start(controller) { connection.controller = controller; },
+        cancel() { connection.cancelled = true; },
+      }));
+    }
+    if (path.endsWith("/results")) { result.resolve(await request.json()); return new Response(null, { status: 204 }); }
+    if (path === "/v1/sessions") return Response.json(state(`session-${++sessions}`));
+    if (path.endsWith("/end")) return Response.json(state(path.split("/")[3], "ended"));
+    if (path === "/v1/models") return Response.json({ providers: [] });
+    throw new Error(`unexpected request ${request.method} ${path}`);
+  } });
+  t.after(() => client.close());
+  const loop = agentloop({ implementation: component(new Uint8Array([1])) });
+  const lookup = tool({ name: "lookup", description: "Look up a value.", input: z.object({}), run });
+  const options = {
+    agentloop: loop({ env: brainEnv({ name: "brain" }) }),
+    model: { provider: "openai", name: "gpt-5", apiKey: "fixture-model-token" },
+    tools: [lookup({ env: hostEnv({ name: "app" }) })],
+  };
+  const invoke = (sessionId) => connections.at(-1).controller.enqueue(new TextEncoder().encode(
+    `event: command\ndata: ${JSON.stringify({ session_id: sessionId, environment: "app", sequence: 2,
+      deadline_at_ms: Date.now() + 10_000, operation: { type: "invoke_tool", name: "lookup", input: {} } })}\n\n`,
+  ));
+  return { client, options, requests, connections, invoke, result: result.promise };
+}
+
+test("close is idempotent before use and rejects new work", async (t) => {
+  const f = fixture(t);
+  const closing = f.client.close();
+  assert.equal(f.client.close(), closing);
+  await closing;
+  for (const operation of [
+    () => f.client.models(), () => f.client.register(), () => f.client.credentials(),
+    () => f.client.sessions.create(f.options), () => f.client.admit(f.options.agentloop),
+    () => f.client.stream("session").next(),
+  ]) await assert.rejects(operation(), aborted);
+  assert.throws(() => f.client.withToken("another-token"), aborted);
+  assert.deepEqual(f.requests, []);
+});
+
+test("a failed create retains the shared stream until client close", async (t) => {
+  const f = fixture(t, { route: (path) => path === "/v1/sessions"
+    ? Response.json({ code: "invalid_request", message: "creation refused" }, { status: 400 }) : undefined });
+  await assert.rejects(f.client.sessions.create(f.options), /creation refused/u);
+  assert.equal(f.connections.length, 1);
+  assert.equal(f.connections[0].cancelled, false);
+  await f.client.close();
+  assert.equal(f.connections[0].cancelled, true);
+  assert.equal(f.connections[0].signal.aborted, true);
+  assert.equal(f.requests.some(request => request.method === "DELETE" || /\/(cancel|end)$/u.test(request.path)), false);
+});
+
+test("ending the last session does not stop a concurrent create", async (t) => {
+  const entered = Promise.withResolvers();
+  const response = Promise.withResolvers();
+  let creates = 0;
+  const f = fixture(t, { route: (path) => {
+    if (path === "/v1/sessions" && ++creates === 2) { entered.resolve(); return response.promise; }
+  } });
+  const first = await f.client.sessions.create(f.options);
+  const pending = f.client.sessions.create(f.options);
+  await entered.promise;
+  await first.end();
+  assert.equal(f.connections[0].signal.aborted, false);
+  response.resolve(Response.json(state("second")));
+  const second = await pending;
+  f.invoke(second.id);
+  assert.deepEqual((await f.result).outcome, { status: "ok", value: "done" });
+  assert.equal(f.connections.length, 1);
+  await assert.rejects((async () => { await f.client.close(); await f.client.admit(f.options.agentloop); })(), aborted);
+});
+
+test("a failed reattachment leaves the client usable and closes with it", async (t) => {
+  const f = fixture(t, { route: (path) => {
+    if (path === "/v1/sessions/retained") return Response.json(state("retained"));
+    if (path === "/v1/sessions/retained/events") return Response.json({ events: [{
+      sequence: 1, recorded_at_ms: 0, event_type: "session_creation_ended", data: { configuration: {
+        environments: [{ name: "other", driver: "host", host_id: registration.host_id }], tools: [],
+      } },
+    }], next_cursor: 1 });
+  } });
+  await assert.rejects(f.client.sessions.get("retained", { tools: f.options.tools }), /exactly those/u);
+  const session = await f.client.sessions.create(f.options);
+  f.invoke(session.id);
+  assert.equal((await f.result).outcome.status, "ok");
+  assert.equal(f.connections.length, 1);
+  await f.client.close();
+  assert.equal(f.connections[0].cancelled, true);
+});
+
+for (const phase of ["registration", "stream opening"]) {
+  test(`close aborts host ${phase} without opening a session`, async (t) => {
+    const entered = Promise.withResolvers();
+    const f = fixture(t, { route: (path, request) => {
+      if (phase === "registration" ? path === "/v1/hosts" : path.endsWith("/commands")) {
+        entered.resolve();
+        return untilAbort(request.signal);
+      }
+    } });
+    const rejected = assert.rejects(f.client.sessions.create(f.options), aborted);
+    await entered.promise;
+    await f.client.close();
+    await rejected;
+    assert.equal(f.requests.some(request => request.path === "/v1/sessions"), false);
+  });
+}
+
+for (const phase of ["request body", "Component download"]) {
+  test(`close aborts a pending ${phase}`, async (t) => {
+    const entered = Promise.withResolvers();
+    const f = fixture(t, { route: (path, request) => {
+      if (path === "/v1/models" || path === "/loop.wasm") return new Response(new ReadableStream({
+        start(controller) {
+          request.signal.addEventListener("abort", () => controller.error(request.signal.reason), { once: true });
+          entered.resolve();
+        },
+      }));
+    } });
+    const pending = phase === "request body" ? f.client.models()
+      : f.client.admitAgentloop(component(new URL("https://artifacts.example/loop.wasm")));
+    const rejected = assert.rejects(pending, aborted);
+    await entered.promise;
+    await f.client.close();
+    await rejected;
+    assert.equal(f.requests.some(request => request.path === "/v1/agentloops"), false);
+  });
+}
+
+test("close cancels a paused event reader and does not end its session", async (t) => {
+  let cancelled = false;
+  const f = fixture(t, { route: (path) => path.endsWith("/events") ? new Response(new ReadableStream({
+    start(controller) { controller.enqueue(new TextEncoder().encode("event: first\ndata: {}\n\nevent: buffered\ndata: {}\n\n")); },
+    cancel() { cancelled = true; },
+  })) : undefined });
+  const events = f.client.stream("retained");
+  assert.equal((await events.next()).value.type, "first");
+  await f.client.close();
+  assert.equal(cancelled, true);
+  await assert.rejects(events.next(), aborted);
+  assert.equal(f.requests.length, 1);
+});
+
+for (const operation of ["events", "results"]) {
+  test(`close aborts a host ${operation} post`, async (t) => {
+    const entered = Promise.withResolvers();
+    let signal;
+    const f = fixture(t, {
+      route: (path, request) => {
+        if (path.endsWith(`/${operation}`)) { signal = request.signal; entered.resolve(); return untilAbort(signal); }
+      },
+      run: async (_, context) => { if (operation === "events") await context.emit("progress", {}); return "done"; },
+    });
+    const session = await f.client.sessions.create(f.options);
+    f.invoke(session.id);
+    await entered.promise;
+    await f.client.close();
+    assert.equal(signal.aborted, true);
+    assert.equal(f.connections[0].cancelled, true);
+  });
+}
+
+test("close does not await an uncooperative handler or publish its late output", { timeout: 2_000 }, async (t) => {
+  const entered = Promise.withResolvers();
+  const result = Promise.withResolvers();
+  let signal;
+  const f = fixture(t, { run: (_, context) => { signal = context.signal; entered.resolve(); return result.promise; } });
+  const session = await f.client.sessions.create(f.options);
+  f.invoke(session.id);
+  await entered.promise;
+  await f.client.close();
+  assert.equal(signal.aborted, true);
+  result.resolve("late result");
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(f.requests.some(request => request.path.endsWith("/results")), false);
+});
+
+test("withToken clients have independent lifetimes", async (t) => {
+  const f = fixture(t);
+  const other = f.client.withToken("other-token");
+  t.after(() => other.close());
+  await f.client.close();
+  assert.deepEqual(await other.models(), { providers: [] });
+});

--- a/packages/brain-sdk/test/client-tools.test.mjs
+++ b/packages/brain-sdk/test/client-tools.test.mjs
@@ -10,7 +10,7 @@ const sessionId = "ses_12345678901234567890";
 const sse = (data) => `event: command\ndata: ${JSON.stringify(data)}\n\n`;
 const model = { provider: "openai", name: "gpt-5", apiKey: "model-token" };
 
-test("saved host credentials reattach handlers to an existing session", async () => {
+test("saved host credentials reattach handlers to an existing session", async (t) => {
   const credentials = { hostId: "host_12345678901234567890", token: "saved-token" };
   let controller;
   let finish;
@@ -33,6 +33,7 @@ test("saved host credentials reattach handlers to an existing session", async ()
     if (path === `/v1/sessions/${sessionId}`) return Response.json({ session_id: sessionId, environment: "app", status: "idle", last_sequence: 1 });
     throw new Error(`unexpected request ${path}`);
   } });
+  t.after(() => client.close());
   const lookup = tool({ name: "lookup", description: "Lookup.", input: z.object({}), run: async () => "restored" });
   const session = await client.sessions.get(sessionId, { tools: [lookup({ env: hostEnv({ name: "app" }) })] });
   assert.deepEqual(await client.credentials(), credentials);
@@ -41,7 +42,7 @@ test("saved host credentials reattach handlers to an existing session", async ()
   await session.end();
 });
 
-test("one host runs the Tools placed in it and commits ctx.emit before its result", async () => {
+test("one host runs the Tools placed in it and commits ctx.emit before its result", async (t) => {
   const requests = [];
   let releaseStream;
   let releaseCommand;
@@ -92,6 +93,7 @@ test("one host runs the Tools placed in it and commits ctx.emit before its resul
   });
   const pi = agentloop({ implementation: component(new Uint8Array([1])) });
   const client = new Brain({ baseUrl: "https://brain.example", token: "brain-token", fetch: fetchStub });
+  t.after(() => client.close());
   const app = hostEnv({ name: "app" });
   const session = await client.sessions.create({
     model,
@@ -114,7 +116,7 @@ test("one host runs the Tools placed in it and commits ctx.emit before its resul
   await session.delete();
 });
 
-test("session creation waits for the host command stream", async () => {
+test("session creation waits for the host command stream", async (t) => {
   const paths = [];
   const client = new Brain({ baseUrl: "https://brain.example", fetch: async (input, init) => {
     const request = new Request(input, init);
@@ -126,6 +128,7 @@ test("session creation waits for the host command stream", async () => {
     if (path === "/v1/sessions") throw new Error("session create raced the host connection");
     throw new Error(`unexpected request ${request.method} ${path}`);
   } });
+  t.after(() => client.close());
   const pi = agentloop({ implementation: component(new Uint8Array([1])) });
   const local = tool({
     name: "local",
@@ -180,6 +183,7 @@ test("a host reconnects without replaying old commands", async () => {
   assert.equal(connections, 2);
   assert.deepEqual(result.outcome, { status: "ok", value: { id: "2" } });
   pump.unregister(sessionId);
+  pump.stop();
   await pump.closed;
 });
 
@@ -211,9 +215,10 @@ test("losing the command stream reports an in-flight call as unknown without rep
   assert.equal(calls, 1);
 });
 
-test("a new session reconnects the durable host after its previous stream stopped", async () => {
+test("a new session shares the host connection after the previous session ends", async (t) => {
   let hosts = 0;
   let sessions = 0;
+  let connections = 0;
   const placements = [];
   const client = new Brain({ baseUrl: "https://brain.example", fetch: async (input, init) => {
     const request = new Request(input, init);
@@ -226,6 +231,7 @@ test("a new session reconnects the durable host after its previous stream stoppe
       return Response.json({ host_id: `host_${hosts}`, token: `token_${hosts}` });
     }
     if (path.endsWith("/commands")) {
+      connections++;
       return new Response(new ReadableStream({
         start(controller) {
           request.signal.addEventListener("abort", () => controller.close(), { once: true });
@@ -243,6 +249,7 @@ test("a new session reconnects the durable host after its previous stream stoppe
     }
     throw new Error(`unexpected request ${request.method} ${path}`);
   } });
+  t.after(() => client.close());
   const pi = agentloop({ implementation: component(new Uint8Array([1])) });
   const local = tool({
     name: "local",
@@ -262,5 +269,6 @@ test("a new session reconnects the durable host after its previous stream stoppe
   await second.end();
 
   assert.equal(hosts, 1);
+  assert.equal(connections, 1);
   assert.deepEqual(placements, ["host_1", "host_1"]);
 });

--- a/packages/brain-sdk/test/client.test.mjs
+++ b/packages/brain-sdk/test/client.test.mjs
@@ -181,7 +181,8 @@ test("long operations have no implicit client timeout", async () => {
     },
   });
   await client.sessions.list();
-  assert.equal(defaultSignal, undefined);
+  assert.ok(defaultSignal instanceof AbortSignal);
+  assert.equal(defaultSignal.aborted, false);
 
   let explicitSignal;
   const bounded = new Brain({

--- a/packages/brain-sdk/test/execution.test.mjs
+++ b/packages/brain-sdk/test/execution.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { HostToolRegistry } from "../dist/host.js";
 
 import { z } from "zod";
 import {
@@ -102,4 +103,36 @@ test("native grants are explicit, validated, and independent between bindings", 
   }
   assert.throws(() => brainEnv({ name: "bad", filesystem: { workspace: "root" } }), /read/u);
   assert.throws(() => brainEnv({ name: "bad", filesystem: { home: "read" } }), /Unrecognized/u);
+});
+
+for (const strict of [false, true]) {
+  test(`Tool input schemas describe accepted ${strict ? "strict" : "ordinary"} inputs before parsing`, async () => {
+    let called = 0;
+    const shape = { text: z.string().transform(value => value.toUpperCase()), limit: z.number().default(10) };
+    const input = strict ? z.strictObject(shape) : z.object(shape);
+    const lookup = tool({ name: "lookup", description: "Look up values.", input,
+      output: z.object({ text: z.string(), limit: z.number().default(10) }),
+      run: value => { called++; return value; },
+    })({ env: hostEnv({ name: "app" }) });
+    const source = inspectTool(lookup);
+    assert.deepEqual(source.definition.inputSchema.required, ["text"]);
+    assert.equal(source.definition.inputSchema.properties.text.type, "string");
+    assert.equal(source.definition.inputSchema.additionalProperties, strict ? false : undefined);
+    assert.deepEqual(source.definition.outputSchema.required, ["text", "limit"]);
+    const registry = new HostToolRegistry();
+    registry.register("app", source.contract, source.handler);
+    const invoke = arguments_ => registry.run({ sessionId: "session", environment: "app", sequence: 1,
+      name: "lookup", arguments: arguments_, deadline_ms: 1_000, emit: async () => 1,
+    });
+    assert.deepEqual(await invoke({ text: "cyan" }), { status: "ok", value: { text: "CYAN", limit: 10 } });
+    assert.equal((await invoke({})).error.code, "invalid_input");
+    assert.equal(called, 1);
+    const extra = await invoke({ text: "blue", extra: true });
+    if (strict) assert.equal(extra.error.code, "invalid_input");
+    else assert.deepEqual(extra, { status: "ok", value: { text: "BLUE", limit: 10 } });
+  });
+}
+
+test("unrepresentable Tool schemas fail during authoring", () => {
+  assert.throws(() => tool({ name: "date", description: "Date.", input: z.object({ date: z.date() }), run: () => null }), /Date/u);
 });

--- a/packages/brain-sdk/test/types/lifecycle.ts
+++ b/packages/brain-sdk/test/types/lifecycle.ts
@@ -1,0 +1,10 @@
+import { Brain, type SessionHandle } from "../../dist/index.js";
+
+const client = new Brain({ baseUrl: "https://brain.example" });
+declare const session: SessionHandle;
+const closing: Promise<void> = client.close();
+const interrupting: Promise<void> = session.interrupt({ idempotencyKey: "interrupt-once" });
+void closing;
+void interrupting;
+// @ts-expect-error The public interruption method has one spelling.
+session.cancel();

--- a/tests/journeys/README.md
+++ b/tests/journeys/README.md
@@ -16,10 +16,10 @@ Linux worker job, then runs all journeys as a required part of `build-test`.
 | `component`, `agentloop`, `admit`, `admitAgentloop`, `admitTool`, inspection | File/bytes/HTTP artifacts, id reuse, parallel preparation, rejected artifacts, prepared session creation, native Tool execution |
 | `sessions.create/get/list`, initial transcript, system, response format, idle policy | Full conversation lifecycle, seeded context, reopen through another client, idempotent creation with and without host Tools, conflicting keys, parallel conversations |
 | `send`, `state`, `id`, `transcript` | String/structured input, multiple suspended turns, idempotent sends, invalid input, cold reads, committed input after interruption |
-| `cancel`, `end`, `delete` | Running and idle cancellation, model and host Tool cancellation, repeated keyed operations, ended-session reads, invalid deletion, independent sessions |
+| `interrupt`, `end`, `delete` | Running and idle cancellation, model and host Tool cancellation, repeated keyed operations, ended-session reads, invalid deletion, independent sessions |
 | `events`, `stream`, client `stream` | Durable cursors, a full page boundary, replay-to-live delivery, reconnect, abort, authentication, session isolation |
-| `tool` with `run` in `hostEnv`, options, schemas, context | Progress ordering, input/output errors, handler errors, deadlines/signals, the call's sequence, concurrent sessions, protected Event rejection |
-| `register`, `credentials`, reattachment | Save credentials, close the host connection, reject mismatched placements, restore matching handlers, preserve active-call cancellation on creation replay |
+| `tool` with `run` in `hostEnv`, options, schemas, context | Progress ordering, input defaults and extra-property policy, input/output errors, handler errors, deadlines/signals, the call's sequence, concurrent sessions, protected Event rejection |
+| `close`, `register`, `credentials`, reattachment | Save credentials, close the client while retaining sessions, reject mismatched placements, restore matching handlers, preserve active-call cancellation on creation replay |
 | `environment`, `brainEnv`, placed Tools | Independent authenticated Environments, lazy allocation, configuration validation, explicit native grants and denied access, workspace persistence/isolation |
 | An Agentloop placed in an Environment reached over HTTP | The turn's model call, emit, and dispatch through Brain's turn routes, a dispatched Tool running in the host env, and the routes closing with the turn |
 | `timeoutMs` | Explicit client timeout leaves the server's execution observable and does not retry the model call |

--- a/tests/journeys/host.test.mjs
+++ b/tests/journeys/host.test.mjs
@@ -23,7 +23,7 @@ test("cancelling a parent reaches an owned child turn through the host Tool sign
   const parent = await f.create(t, { tools: [delegate({ env: hostEnv({ name: "owner" }) })] });
   const running = parent.send("delegate work");
   await entered.promise;
-  await parent.cancel();
+  await parent.interrupt();
   await running;
   await finished.promise;
   assert.equal((await f.brain.sessions.get(child.id)).state.status, "idle");
@@ -154,14 +154,11 @@ test("saved host credentials reattach a tool after its connection is closed", { 
   const lookup = tool({ name: "lookup", description: "Lookup", input: z.object({}), run: () => "original" });
   const original = await f.create(t, { tools: [lookup({ env: app })] }, firstClient);
   const credentials = await firstClient.credentials();
-  const host = await firstClient.register();
-  host.pump.stop();
-  await host.pump.closed;
+  await firstClient.close();
+  assert.equal((await f.brain.sessions.get(original.id)).state.status, "idle");
   const restored = f.client({ credentials });
   const rebound = tool({ name: "lookup", description: "Lookup", input: z.object({}), run: () => "restored" });
   await assert.rejects(restored.sessions.get(original.id, { tools: [] }), /exactly those the session placed/u);
-  const restoredHost = await restored.register();
-  t.after(() => restoredHost.pump.stop());
   const session = await restored.sessions.get(original.id, { tools: [rebound({ env: app })] });
   assert.deepEqual(await restored.credentials(), credentials);
   f.model = dispatch("lookup", {});
@@ -169,6 +166,27 @@ test("saved host credentials reattach a tool after its connection is closed", { 
   assert.ok(JSON.stringify(f.modelRequests.at(-1).input).includes("restored"));
   await session.end();
 });
+
+for (const strict of [false, true]) {
+  test(`defaulted host input passes dispatch and ${strict ? "rejects" : "strips"} extra arguments`, { timeout: 30_000 }, async (t) => {
+    const seen = [];
+    const shape = { query: z.string(), limit: z.number().int().positive().default(10) };
+    const lookup = tool({ name: "lookup", description: "Look up results", input: strict ? z.strictObject(shape) : z.object(shape),
+      run: input => { seen.push(input); return input; },
+    });
+    const session = await f.create(t, { tools: [lookup({ env: app })] });
+    f.model = dispatch("lookup", { query: "cyan" });
+    await session.send("find cyan");
+    assert.deepEqual(seen, [{ query: "cyan", limit: 10 }]);
+    assert.deepEqual(f.modelRequests[0].tools[0].parameters.required, ["query"]);
+    f.model = dispatch("lookup", { query: "blue", extra: true });
+    await session.send("find blue");
+    if (strict) {
+      assert.equal(seen.length, 1);
+      assert.match(f.modelRequests.at(-1).input.at(-1).output, /invalid_input/u);
+    } else assert.deepEqual(seen[1], { query: "blue", limit: 10 });
+  });
+}
 
 test("cancellation reaches the tool's signal and does not execute the tool twice", { timeout: 30_000 }, async (t) => {
   const entered = deferred();
@@ -185,7 +203,7 @@ test("cancellation reaches the tool's signal and does not execute the tool twice
   const session = await f.create(t, { tools: [wait({ env: app })] });
   const pending = session.send("wait").catch((error) => error);
   await entered.promise;
-  await session.cancel();
+  await session.interrupt();
   await cancelled.promise;
   await pending;
   assert.equal(calls, 1);
@@ -250,7 +268,7 @@ test("replaying creation during a tool call preserves its cancellation handler",
   await entered.promise;
   const repeated = await f.brain.sessions.create(f.options(options), operation);
   assert.equal(repeated.id, first.id);
-  await repeated.cancel();
+  await repeated.interrupt();
   await cancelled.promise;
   await pending;
   assert.equal(calls, 1);

--- a/tests/journeys/sessions.test.mjs
+++ b/tests/journeys/sessions.test.mjs
@@ -22,7 +22,7 @@ test("create, list, reopen, end, and delete a conversation", { timeout: 30_000 }
 
 test("cancel an idle session and repeat deletion using the same operation key", { timeout: 30_000 }, async (t) => {
   const session = await f.create(t);
-  await session.cancel();
+  await session.interrupt();
   assert.equal((await f.brain.sessions.get(session.id)).state.status, "idle");
   await session.send("still usable");
   await session.end();

--- a/tests/journeys/support.mjs
+++ b/tests/journeys/support.mjs
@@ -8,7 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { before, beforeEach, after } from "node:test";
 import { pathToFileURL } from "node:url";
-import { Brain, BrainError, agentloop, brainEnv, component, environment, inspectTool } from "@aexhq/brain";
+import { Brain, BrainError, agentloop, brainEnv, component, environment } from "@aexhq/brain";
 import { z } from "zod";
 
 export const collect = async (events) => { const result = []; for await (const event of events) result.push(event); return result; };
@@ -40,7 +40,7 @@ export function fixture({ providers = {} } = {}) {
   let upstream;
   let directory;
   let logs = "";
-  const pumps = new Set();
+  const clients = new Set();
   beforeEach(() => {
     f.modelRequests.length = 0;
     f.model = (_request, response) => reply(response);
@@ -100,7 +100,11 @@ export function fixture({ providers = {} } = {}) {
       ...extra,
     });
   }, { timeout: 60_000 });
-  f.client = (options = {}) => new Brain({ baseUrl: f.baseUrl, token: f.token, ...options });
+  f.client = (options = {}) => {
+    const client = new Brain({ baseUrl: f.baseUrl, token: f.token, ...options });
+    clients.add(client);
+    return client;
+  };
   f.start = async () => {
     child = spawn(process.env.BRAIN_TEST_SERVER, [], { env: {
       ...process.env,
@@ -128,15 +132,17 @@ export function fixture({ providers = {} } = {}) {
   };
   f.create = async (t, extra = {}, client = f.brain, operation) => {
     const session = await client.sessions.create(f.options(extra), operation);
-    if (extra.tools?.some((tool) => inspectTool(tool).handler !== undefined)) pumps.add((await client.register()).pump);
     t.after(async () => {
-      try { await session.end(); await session.delete(); } catch (error) { if (!failure(404)(error)) throw error; }
+      try {
+        const retained = await f.brain.sessions.get(session.id);
+        await retained.end();
+        await retained.delete();
+      } catch (error) { if (!failure(404)(error)) throw error; }
     }, { timeout: 10_000 });
     return session;
   };
   after(async () => {
-    for (const pump of pumps) pump.stop();
-    await Promise.all([...pumps].map((pump) => pump.closed));
+    await Promise.all([...clients].map((client) => client.close()));
     await f.stop();
     if (upstream) {
       upstream.closeAllConnections();

--- a/tests/journeys/turns.test.mjs
+++ b/tests/journeys/turns.test.mjs
@@ -32,8 +32,8 @@ test("cancel a running turn, inspect its outcome, and explicitly send again", { 
   const pending = session.send("wait for cancellation").then((value) => ({ value }), (error) => ({ error }));
   await entered.promise;
   assert.equal((await f.brain.sessions.get(session.id)).state.status, "running");
-  await session.cancel({ idempotencyKey: "cancel-once" });
-  await session.cancel({ idempotencyKey: "cancel-once" });
+  await session.interrupt({ idempotencyKey: "cancel-once" });
+  await session.interrupt({ idempotencyKey: "cancel-once" });
   await pending;
   const events = await collect(session.events());
   assert.ok(events.some(({ type }) => type === "turn_failed"));

--- a/tests/release/sdk-events.mjs
+++ b/tests/release/sdk-events.mjs
@@ -11,35 +11,39 @@ const brain = new Brain({ baseUrl, token });
 const diagnostic = agentloop({
   implementation: component(new URL("./diagnostic-agentloop.wasm", import.meta.url)),
 });
-const session = await brain.sessions.create({
-  model: {
-    provider: "vercel-ai-gateway",
-    name: "openai/gpt-5-mini",
-    apiKey: "release-smoke-key",
-  },
-  agentloop: diagnostic({ env: brainEnv({ name: "brain" }) }),
-});
-await session.send("first turn");
-await session.send("second turn");
+try {
+  const session = await brain.sessions.create({
+    model: {
+      provider: "vercel-ai-gateway",
+      name: "openai/gpt-5-mini",
+      apiKey: "release-smoke-key",
+    },
+    agentloop: diagnostic({ env: brainEnv({ name: "brain" }) }),
+  });
+  await session.send("first turn");
+  await session.send("second turn");
 
-const complete = [];
-for await (const event of session.events()) complete.push(event);
-assert.equal(complete.at(-1)?.sequence, session.state.lastSequence);
-const ended = complete.filter(({ type }) => type === "turn_ended");
-assert.equal(ended.length, 2);
+  const complete = [];
+  for await (const event of session.events()) complete.push(event);
+  assert.equal(complete.at(-1)?.sequence, session.state.lastSequence);
+  const ended = complete.filter(({ type }) => type === "turn_ended");
+  assert.equal(ended.length, 2);
 
-const cursor = ended[0].sequence;
-const suffix = [];
-for await (const event of session.events(cursor)) suffix.push(event);
-assert.deepEqual(
-  suffix.map(({ type }) => type),
-  ["session_resumed", "turn_started", "activation_started", "note", "activation_ended", "turn_ended"],
-);
-assert.equal(suffix.at(-1)?.sequence, session.state.lastSequence);
+  const cursor = ended[0].sequence;
+  const suffix = [];
+  for await (const event of session.events(cursor)) suffix.push(event);
+  assert.deepEqual(
+    suffix.map(({ type }) => type),
+    ["session_resumed", "turn_started", "activation_started", "note", "activation_ended", "turn_ended"],
+  );
+  assert.equal(suffix.at(-1)?.sequence, session.state.lastSequence);
 
-const streamed = [];
-for await (const event of session.events(cursor)) streamed.push(event);
-assert.deepEqual(streamed.map(({ sequence }) => sequence), suffix.map(({ sequence }) => sequence));
+  const streamed = [];
+  for await (const event of session.events(cursor)) streamed.push(event);
+  assert.deepEqual(streamed.map(({ sequence }) => sequence), suffix.map(({ sequence }) => sequence));
 
-await session.end();
-await session.delete();
+  await session.end();
+  await session.delete();
+} finally {
+  await brain.close();
+}

--- a/tests/release/sdk-turns.mjs
+++ b/tests/release/sdk-turns.mjs
@@ -11,30 +11,34 @@ const brain = new Brain({ baseUrl, token });
 const diagnostic = agentloop({
   implementation: component(new URL("./diagnostic-agentloop.wasm", import.meta.url)),
 });
-const session = await brain.sessions.create({
-  model: {
-    provider: "vercel-ai-gateway",
-    name: "openai/gpt-5-mini",
-    apiKey: "release-smoke-key",
-  },
-  agentloop: diagnostic({ env: brainEnv({ name: "brain" }) }),
-});
+try {
+  const session = await brain.sessions.create({
+    model: {
+      provider: "vercel-ai-gateway",
+      name: "openai/gpt-5-mini",
+      apiKey: "release-smoke-key",
+    },
+    agentloop: diagnostic({ env: brainEnv({ name: "brain" }) }),
+  });
 
-const completed = await session.send("finish without external capabilities");
-assert.equal(completed.status, "idle");
+  const completed = await session.send("finish without external capabilities");
+  assert.equal(completed.status, "idle");
 
-const events = [];
-for await (const event of session.events()) events.push(event);
-assert.deepEqual(
-  events.slice(-5).map(({ type }) => type),
-  ["turn_started", "activation_started", "note", "activation_ended", "turn_ended"],
-);
-assert.deepEqual(events.at(-1)?.data.result, { turns: 1, message: "finish without external capabilities" });
-assert.ok(events.every(({ recordedAt }) => recordedAt instanceof Date && !Number.isNaN(recordedAt.valueOf())));
-// One sequence counter numbers both logs, so the feed is strictly increasing, not contiguous.
-assert.ok(events.every(({ sequence }, index) => index === 0 || sequence > events[index - 1].sequence));
+  const events = [];
+  for await (const event of session.events()) events.push(event);
+  assert.deepEqual(
+    events.slice(-5).map(({ type }) => type),
+    ["turn_started", "activation_started", "note", "activation_ended", "turn_ended"],
+  );
+  assert.deepEqual(events.at(-1)?.data.result, { turns: 1, message: "finish without external capabilities" });
+  assert.ok(events.every(({ recordedAt }) => recordedAt instanceof Date && !Number.isNaN(recordedAt.valueOf())));
+  // One sequence counter numbers both logs, so the feed is strictly increasing, not contiguous.
+  assert.ok(events.every(({ sequence }, index) => index === 0 || sequence > events[index - 1].sequence));
 
-assert.deepEqual((await session.transcript()).messages, []);
+  assert.deepEqual((await session.transcript()).messages, []);
 
-await session.end();
-await session.delete();
+  await session.end();
+  await session.delete();
+} finally {
+  await brain.close();
+}

--- a/tests/release/sdk.mjs
+++ b/tests/release/sdk.mjs
@@ -11,17 +11,21 @@ const brain = new Brain({ baseUrl, token });
 const diagnostic = agentloop({
   implementation: component(new URL("./diagnostic-agentloop.wasm", import.meta.url)),
 });
-const session = await brain.sessions.create({
-  model: {
-    provider: "vercel-ai-gateway",
-    name: "openai/gpt-5-mini",
-    apiKey: "release-smoke-key",
-  },
-  agentloop: diagnostic({ env: brainEnv({ name: "brain" }) }),
-});
-assert.equal(session.state.status, "idle");
-assert.equal((await brain.sessions.get(session.id)).id, session.id);
-assert.ok((await brain.sessions.list()).some((candidate) => candidate.id === session.id));
-assert.equal((await session.end()).status, "ended");
-await session.delete();
-assert.deepEqual(await brain.sessions.list(), []);
+try {
+  const session = await brain.sessions.create({
+    model: {
+      provider: "vercel-ai-gateway",
+      name: "openai/gpt-5-mini",
+      apiKey: "release-smoke-key",
+    },
+    agentloop: diagnostic({ env: brainEnv({ name: "brain" }) }),
+  });
+  assert.equal(session.state.status, "idle");
+  assert.equal((await brain.sessions.get(session.id)).id, session.id);
+  assert.ok((await brain.sessions.list()).some((candidate) => candidate.id === session.id));
+  assert.equal((await session.end()).status, "ended");
+  await session.delete();
+  assert.deepEqual(await brain.sessions.list(), []);
+} finally {
+  await brain.close();
+}

--- a/tools/package-smoke.mjs
+++ b/tools/package-smoke.mjs
@@ -54,11 +54,14 @@ try {
       `globalThis.fetch = async () => { throw new Error("validated Brain reached fetch"); };\n` +
       `const brain = new Brain({ baseUrl: "http://127.0.0.1:8080" });\n` +
       `assert.equal(typeof brain.sessions.create, "function");\n` +
+      `assert.equal(typeof brainSdk.SessionHandle.prototype.interrupt, "function");\n` +
       `assert.deepEqual(Object.keys(simple({ env: runtime })), []);\n` +
       `await assert.rejects(brain.sessions.create({ model: { provider: "vercel-ai-gateway", name: "openai/test", apiKey: "test" }, agentloop: simple({ env: runtime }) }), /validated Brain reached fetch/u);\n` +
       `assert.equal(typeof brainSdk.tool, "function");\n` +
       `assert.equal(typeof brainSdk.environment, "function");\n` +
-      `assert.equal("DurableEventBridge" in brainSdk, false);\n`,
+      `assert.equal("DurableEventBridge" in brainSdk, false);\n` +
+      `await brain.close();\n` +
+      `await assert.rejects(brain.sessions.list(), { name: "AbortError" });\n`,
   );
   execFileSync(process.execPath, ["smoke.mjs"], { cwd: directory, stdio: "inherit" });
   process.stdout.write("packed Brain packages passed an empty-consumer smoke test\n");


### PR DESCRIPTION
A failed session create or an overlapping create/end could leave a host connection with unclear ownership. The client now keeps one lazy host stream until idempotent `close()`, which aborts owned transport and local handlers without ending stored sessions. Rename the SDK operation to `session.interrupt()` and document the create-inside-try/finally lifetime.

Tool JSON Schemas now describe Zod inputs, so omitted defaulted arguments reach the normal parser. Output schema semantics remain unchanged.

Validation: all 62 local SDK/example tests pass, including shutdown races, paused SSE readers, host reattachment, defaulted/strict schemas and public types; packed-consumer smoke passes. Required CI includes real Brain/Wasmtime journeys and contract regeneration. SDK 0.24.0 is a coordinated pre-stable API release; the HTTP cancellation route and journal contracts remain unchanged.
