### PR TITLE
docs: align quickstarts with the media client release

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,10 @@ docker run --rm -p 127.0.0.1:8080:8080 \
 ```
 
 ```sh
-npm install @aexhq/brain@0.24.0 @aexhq/agentloop-pi@6.1.0 zod
+npm install @aexhq/brain@0.24.2 @aexhq/agentloop-pi@6.1.1 zod
 ```
 
-Pi 6.1.0 depends on SDK 0.24.0. Keep these client versions together; the media runtime patch
-works with this pair.
+Keep the Brain SDK version aligned with the version required by your extensions.
 
 Save as `order.mjs` and run with `node order.mjs`:
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -28,11 +28,10 @@ Brain permits an unauthenticated loopback listener. A non-loopback listener requ
 Install the client, an Agentloop, and Zod:
 
 ```sh
-npm install @aexhq/brain@0.24.0 @aexhq/agentloop-pi@6.1.0 zod
+npm install @aexhq/brain@0.24.2 @aexhq/agentloop-pi@6.1.1 zod
 ```
 
-Pi 6.1.0 depends on SDK 0.24.0. Keep these client versions together; the media runtime patch
-works with this pair.
+Keep the Brain SDK version aligned with the version required by your extensions.
 
 Save this as `order.mjs`:
 


### PR DESCRIPTION
Update the README and quickstart to Brain SDK 0.24.2 with Pi 6.1.1. Keeping the exact SDK dependency aligned avoids duplicate nominal TypeScript extension types when composing a fresh application.

Validation: a registry install resolves one deduplicated Brain SDK, and the quickstart passes strict TypeScript compilation with NodeNext module resolution. Required CI and CodeQL passed.
