### PR TITLE
docs: align quickstart SDK with Pi dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,11 @@ docker run --rm -p 127.0.0.1:8080:8080 \
 ```
 
 ```sh
-npm install @aexhq/brain@0.24.1 @aexhq/agentloop-pi@6.1.0 zod
+npm install @aexhq/brain@0.24.0 @aexhq/agentloop-pi@6.1.0 zod
 ```
+
+Pi 6.1.0 depends on SDK 0.24.0. Keep these client versions together; the media runtime patch
+works with this pair.
 
 Save as `order.mjs` and run with `node order.mjs`:
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -28,8 +28,11 @@ Brain permits an unauthenticated loopback listener. A non-loopback listener requ
 Install the client, an Agentloop, and Zod:
 
 ```sh
-npm install @aexhq/brain@0.24.1 @aexhq/agentloop-pi@6.1.0 zod
+npm install @aexhq/brain@0.24.0 @aexhq/agentloop-pi@6.1.0 zod
 ```
+
+Pi 6.1.0 depends on SDK 0.24.0. Keep these client versions together; the media runtime patch
+works with this pair.
 
 Save this as `order.mjs`:
 


### PR DESCRIPTION
Installing Brain SDK 0.24.1 alongside Pi 6.1.0 also installs Pi's pinned SDK 0.24.0. TypeScript treats their extension brands as different types, so the quickstart does not compile.

Keep the quickstart and README on the compatible SDK 0.24.0/Pi 6.1.0 client pair. The media fix is in the server and works with these existing clients; publishing a runtime patch does not require changing the Agentloop dependency tuple.

Validation: reproduced TS2741 with a fresh install of SDK 0.24.1/Pi 6.1.0; the same strict NodeNext quickstart compile passes with SDK 0.24.0/Pi 6.1.0. The deployed runtime passes an Aex 0.75.0/Pi 6.1.0 session with a hosted image, PDF Tool result and typed subsequent turn. `git diff --check` passes.
