### PR TITLE
model: accept null media sources after Responses compaction

### DIFF
--- a/crates/brain/src/model/continuation_tests.rs
+++ b/crates/brain/src/model/continuation_tests.rs
@@ -66,7 +66,14 @@ fn responses_reasoning_and_compaction_preserve_native_items() {
     let body = responses::body("test", &[], &request(vec![message])).unwrap();
     assert_eq!(body["input"][0], reasoning);
     assert_eq!(body["input"][1]["call_id"], "call");
-    let retained = json!([{"type":"message","role":"user","content":[{"type":"input_text","text":"task"}]}, {"type":"compaction","encrypted_content":"compact"}]);
+    let retained = json!([
+        {"type":"message","role":"user","content":[
+            {"type":"input_text","text":"task"},
+            {"type":"input_image","image_url":"https://example.com/view.png","file_id":null,"detail":"auto"},
+            {"type":"input_file","file_url":"https://example.com/report.pdf","file_id":null,"detail":"auto"}
+        ]},
+        {"type":"compaction","encrypted_content":"compact"}
+    ]);
     let result = responses::compact_result(json!({"output":retained})).unwrap();
     let restored = serde_json::from_slice(&serde_json::to_vec(&result.message).unwrap()).unwrap();
     assert_eq!(

--- a/crates/brain/src/model/responses.rs
+++ b/crates/brain/src/model/responses.rs
@@ -127,7 +127,7 @@ fn validate_native_media(item: &Value) -> Result<(), Error> {
                     ));
                 }
             };
-            if part.get("file_data").is_some() || part.get("file_id").is_some() {
+            if !part["file_data"].is_null() || !part["file_id"].is_null() {
                 return Err(Error::InvalidState(
                     "native media requires an HTTPS URL".into(),
                 ));

--- a/docs/concepts/model.mdx
+++ b/docs/concepts/model.mdx
@@ -45,6 +45,8 @@ Brain passes the URL to Responses `input_image.image_url` / `input_file.file_url
 URL image / document source. Brain does not fetch, host, upload, convert or refresh attachments.
 Inline data, local paths and provider file IDs are unsupported, including in known native input
 positions. Opaque signed thinking and encrypted continuation state remain unchanged.
+Responses continuation may include `file_id: null` or `file_data: null` beside an HTTPS source;
+Brain preserves those empty optional fields, including after compaction.
 
 The caller owns file storage, access and lifetime. Keep the same bytes available at the same URL
 for every later turn that needs them. Expiry can cause a later model call to fail, and cannot


### PR DESCRIPTION
Responses compaction returns HTTPS image/PDF parts with `file_id: null`. Brain rejected these empty optional fields as provider file IDs, preventing the next turn after compaction. Accept null optional sources while preserving HTTPS validation and rejecting non-null file IDs or inline data.

Extend the existing compaction round-trip regression with the observed media payload and document the behavior. The regression failed before the fix; all 55 Brain library tests, formatting and Brain clippy now pass. Live image-based PDF probes pass user input, PDF Tool results, continuation and compaction through direct OpenAI and Vercel Responses.

The committed vector-only PDF still fails on both endpoints. The live-media promotion gate and fixtures remain unchanged; these diagnostic passes do not establish release readiness.
