### PR TITLE
release: prepare native media fixture and compaction patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docker run --rm -p 127.0.0.1:8080:8080 \
 ```
 
 ```sh
-npm install @aexhq/brain @aexhq/agentloop-pi zod
+npm install @aexhq/brain@0.24.1 @aexhq/agentloop-pi@6.1.0 zod
 ```
 
 Save as `order.mjs` and run with `node order.mjs`:

--- a/docs/concepts/model.mdx
+++ b/docs/concepts/model.mdx
@@ -55,6 +55,9 @@ limits. Download/format failures become ordinary failed model effects, without a
 Tool execution still returns arbitrary JSON. The Agentloop explicitly maps selected output into
 Tool-result media. URL length is not an estimate of image or PDF model tokens.
 
+PDF processing varies by provider. If a diagram's visual content is not recognized, supply it as
+an image or a PDF containing embedded page images.
+
 ## Native continuation state
 
 `{ type: "native", format, data }` retains adapter-owned JSON in content order. Keep these blocks

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -28,7 +28,7 @@ Brain permits an unauthenticated loopback listener. A non-loopback listener requ
 Install the client, an Agentloop, and Zod:
 
 ```sh
-npm install @aexhq/brain @aexhq/agentloop-pi zod
+npm install @aexhq/brain@0.24.1 @aexhq/agentloop-pi@6.1.0 zod
 ```
 
 Save this as `order.mjs`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
     },
     "packages/brain-sdk": {
       "name": "@aexhq/brain",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"

--- a/packages/brain-sdk/package.json
+++ b/packages/brain-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aexhq/brain",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "TypeScript SDK for an independently runnable Brain server",
   "license": "MIT",
   "repository": {

--- a/tests/fixtures/media/README.md
+++ b/tests/fixtures/media/README.md
@@ -1,0 +1,10 @@
+# Native media fixtures
+
+`diagram.png` contains two red circles. `diagram.pdf` contains an embedded image of three blue
+squares and no answer text. The live probe checks these counts in user input, Tool results,
+continuation and Responses compaction using HTTPS URLs at the tested commit.
+
+`diagram-vector.pdf` preserves the same three blue squares as vector drawings. Direct OpenAI and
+Vercel Responses did not recognize its visual content in the September 2026 controls, while the
+image-based PDF passed. Keep it for reproducing that provider compatibility issue; the release
+probe uses `diagram.pdf`.

--- a/tests/fixtures/media/diagram-vector.pdf
+++ b/tests/fixtures/media/diagram-vector.pdf
@@ -1,0 +1,33 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 480 240] /Resources << >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 95 >>
+stream
+1 1 1 rg 0 0 480 240 re f
+0.05 0.2 0.9 rg
+45 85 70 70 re f
+205 85 70 70 re f
+365 85 70 70 re f
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000225 00000 n 
+trailer
+<< /Size 5 /Root 1 0 R >>
+startxref
+369
+%%EOF

--- a/tests/fixtures/media/diagram.pdf
+++ b/tests/fixtures/media/diagram.pdf
@@ -1,33 +1,79 @@
-%PDF-1.4
-%âãÏÓ
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document (opensource)
 1 0 obj
-<< /Type /Catalog /Pages 2 0 R >>
+<<
+/F1 2 0 R
+>>
 endobj
 2 0 obj
-<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
 endobj
 3 0 obj
-<< /Type /Page /Parent 2 0 R /MediaBox [0 0 480 240] /Resources << >> /Contents 4 0 R >>
+<<
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 480 /Length 3837 /Subtype /Image 
+  /Type /XObject /Width 960
+>>
+stream
+Gb"0L;%3R-&B-m:\A>p"F;toOiMV`I-C)s@!<<*"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz!!%P!om2*E?Mt/Ani:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!M9b3.8Wr<U%+3H\@e_QJ8]S^ie*/"]aQocrhGkL<Z5#eTXfF]L`DY'a!8eW6pbT2TCq,OES9e62_U]CIt)<^4I(Hqp6_O0C.,;ePbJm)nM@=oAW<ni:hn5JjRN:7]prYUc>EBD!JLzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz!:[TR>0<cj~>endstream
 endobj
 4 0 obj
-<< /Length 95 >>
+<<
+/Contents 8 0 R /MediaBox [ 0 0 480 240 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.de3b18b5489a5430b17e1826bb640eb5 3 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260912211925+01'00') /Creator (anonymous) /Keywords () /ModDate (D:20260912211925+01'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (Visual input control) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 126
+>>
 stream
-1 1 1 rg 0 0 480 240 re f
-0.05 0.2 0.9 rg
-45 85 70 70 re f
-205 85 70 70 re f
-365 85 70 70 re f
-endstream
+GapA.0b-H6&4YW-:@Xs,R5N0&"dMQ_L"<Ihfl6tCLqMeKT7Gh[qfW$H6obUm+W_1H'QLu$kopT7.B!)Z.`Zq/9=A;*Pt<[5Tj>?4CsjR8Xu<>GPBlegAcb+Gknt]~>endstream
 endobj
 xref
-0 5
+0 9
 0000000000 65535 f 
-0000000015 00000 n 
-0000000064 00000 n 
-0000000121 00000 n 
-0000000225 00000 n 
+0000000061 00000 n 
+0000000092 00000 n 
+0000000199 00000 n 
+0000004227 00000 n 
+0000004483 00000 n 
+0000004551 00000 n 
+0000004824 00000 n 
+0000004883 00000 n 
 trailer
-<< /Size 5 /Root 1 0 R >>
+<<
+/ID 
+[<08b0eb89d5fd399a3a360d4fd3ce529d><08b0eb89d5fd399a3a360d4fd3ce529d>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
 startxref
-369
+5099
 %%EOF


### PR DESCRIPTION
The live media probe cannot read the original vector-only PDF through direct OpenAI or Vercel Responses. Use an equivalent PDF containing an embedded image of the same three blue squares, with no answer text. Keep the original fixture and document its provider compatibility limitation; the expected counts and provider matrix are unchanged.

Prepare Brain 0.24.1 for the compaction fix in #199 so the SDK archive and runtime image can be staged with provenance for the same release commit. The public model guide explains the PDF input alternative. Pin the README and quickstart to the matching Brain/Pi versions while `latest` promotion is pending.

Validation: visually inspected the three-square fixture and confirmed one PDF page, one embedded image, and no extracted text; `git diff --check` passes. Existing live controls against #199 pass user image/PDF input, PDF Tool results, continuation and compaction through direct OpenAI and Vercel Responses. CI and the committed-fixture media workflow must still run on the final merged commit. Direct Anthropic credentials remain deferred.
