### PR TITLE
test: isolate host journeys after server restart

### DIFF
--- a/tests/journeys/host.test.mjs
+++ b/tests/journeys/host.test.mjs
@@ -96,6 +96,9 @@ test("graceful shutdown lets a host Tool finish and saves the completed turn", {
   assert.ok(events.some((event) => event.type === "finished_during_drain"));
   assert.equal(events.at(-1).type, "turn_ended");
   assert.equal((await session.transcript()).messages.at(-1).content[0].text, "answered");
+  // Server readiness does not wait for the previous client's host stream to reconnect.
+  await f.brain.close();
+  f.brain = f.client();
 });
 
 test("a tool this process holds receives validated options and commits progress before its result", { timeout: 30_000 }, async (t) => {


### PR DESCRIPTION
The shutdown journey restarts its shared server, but HTTP readiness can arrive before the existing host stream completes its 100 ms reconnect delay. The following Tool-options journey can then fail during session creation with `the host is not connected`.

Close and replace the shared client after the shutdown and recovery assertions finish. Following tests open a fresh host connection. SDK/runtime behavior, assertions and test coverage are unchanged; no sleep or retry is added.

Validation: JavaScript syntax check passed. The existing complete Linux worker and SDK journey gate validates the change. Observed failure: https://github.com/aexhq/brain/actions/runs/34722714984/job/103631393640.
